### PR TITLE
feat: Support auth code and fix uppercase lowercase bug

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/defs/CRSFetchException.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/CRSFetchException.java
@@ -1,0 +1,104 @@
+package org.datasyslab.proj4sedona.defs;
+
+/**
+ * Exception thrown when a CRS definition cannot be fetched from a remote source.
+ * 
+ * <p>This is an unchecked (runtime) exception that indicates one of the following:</p>
+ * <ul>
+ *   <li>{@link Reason#NOT_FOUND} - The CRS code does not exist on the remote server (HTTP 404)</li>
+ *   <li>{@link Reason#NETWORK_ERROR} - A network error occurred (connection failed, timeout, etc.)</li>
+ *   <li>{@link Reason#INVALID_RESPONSE} - The server returned an invalid or unparseable response</li>
+ * </ul>
+ * 
+ * <p>Usage:</p>
+ * <pre>
+ * try {
+ *     ProjectionDef def = Defs.get("ESRI:999999");
+ * } catch (CRSFetchException e) {
+ *     if (e.getReason() == CRSFetchException.Reason.NOT_FOUND) {
+ *         // Handle missing CRS code
+ *     } else if (e.getReason() == CRSFetchException.Reason.NETWORK_ERROR) {
+ *         // Handle network failure
+ *     }
+ * }
+ * </pre>
+ */
+public class CRSFetchException extends RuntimeException {
+
+    /**
+     * The reason why the CRS fetch failed.
+     */
+    public enum Reason {
+        /**
+         * The CRS code was not found on the remote server (HTTP 404).
+         */
+        NOT_FOUND,
+
+        /**
+         * A network error occurred while fetching (connection failed, timeout, server error, etc.).
+         */
+        NETWORK_ERROR,
+
+        /**
+         * The server returned an invalid or unparseable response.
+         */
+        INVALID_RESPONSE
+    }
+
+    private final String crsCode;
+    private final Reason reason;
+
+    /**
+     * Constructs a new CRSFetchException.
+     *
+     * @param crsCode The CRS code that failed to fetch (e.g., "EPSG:4326", "ESRI:102001")
+     * @param reason The reason for the failure
+     * @param message A detailed error message
+     */
+    public CRSFetchException(String crsCode, Reason reason, String message) {
+        super(message);
+        this.crsCode = crsCode;
+        this.reason = reason;
+    }
+
+    /**
+     * Constructs a new CRSFetchException with a cause.
+     *
+     * @param crsCode The CRS code that failed to fetch
+     * @param reason The reason for the failure
+     * @param message A detailed error message
+     * @param cause The underlying exception that caused this failure
+     */
+    public CRSFetchException(String crsCode, Reason reason, String message, Throwable cause) {
+        super(message, cause);
+        this.crsCode = crsCode;
+        this.reason = reason;
+    }
+
+    /**
+     * Get the CRS code that failed to fetch.
+     *
+     * @return The CRS code (e.g., "EPSG:4326", "ESRI:102001")
+     */
+    public String getCrsCode() {
+        return crsCode;
+    }
+
+    /**
+     * Get the reason for the failure.
+     *
+     * @return The failure reason
+     */
+    public Reason getReason() {
+        return reason;
+    }
+
+    @Override
+    public String toString() {
+        return "CRSFetchException{" +
+                "crsCode='" + crsCode + '\'' +
+                ", reason=" + reason +
+                ", message='" + getMessage() + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/grid/TransformationRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/grid/TransformationRegistry.java
@@ -3,6 +3,8 @@ package org.datasyslab.proj4sedona.grid;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.datasyslab.proj4sedona.util.CRSUtils;
+
 /**
  * Registry of CRS pairs to grid files for automatic grid-based datum transformations.
  * 
@@ -89,9 +91,10 @@ public final class TransformationRegistry {
 
     /**
      * Create a lookup key from two CRS codes.
+     * Authority codes are normalized to uppercase for case-insensitive matching.
      */
     private static String makeKey(String fromCrs, String toCrs) {
-        return fromCrs + "|" + toCrs;
+        return CRSUtils.normalizeAuthorityCode(fromCrs) + "|" + CRSUtils.normalizeAuthorityCode(toCrs);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -775,9 +775,10 @@ public final class CRSSerializer {
             return null;
         }
 
-        // Check if srsCode is already an EPSG code
-        if (params.srsCode != null && params.srsCode.startsWith("EPSG:")) {
-            return params.srsCode;
+        // Check if srsCode is already an EPSG code (case-insensitive)
+        if (params.srsCode != null && params.srsCode.length() > 5 
+                && params.srsCode.substring(0, 5).equalsIgnoreCase("EPSG:")) {
+            return params.srsCode.substring(0, 5).toUpperCase() + params.srsCode.substring(5);
         }
 
         // Initialize global definitions

--- a/src/main/java/org/datasyslab/proj4sedona/util/CRSUtils.java
+++ b/src/main/java/org/datasyslab/proj4sedona/util/CRSUtils.java
@@ -1,0 +1,55 @@
+package org.datasyslab.proj4sedona.util;
+
+/**
+ * Utility methods for working with Coordinate Reference System identifiers.
+ */
+public final class CRSUtils {
+
+    private CRSUtils() {
+        // Utility class - prevent instantiation
+    }
+
+    /**
+     * Normalize an authority:code string to uppercase authority.
+     * E.g., "epsg:4326" -> "EPSG:4326", "esri:102001" -> "ESRI:102001"
+     * 
+     * <p>This method is optimized to quickly reject long strings like
+     * PROJ strings, PROJJSON, and WKT without overhead.</p>
+     * 
+     * @param name The input CRS identifier
+     * @return The normalized string, or the original if not an authority:code pattern
+     */
+    public static String normalizeAuthorityCode(String name) {
+        if (name == null || name.isEmpty()) {
+            return name;
+        }
+        
+        // Quick rejection for PROJ strings and PROJJSON
+        char first = name.charAt(0);
+        if (first == '+' || first == '{') {
+            return name;
+        }
+        
+        // Authority codes are short (e.g., "EPSG:4326", "IAU_2015:49900")
+        int len = name.length();
+        if (len > 25) {
+            return name;
+        }
+        
+        // Find colon - authority codes have exactly one
+        int colonIdx = name.indexOf(':');
+        if (colonIdx <= 0 || colonIdx == len - 1) {
+            return name;
+        }
+        
+        // Check for second colon (would indicate not an authority:code)
+        if (name.indexOf(':', colonIdx + 1) >= 0) {
+            return name;
+        }
+        
+        // Normalize: uppercase authority, keep code as-is
+        String authority = name.substring(0, colonIdx).toUpperCase();
+        String code = name.substring(colonIdx + 1);
+        return authority + ":" + code;
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
@@ -7,6 +7,8 @@ import org.datasyslab.proj4sedona.Proj4;
 import org.datasyslab.proj4sedona.core.Point;
 import org.datasyslab.proj4sedona.core.ProjectionDef;
 import org.datasyslab.proj4sedona.transform.Converter;
+import org.datasyslab.proj4sedona.defs.SpatialReferenceFetcher;
+import org.datasyslab.proj4sedona.defs.CRSFetchException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -268,5 +270,281 @@ class DefsTest {
         
         assertEquals(original.x, restored.x, 1e-6);
         assertEquals(original.y, restored.y, 1e-6);
+    }
+
+    // ==================== Case Sensitivity Tests ====================
+
+    @Test
+    void testGetCaseInsensitive_BuiltIn() {
+        Defs.globals();
+        
+        // Disable remote fetch to ensure we're testing built-in definitions
+        Defs.setRemoteFetchEnabled(false);
+        
+        try {
+            // These should all return the same built-in definition
+            ProjectionDef upper = Defs.get("EPSG:4326");
+            ProjectionDef lower = Defs.get("epsg:4326");
+            ProjectionDef mixed = Defs.get("Epsg:4326");
+            
+            assertNotNull(upper, "EPSG:4326 should be found");
+            assertNotNull(lower, "epsg:4326 should be found (case-insensitive)");
+            assertNotNull(mixed, "Epsg:4326 should be found (case-insensitive)");
+            
+            // They should be the exact same object (from built-in registry)
+            assertSame(upper, lower, "Should return same definition regardless of case");
+            assertSame(upper, mixed, "Should return same definition regardless of case");
+        } finally {
+            Defs.setRemoteFetchEnabled(true);
+        }
+    }
+
+    @Test
+    void testHasCaseInsensitive() {
+        Defs.globals();
+        
+        assertTrue(Defs.has("EPSG:4326"), "Should find EPSG:4326");
+        assertTrue(Defs.has("epsg:4326"), "Should find epsg:4326 (case-insensitive)");
+        assertTrue(Defs.has("Epsg:4326"), "Should find Epsg:4326 (case-insensitive)");
+        assertTrue(Defs.has("EPSG:3857"), "Should find EPSG:3857");
+        assertTrue(Defs.has("epsg:3857"), "Should find epsg:3857 (case-insensitive)");
+    }
+
+    @Test
+    void testAliasCaseInsensitive() {
+        Defs.globals();
+        
+        // Create alias using lowercase source
+        Defs.alias("MY_WGS84", "epsg:4326");
+        
+        ProjectionDef original = Defs.get("EPSG:4326");
+        ProjectionDef aliased = Defs.get("MY_WGS84");
+        
+        assertSame(original, aliased, "Alias should point to same definition");
+    }
+
+    @Test
+    void testRemoveCaseInsensitive() {
+        Defs.set("TEST:123", "+proj=longlat +datum=WGS84");
+        
+        assertTrue(Defs.has("TEST:123"));
+        assertTrue(Defs.has("test:123"));
+        
+        // Remove using lowercase
+        ProjectionDef removed = Defs.remove("test:123");
+        assertNotNull(removed);
+        
+        assertFalse(Defs.has("TEST:123"));
+        assertFalse(Defs.has("test:123"));
+    }
+
+    @Test
+    void testNormalizationDoesNotAffectProjStrings() {
+        // PROJ strings should not be normalized (they don't match authority:code pattern)
+        Defs.set("PROJ_TEST", "+proj=longlat +datum=WGS84");
+        
+        // Looking up by name should work
+        ProjectionDef def = Defs.get("PROJ_TEST");
+        assertNotNull(def);
+    }
+
+    @Test
+    void testNormalizationPreservesCode() {
+        // Register with uppercase authority
+        Defs.set("TEST:AbC123", "+proj=longlat +datum=WGS84");
+        
+        // Lookup with lowercase authority should work
+        ProjectionDef def = Defs.get("test:AbC123");
+        assertNotNull(def, "Should find with lowercase authority");
+        
+        // The code part should be preserved as-is
+        assertEquals("TEST:AbC123", def.getSrsCode());
+    }
+
+    @Test
+    void testProj4WithLowercaseEpsgCodes() {
+        // This tests the main use case: Flink tests using lowercase "epsg:4326"
+        Converter conv = Proj4.proj4("epsg:4326", "epsg:3857");
+        
+        Point wgs84 = new Point(0, 0);
+        Point webMerc = conv.forward(wgs84);
+        
+        assertEquals(0, webMerc.x, 1e-6);
+        assertEquals(0, webMerc.y, 1e-6);
+    }
+
+    // ==================== Remote Fetch Tests (Non-EPSG Authorities) ====================
+    // These tests require network access to spatialreference.org
+
+    @Test
+    void testRemoteFetch_ESRI_102001_CanadaAlbers() {
+        // ESRI:102001 = Canada Albers Equal Area Conic
+        // Should be fetched from spatialreference.org
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        ProjectionDef def = Defs.get("ESRI:102001");
+        
+        assertNotNull(def, "ESRI:102001 should be fetched from spatialreference.org");
+        // PROJJSON returns full name "Albers Equal Area", check it contains expected keywords
+        String projName = def.getProjName().toLowerCase();
+        assertTrue(projName.contains("aea") || projName.contains("albers"), 
+            "Should be Albers Equal Area projection, got: " + def.getProjName());
+        assertEquals("ESRI:102001", def.getSrsCode());
+    }
+
+    @Test
+    void testRemoteFetch_ESRI_CaseInsensitive() {
+        // Test case-insensitivity for ESRI authority codes
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        // Fetch with uppercase
+        ProjectionDef upper = Defs.get("ESRI:102001");
+        assertNotNull(upper, "ESRI:102001 should be found");
+        
+        // Fetch with lowercase - should use cached definition
+        ProjectionDef lower = Defs.get("esri:102001");
+        assertNotNull(lower, "esri:102001 should be found (case-insensitive)");
+        
+        // Fetch with mixed case
+        ProjectionDef mixed = Defs.get("Esri:102001");
+        assertNotNull(mixed, "Esri:102001 should be found (case-insensitive)");
+        
+        // All should be the same cached object
+        assertSame(upper, lower, "Should return same cached definition regardless of case");
+        assertSame(upper, mixed, "Should return same cached definition regardless of case");
+    }
+
+    @Test
+    void testRemoteFetch_ESRI_102008_NorthAmericaAlbers() {
+        // ESRI:102008 = North America Albers Equal Area Conic
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        ProjectionDef def = Defs.get("ESRI:102008");
+        
+        assertNotNull(def, "ESRI:102008 should be fetched from spatialreference.org");
+        // PROJJSON returns full name "Albers Equal Area", check it contains expected keywords
+        String projName = def.getProjName().toLowerCase();
+        assertTrue(projName.contains("aea") || projName.contains("albers"), 
+            "Should be Albers Equal Area projection, got: " + def.getProjName());
+    }
+
+    @Test
+    void testRemoteFetch_IAU2015_49900_Mars() {
+        // IAU_2015:49900 = Mars (2015) - Sphere / Ocentric
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        ProjectionDef def = Defs.get("IAU_2015:49900");
+        
+        assertNotNull(def, "IAU_2015:49900 should be fetched from spatialreference.org");
+        assertEquals("longlat", def.getProjName(), "Mars geographic CRS should be longlat");
+    }
+
+    @Test
+    void testRemoteFetch_IAU2015_CaseInsensitive() {
+        // Test case-insensitivity for IAU_2015 authority codes
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        // Fetch with uppercase
+        ProjectionDef upper = Defs.get("IAU_2015:49900");
+        assertNotNull(upper, "IAU_2015:49900 should be found");
+        
+        // Fetch with lowercase
+        ProjectionDef lower = Defs.get("iau_2015:49900");
+        assertNotNull(lower, "iau_2015:49900 should be found (case-insensitive)");
+        
+        // All should be the same cached object
+        assertSame(upper, lower, "Should return same cached definition regardless of case");
+    }
+
+    @Test
+    void testRemoteFetch_Transform_ESRI_ToWGS84() {
+        // Test transformation using remotely fetched ESRI definition
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        // Transform from WGS84 to ESRI:102001 (Canada Albers) and back
+        Converter conv = Proj4.proj4("EPSG:4326", "ESRI:102001");
+        
+        // Ottawa, Canada (approximately in the center of the projection)
+        Point wgs84 = new Point(-75.7, 45.4);
+        Point albers = conv.forward(wgs84);
+        
+        // Verify we got valid projected coordinates
+        assertTrue(Double.isFinite(albers.x), "Easting should be finite");
+        assertTrue(Double.isFinite(albers.y), "Northing should be finite");
+        
+        // Round-trip test
+        Point restored = conv.inverse(albers);
+        assertEquals(wgs84.x, restored.x, 1e-6, "Longitude should round-trip");
+        assertEquals(wgs84.y, restored.y, 1e-6, "Latitude should round-trip");
+    }
+
+    @Test
+    void testRemoteFetch_Transform_LowercaseEsri() {
+        // Test transformation using lowercase "esri:102001"
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        // This is the key use case: user specifies lowercase authority
+        Converter conv = Proj4.proj4("epsg:4326", "esri:102001");
+        
+        Point wgs84 = new Point(-100, 50);
+        Point albers = conv.forward(wgs84);
+        
+        assertTrue(Double.isFinite(albers.x), "Should transform successfully with lowercase authority");
+        assertTrue(Double.isFinite(albers.y), "Should transform successfully with lowercase authority");
+    }
+
+    @Test
+    void testRemoteFetch_NonExistentCode_ThrowsException() {
+        // Test that non-existent codes throw CRSFetchException
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        CRSFetchException ex = assertThrows(CRSFetchException.class, () -> {
+            Defs.get("ESRI:999999999");
+        });
+        
+        assertEquals("ESRI:999999999", ex.getCrsCode());
+        assertEquals(CRSFetchException.Reason.NOT_FOUND, ex.getReason());
+        assertTrue(ex.getMessage().contains("not found"));
+        
+        // Verify it's in the negative cache
+        assertTrue(SpatialReferenceFetcher.isInNotFoundCache("esri", "999999999"),
+            "Non-existent code should be in negative cache");
+    }
+
+    @Test
+    void testRemoteFetch_NonExistentAuthority_ThrowsException() {
+        // Test that non-existent authorities throw CRSFetchException
+        Defs.globals();
+        SpatialReferenceFetcher.clearNotFoundCache();
+        
+        CRSFetchException ex = assertThrows(CRSFetchException.class, () -> {
+            Defs.get("BOGUS:12345");
+        });
+        
+        assertEquals("BOGUS:12345", ex.getCrsCode());
+        assertEquals(CRSFetchException.Reason.NOT_FOUND, ex.getReason());
+    }
+
+    @Test
+    void testRemoteFetchDisabled_NonBuiltIn_ReturnsNull() {
+        // When remote fetch is disabled, non-built-in codes should return null (no exception)
+        Defs.globals();
+        Defs.setRemoteFetchEnabled(false);
+        
+        try {
+            // ESRI:102001 is not a built-in, so should return null
+            ProjectionDef def = Defs.get("ESRI:102001");
+            assertNull(def, "Should return null when remote fetch is disabled");
+        } finally {
+            Defs.setRemoteFetchEnabled(true);
+        }
     }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/grid/TransformationRegistryTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/grid/TransformationRegistryTest.java
@@ -1,0 +1,116 @@
+package org.datasyslab.proj4sedona.grid;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for TransformationRegistry.
+ */
+class TransformationRegistryTest {
+
+    // ==================== Basic Functionality Tests ====================
+
+    @Test
+    void testGetGridMapping_Exists() {
+        // NAD27 -> NAD83 should have a grid mapping
+        TransformationRegistry.GridMapping mapping = 
+            TransformationRegistry.getGridMapping("EPSG:4267", "EPSG:4269");
+        
+        assertNotNull(mapping, "Should find grid mapping for NAD27 -> NAD83");
+        assertNotNull(mapping.gridFile, "Grid file should not be null");
+        assertTrue(mapping.gridFile.contains("ntv2") || mapping.gridFile.contains("nrc"), 
+            "Should be NTv2 grid file");
+    }
+
+    @Test
+    void testGetGridMapping_NotExists() {
+        // Random EPSG codes that don't have grid mappings
+        TransformationRegistry.GridMapping mapping = 
+            TransformationRegistry.getGridMapping("EPSG:4326", "EPSG:3857");
+        
+        assertNull(mapping, "Should return null for pairs without grid mapping");
+    }
+
+    @Test
+    void testHasGridMapping() {
+        assertTrue(TransformationRegistry.hasGridMapping("EPSG:4267", "EPSG:4269"),
+            "Should have NAD27 -> NAD83 mapping");
+        assertFalse(TransformationRegistry.hasGridMapping("EPSG:4326", "EPSG:3857"),
+            "Should not have WGS84 -> Web Mercator mapping");
+    }
+
+    @Test
+    void testGetGridFile() {
+        String gridFile = TransformationRegistry.getGridFile("EPSG:4267", "EPSG:4269");
+        assertNotNull(gridFile);
+        assertTrue(gridFile.endsWith(".tif"), "Grid file should be a GeoTIFF");
+    }
+
+    @Test
+    void testBidirectionalMapping() {
+        // Forward direction
+        TransformationRegistry.GridMapping forward = 
+            TransformationRegistry.getGridMapping("EPSG:4267", "EPSG:4269");
+        
+        // Reverse direction
+        TransformationRegistry.GridMapping reverse = 
+            TransformationRegistry.getGridMapping("EPSG:4269", "EPSG:4267");
+        
+        assertNotNull(forward);
+        assertNotNull(reverse);
+        
+        // Same grid file
+        assertEquals(forward.gridFile, reverse.gridFile);
+        
+        // But different application direction
+        assertTrue(forward.applyToSource, "Forward should apply to source");
+        assertFalse(reverse.applyToSource, "Reverse should apply to destination");
+    }
+
+    // ==================== Case Sensitivity Tests ====================
+
+    @Test
+    void testGetGridMapping_CaseInsensitive() {
+        // All these should find the same mapping
+        TransformationRegistry.GridMapping upper = 
+            TransformationRegistry.getGridMapping("EPSG:4267", "EPSG:4269");
+        TransformationRegistry.GridMapping lower = 
+            TransformationRegistry.getGridMapping("epsg:4267", "epsg:4269");
+        TransformationRegistry.GridMapping mixed = 
+            TransformationRegistry.getGridMapping("Epsg:4267", "Epsg:4269");
+        
+        assertNotNull(upper, "Should find with uppercase");
+        assertNotNull(lower, "Should find with lowercase");
+        assertNotNull(mixed, "Should find with mixed case");
+        
+        assertEquals(upper.gridFile, lower.gridFile);
+        assertEquals(upper.gridFile, mixed.gridFile);
+    }
+
+    @Test
+    void testHasGridMapping_CaseInsensitive() {
+        assertTrue(TransformationRegistry.hasGridMapping("EPSG:4267", "EPSG:4269"));
+        assertTrue(TransformationRegistry.hasGridMapping("epsg:4267", "epsg:4269"));
+        assertTrue(TransformationRegistry.hasGridMapping("Epsg:4267", "Epsg:4269"));
+    }
+
+    @Test
+    void testGetGridFile_CaseInsensitive() {
+        String upper = TransformationRegistry.getGridFile("EPSG:4267", "EPSG:4269");
+        String lower = TransformationRegistry.getGridFile("epsg:4267", "epsg:4269");
+        
+        assertNotNull(upper);
+        assertNotNull(lower);
+        assertEquals(upper, lower, "Should return same grid file regardless of case");
+    }
+
+    // ==================== Size Test ====================
+
+    @Test
+    void testSize() {
+        // Should have at least the registered mappings (bidirectional, so 2x)
+        assertTrue(TransformationRegistry.size() >= 2, 
+            "Should have at least one bidirectional mapping registered");
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/util/CRSUtilsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/util/CRSUtilsTest.java
@@ -1,0 +1,103 @@
+package org.datasyslab.proj4sedona.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for CRSUtils utility class.
+ */
+class CRSUtilsTest {
+
+    @Test
+    void testNormalizeEpsgCode() {
+        assertEquals("EPSG:4326", CRSUtils.normalizeAuthorityCode("epsg:4326"));
+        assertEquals("EPSG:4326", CRSUtils.normalizeAuthorityCode("EPSG:4326"));
+        assertEquals("EPSG:4326", CRSUtils.normalizeAuthorityCode("Epsg:4326"));
+        assertEquals("EPSG:3857", CRSUtils.normalizeAuthorityCode("ePsG:3857"));
+    }
+
+    @Test
+    void testNormalizeOtherAuthorities() {
+        assertEquals("ESRI:102001", CRSUtils.normalizeAuthorityCode("esri:102001"));
+        assertEquals("IAU_2015:49900", CRSUtils.normalizeAuthorityCode("iau_2015:49900"));
+        assertEquals("IGNF:LAMB93", CRSUtils.normalizeAuthorityCode("ignf:LAMB93"));
+        assertEquals("OGC:CRS84", CRSUtils.normalizeAuthorityCode("ogc:CRS84"));
+    }
+
+    @Test
+    void testPreservesCodeCase() {
+        // Code part should be preserved as-is
+        assertEquals("TEST:AbC123", CRSUtils.normalizeAuthorityCode("test:AbC123"));
+        assertEquals("EPSG:4326", CRSUtils.normalizeAuthorityCode("epsg:4326"));
+        assertEquals("IGNF:LAMB93", CRSUtils.normalizeAuthorityCode("ignf:LAMB93"));
+    }
+
+    @Test
+    void testRejectsProjStrings() {
+        String proj = "+proj=longlat +datum=WGS84";
+        assertEquals(proj, CRSUtils.normalizeAuthorityCode(proj));
+        
+        String projLong = "+proj=merc +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m";
+        assertEquals(projLong, CRSUtils.normalizeAuthorityCode(projLong));
+    }
+
+    @Test
+    void testRejectsProjJson() {
+        String json = "{\"type\":\"GeographicCRS\"}";
+        assertEquals(json, CRSUtils.normalizeAuthorityCode(json));
+        
+        String jsonLong = "{\"type\":\"GeographicCRS\",\"name\":\"WGS 84\"}";
+        assertEquals(jsonLong, CRSUtils.normalizeAuthorityCode(jsonLong));
+    }
+
+    @Test
+    void testRejectsLongStrings() {
+        String wkt = "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\"]]";
+        assertEquals(wkt, CRSUtils.normalizeAuthorityCode(wkt));
+        
+        // Exactly at the limit (25 chars)
+        String atLimit = "AUTHORITY:1234567890123456";  // 26 chars - should be rejected
+        assertEquals(atLimit, CRSUtils.normalizeAuthorityCode(atLimit));
+    }
+
+    @Test
+    void testRejectsNoColon() {
+        assertEquals("WGS84", CRSUtils.normalizeAuthorityCode("WGS84"));
+        assertEquals("GOOGLE", CRSUtils.normalizeAuthorityCode("GOOGLE"));
+        assertEquals("NAD83", CRSUtils.normalizeAuthorityCode("NAD83"));
+    }
+
+    @Test
+    void testRejectsMultipleColons() {
+        String urn = "urn:ogc:def:crs:EPSG::4326";
+        assertEquals(urn, CRSUtils.normalizeAuthorityCode(urn));
+        
+        String custom = "A:B:C";
+        assertEquals(custom, CRSUtils.normalizeAuthorityCode(custom));
+    }
+
+    @Test
+    void testRejectsColonAtEdges() {
+        // Colon at start
+        assertEquals(":4326", CRSUtils.normalizeAuthorityCode(":4326"));
+        
+        // Colon at end
+        assertEquals("EPSG:", CRSUtils.normalizeAuthorityCode("EPSG:"));
+    }
+
+    @Test
+    void testHandlesNullAndEmpty() {
+        assertNull(CRSUtils.normalizeAuthorityCode(null));
+        assertEquals("", CRSUtils.normalizeAuthorityCode(""));
+    }
+
+    @Test
+    void testValidAuthorityCodePatterns() {
+        // Various valid patterns
+        assertEquals("A:1", CRSUtils.normalizeAuthorityCode("a:1"));
+        assertEquals("AB:12", CRSUtils.normalizeAuthorityCode("ab:12"));
+        assertEquals("A1:B2", CRSUtils.normalizeAuthorityCode("a1:B2"));
+        assertEquals("A_B:123", CRSUtils.normalizeAuthorityCode("a_b:123"));
+    }
+}


### PR DESCRIPTION
This pull request introduces improved error handling and authority code normalization for fetching CRS (Coordinate Reference System) definitions, as well as enhanced remote fetch logic and configuration. The changes make CRS code lookups more robust, extensible (supporting authorities beyond just EPSG), and provide clearer exceptions and diagnostics for failure scenarios.

The most important changes are:

**Error Handling and Exceptions**
* Added a new `CRSFetchException` class to provide detailed, typed exceptions when a CRS definition cannot be fetched, including the specific reason for failure (`NOT_FOUND`, `NETWORK_ERROR`, or `INVALID_RESPONSE`).
* Updated the `Defs.get` and `Defs.fetchFromRemote` methods to throw `CRSFetchException` instead of returning null on failure, and to propagate detailed error information from remote fetches. [[1]](diffhunk://#diff-40a1ff6ed62319b044c7a506de408a06897dca049664bf4018b302410ce7365eL106-L134) [[2]](diffhunk://#diff-40a1ff6ed62319b044c7a506de408a06897dca049664bf4018b302410ce7365eL145-R236)

**Authority Code Normalization and Lookup**
* Authority code lookups are now case-insensitive for the authority part (e.g., "epsg:4326" and "EPSG:4326" are treated the same), and the internal registry uses normalized keys. This affects all relevant methods in `Defs` (`get`, `has`, `remove`, `alias`). [[1]](diffhunk://#diff-40a1ff6ed62319b044c7a506de408a06897dca049664bf4018b302410ce7365eL41-R54) [[2]](diffhunk://#diff-40a1ff6ed62319b044c7a506de408a06897dca049664bf4018b302410ce7365eL145-R236)
* The pattern for matching CRS codes was expanded to support any `authority:code` (e.g., "ESRI:102001", "IAU_2015:49900"), not just EPSG codes.

**Remote Fetching Improvements**
* The remote fetch logic in `Defs` and `SpatialReferenceFetcher` now supports any authority, not just EPSG, and provides more robust retry and error handling. [[1]](diffhunk://#diff-40a1ff6ed62319b044c7a506de408a06897dca049664bf4018b302410ce7365eL106-L134) [[2]](diffhunk://#diff-20d3b98e3f30ceae6f97936cb98c7797ba409208b39be13bc0cd3402296f7f32L24-R28)
* Added a new `FetchResult` class to encapsulate the result of a remote fetch, including status, response, exception, and attempt count, replacing the previous use of nulls and strings for error signaling.

**Configuration and Diagnostics**
* Made connection/read timeouts, retry count, and backoff delay configurable in `SpatialReferenceFetcher`, and ensured the HTTP client is recreated if these settings change. [[1]](diffhunk://#diff-20d3b98e3f30ceae6f97936cb98c7797ba409208b39be13bc0cd3402296f7f32L59-R185) [[2]](diffhunk://#diff-20d3b98e3f30ceae6f97936cb98c7797ba409208b39be13bc0cd3402296f7f32L73-R201)
* Added counters and improved diagnostics for fetch attempts, aiding in debugging and testing.

**Documentation and Comments**
* Updated and clarified documentation throughout `Defs` and `SpatialReferenceFetcher` to reflect the new authority code handling, error semantics, and usage examples. [[1]](diffhunk://#diff-40a1ff6ed62319b044c7a506de408a06897dca049664bf4018b302410ce7365eL106-L134) [[2]](diffhunk://#diff-20d3b98e3f30ceae6f97936cb98c7797ba409208b39be13bc0cd3402296f7f32L24-R28) [[3]](diffhunk://#diff-40a1ff6ed62319b044c7a506de408a06897dca049664bf4018b302410ce7365eL290-R331)

These changes make the CRS definition system more robust, extensible, and user-friendly, especially when dealing with remote lookups and error scenarios.