### PR TITLE
fix: include id field in toProjJson() output

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -704,6 +704,19 @@ public final class CRSSerializer {
             json.put("coordinate_system", buildProjJsonProjCS(params));
         }
 
+        // Add "id" field when the authority is known
+        String[] authority = toAuthority(params);
+        if (authority != null) {
+            Map<String, Object> id = new LinkedHashMap<>();
+            id.put("authority", authority[0]);
+            try {
+                id.put("code", Integer.parseInt(authority[1]));
+            } catch (NumberFormatException e) {
+                id.put("code", authority[1]);
+            }
+            json.put("id", id);
+        }
+
         return json;
     }
 

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -211,6 +211,9 @@ class CRSSerializerTest {
         assertTrue(result.contains("\"ellipsoid\""));
         assertTrue(result.contains("\"semi_major_axis\""));
         assertTrue(result.contains("\"coordinate_system\""));
+        assertTrue(result.contains("\"id\""));
+        assertTrue(result.contains("\"authority\": \"EPSG\""));
+        assertTrue(result.contains("\"code\": 4326"));
     }
 
     @Test
@@ -225,6 +228,9 @@ class CRSSerializerTest {
         assertTrue(result.contains("\"conversion\""));
         assertTrue(result.contains("\"method\""));
         assertTrue(result.contains("\"parameters\""));
+        assertTrue(result.contains("\"id\""));
+        assertTrue(result.contains("\"authority\": \"EPSG\""));
+        assertTrue(result.contains("\"code\": 32610"));
     }
 
     @Test
@@ -246,6 +252,8 @@ class CRSSerializerTest {
         assertNotNull(result);
         assertFalse(result.contains("\n")); // No newlines in compact format
         assertTrue(result.contains("\"type\":\"GeographicCRS\""));
+        assertTrue(result.contains("\"authority\":\"EPSG\""));
+        assertTrue(result.contains("\"code\":4326"));
     }
 
     @Test
@@ -266,6 +274,34 @@ class CRSSerializerTest {
     @DisplayName("toProjJson: null input returns null")
     void testToProjJsonNull() {
         assertNull(CRSSerializer.toProjJson((Proj) null));
+    }
+
+    @Test
+    @DisplayName("toProjJson: id field present for EPSG CRS")
+    void testToProjJsonIdFieldPresent() {
+        // Geographic CRS from authority string
+        Proj wgs84 = new Proj("EPSG:4326");
+        String json4326 = CRSSerializer.toProjJson(wgs84);
+        assertTrue(json4326.contains("\"id\""));
+        assertTrue(json4326.contains("\"authority\": \"EPSG\""));
+        assertTrue(json4326.contains("\"code\": 4326"));
+
+        // Projected CRS from authority string
+        Proj webMercator = new Proj("EPSG:3857");
+        String json3857 = CRSSerializer.toProjJson(webMercator);
+        assertTrue(json3857.contains("\"id\""));
+        assertTrue(json3857.contains("\"authority\": \"EPSG\""));
+        assertTrue(json3857.contains("\"code\": 3857"));
+    }
+
+    @Test
+    @DisplayName("toProjJson: id field absent for custom projection")
+    void testToProjJsonIdFieldAbsentForCustom() {
+        // Custom projection with no known authority
+        Proj custom = new Proj("+proj=lcc +lat_1=20 +lat_2=60 +lat_0=40 +lon_0=-96 +ellps=GRS80 +units=m");
+        String json = CRSSerializer.toProjJson(custom);
+        assertNotNull(json);
+        assertFalse(json.contains("\"id\""), "Custom projection should not have an id field");
     }
 
     // ==================== EPSG Code Lookup Tests ====================


### PR DESCRIPTION
## Summary

`toProjJson()` now includes the `id` field in the generated PROJJSON output when the `Proj` object has a known authority (e.g., `EPSG:4326`).

## Problem

The `id` field is part of the PROJJSON specification and is required by consumers that need to identify the CRS by its authority and code. Without it:
- GeoParquet round-trip loses the SRID
- Interoperability breaks with GDAL, GeoPandas, DuckDB Spatial
- Sedona has to manually inject the `id` field as a workaround

## Changes

- **CRSSerializer.java**: Added `id` field generation at the end of `toProjJsonMap()`. Calls `toAuthority(params)` and appends `{"authority": "EPSG", "code": 4326}` when known. Code is emitted as a number per the PROJJSON spec.
- **CRSSerializerTest.java**: Updated 3 existing tests with `id` assertions; added 2 new tests (id present for EPSG, id absent for custom projections).

All 686 tests pass.