### PR TITLE
fix: a caching bug in the grid loading logic for remote URLs

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/grid/GridLoader.java
+++ b/src/main/java/org/datasyslab/proj4sedona/grid/GridLoader.java
@@ -250,9 +250,8 @@ public final class GridLoader {
             
             if (response.statusCode() == 200) {
                 byte[] data = response.body();
-                // Use the URL as the key (or extract filename from URL)
-                String key = extractFilenameFromUrl(url);
-                GridData grid = load(key, data);
+                // Use the full URL as the key to match the lookup in parseNadgridString
+                GridData grid = load(url, data);
                 // Debug: Downloaded and loaded grid
                 return grid;
             }


### PR DESCRIPTION
This pull request addresses a caching bug in the grid loading logic for remote URLs and adds regression tests to ensure proper caching behavior. The main change ensures that grids loaded from URLs are cached and retrieved using the full URL as the key, preventing unnecessary repeated downloads. Additional tests verify both correctness and performance of the caching mechanism.

**Bug fix: URL-based grid caching**

- Changed the caching logic in `GridLoader.java` so that grids loaded from a URL are stored and retrieved using the full URL as the cache key, rather than just the filename. This ensures that subsequent requests for the same URL use the cached grid instead of re-downloading it.

**Testing improvements**

- Added regression and performance tests in `GridLoaderExtendedTest.java` to verify that:
  - Grids loaded from URLs are cached under the full URL key and reused on subsequent calls.
  - Cached lookups are significantly faster than initial downloads, confirming cache effectiveness.