### PR TITLE
Fix web mercator WKT2/PROJJSON producing wrong values

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -12,6 +12,7 @@ import org.datasyslab.proj4sedona.projection.ProjectionParams;
 import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Main projection class that initializes and manages coordinate system transformations.
@@ -24,6 +25,12 @@ import java.util.Map;
  * 4. Initializes the projection implementation
  */
 public class Proj {
+
+    // Known web mercator EPSG codes whose WKT2/PROJJSON definitions are
+    // traditionally wrong (they declare the WGS84 ellipsoid instead of a sphere).
+    // When we detect one of these after parsing, we replace it with the correct
+    // hard-coded definition.  Mirrors: proj4js lib/parseCode.js checkMercator()
+    private static final Set<String> WEB_MERCATOR_CODES = Set.of("3857", "900913", "3785", "102113");
 
     private final ProjectionParams params;
     private final Projection projection;
@@ -125,7 +132,7 @@ public class Proj {
             try {
                 Gson gson = new Gson();
                 Map<String, Object> json = gson.fromJson(srsCode, Map.class);
-                return WktParser.parse(json);
+                return checkWebMercator(WktParser.parse(json));
             } catch (Exception e) {
                 throw new IllegalArgumentException("Invalid PROJJSON: " + e.getMessage(), e);
             }
@@ -133,7 +140,7 @@ public class Proj {
 
         // Check if it's WKT format (contains '[' and doesn't start with '+')
         if (WktParser.isWkt(srsCode)) {
-            return WktParser.parse(srsCode);
+            return checkWebMercator(WktParser.parse(srsCode));
         }
 
         // Try looking up in the Defs registry (for EPSG codes, aliases, etc.)
@@ -148,6 +155,30 @@ public class Proj {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    /**
+     * If the parsed definition matches a known web mercator EPSG code,
+     * return the hard-coded (correct, sphere-based) definition instead.
+     * Web mercator WKT2/PROJJSON definitions are traditionally wrong because
+     * they declare the WGS84 ellipsoid instead of a sphere (a == b == 6378137).
+     * Mirrors: proj4js PR #546 / lib/parseCode.js checkMercator()
+     */
+    private static ProjectionDef checkWebMercator(ProjectionDef def) {
+        if (def == null) {
+            return null;
+        }
+        String title = def.getTitle();
+        if (title != null) {
+            String lower = title.toLowerCase();
+            if (lower.startsWith("epsg:") && WEB_MERCATOR_CODES.contains(lower.substring(5))) {
+                ProjectionDef hardcoded = Defs.get("EPSG:3857");
+                if (hardcoded != null) {
+                    return hardcoded;
+                }
+            }
+        }
+        return def;
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/transform/TransformTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/transform/TransformTest.java
@@ -465,4 +465,88 @@ class TransformTest {
         assertEquals(0, r1.x, METER_TOLERANCE);
         assertEquals(1000000, r2.x, METER_TOLERANCE);
     }
+
+    // ==================== Web Mercator WKT2/PROJJSON Tests (proj4js #546) ====================
+
+    @Test
+    void testWebMercatorWkt2MatchesEpsgCode() {
+        // WKT2 definition for EPSG:3857 declares the WGS84 ellipsoid (a != b),
+        // but Web Mercator must use a sphere (a == b == 6378137).
+        // After the fix, parsing this WKT2 should produce the same results as "EPSG:3857".
+        String wkt2_3857 = "PROJCRS[\"WGS 84 / Pseudo-Mercator\","
+            + "BASEGEOGCRS[\"WGS 84\","
+            + "  ENSEMBLE[\"World Geodetic System 1984 ensemble\","
+            + "    MEMBER[\"World Geodetic System 1984 (Transit)\"],"
+            + "    MEMBER[\"World Geodetic System 1984 (G730)\"],"
+            + "    MEMBER[\"World Geodetic System 1984 (G873)\"],"
+            + "    MEMBER[\"World Geodetic System 1984 (G1150)\"],"
+            + "    MEMBER[\"World Geodetic System 1984 (G1674)\"],"
+            + "    MEMBER[\"World Geodetic System 1984 (G1762)\"],"
+            + "    MEMBER[\"World Geodetic System 1984 (G2139)\"],"
+            + "    MEMBER[\"World Geodetic System 1984 (G2296)\"],"
+            + "    ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],"
+            + "    ENSEMBLEACCURACY[2.0]],"
+            + "  PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "  ID[\"EPSG\",4326]],"
+            + "CONVERSION[\"Popular Visualisation Pseudo-Mercator\","
+            + "  METHOD[\"Popular Visualisation Pseudo Mercator\",ID[\"EPSG\",1024]],"
+            + "  PARAMETER[\"Latitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],"
+            + "  PARAMETER[\"Longitude of natural origin\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],"
+            + "  PARAMETER[\"False easting\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],"
+            + "  PARAMETER[\"False northing\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],"
+            + "CS[Cartesian,2],"
+            + "  AXIS[\"easting (X)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],"
+            + "  AXIS[\"northing (Y)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],"
+            + "USAGE[SCOPE[\"Web mapping and visualisation.\"],"
+            + "  AREA[\"World between 85.06S and 85.06N.\"],"
+            + "  BBOX[-85.06,-180,85.06,180]],"
+            + "ID[\"EPSG\",3857]]";
+
+        Converter fromEpsg = Proj4.proj4("EPSG:4326", "EPSG:3857");
+        Converter fromWkt2 = Proj4.proj4("EPSG:4326", wkt2_3857);
+
+        // lon=-112.5, lat=42.04 — same test point as proj4js
+        Point ll = new Point(-112.50042920000004, 42.036926809999976);
+        Point xyFromEpsg = fromEpsg.forward(ll);
+        Point xyFromWkt2 = fromWkt2.forward(ll);
+
+        assertEquals(xyFromEpsg.x, xyFromWkt2.x, 0.01, "WKT2 3857 x should match EPSG:3857");
+        assertEquals(xyFromEpsg.y, xyFromWkt2.y, 0.01, "WKT2 3857 y should match EPSG:3857");
+
+        // Verify specific expected values
+        assertEquals(-12523490.49, xyFromWkt2.x, 1.0);
+        assertEquals(5166512.51,   xyFromWkt2.y, 1.0);
+    }
+
+    @Test
+    void testWebMercatorWkt1StillWorks() {
+        // WKT1 with EXTENSION[PROJ4,...] should also continue to work
+        String wkt1_3857 = "PROJCS[\"WGS 84 / Pseudo-Mercator\","
+            + "GEOGCS[\"WGS 84\","
+            + "  DATUM[\"WGS_1984\","
+            + "    SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],"
+            + "    AUTHORITY[\"EPSG\",\"6326\"]],"
+            + "  PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],"
+            + "  UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],"
+            + "  AUTHORITY[\"EPSG\",\"4326\"]],"
+            + "PROJECTION[\"Mercator_1SP\"],"
+            + "PARAMETER[\"central_meridian\",0],"
+            + "PARAMETER[\"scale_factor\",1],"
+            + "PARAMETER[\"false_easting\",0],"
+            + "PARAMETER[\"false_northing\",0],"
+            + "UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],"
+            + "AXIS[\"X\",EAST],AXIS[\"Y\",NORTH],"
+            + "EXTENSION[\"PROJ4\",\"+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs\"],"
+            + "AUTHORITY[\"EPSG\",\"3857\"]]";
+
+        Converter fromEpsg = Proj4.proj4("EPSG:4326", "EPSG:3857");
+        Converter fromWkt1 = Proj4.proj4("EPSG:4326", wkt1_3857);
+
+        Point ll = new Point(-112.50042920000004, 42.036926809999976);
+        Point xyFromEpsg = fromEpsg.forward(ll);
+        Point xyFromWkt1 = fromWkt1.forward(ll);
+
+        assertEquals(xyFromEpsg.x, xyFromWkt1.x, 0.01, "WKT1 3857 x should match EPSG:3857");
+        assertEquals(xyFromEpsg.y, xyFromWkt1.y, 0.01, "WKT1 3857 y should match EPSG:3857");
+    }
 }


### PR DESCRIPTION
## Summary

Port of [proj4js PR #546](https://github.com/proj4js/proj4js/pull/546).

## Problem

Web Mercator (EPSG:3857) WKT2 and PROJJSON definitions declare the WGS84 ellipsoid (a=6378137, b=6356752), but Web Mercator must be computed on a sphere (a=b=6378137). We already had a correct hard-coded definition for EPSG:3857 in BuiltInCRSProvider, but it was bypassed when the CRS input was a WKT2 or PROJJSON string, resulting in incorrect projected coordinates.

## Fix

Added a checkWebMercator() guard in Proj.parseCode() that detects known web mercator EPSG codes (3857, 900913, 3785, 102113) after WKT2/PROJJSON parsing and substitutes the hard-coded sphere-based definition.

## Changes

- Proj.java: Added WEB_MERCATOR_CODES set and checkWebMercator() method; applied after both the PROJJSON and WKT parse branches.
- TransformTest.java: Added two tests:
  - testWebMercatorWkt2MatchesEpsgCode: full WKT2 string for 3857 produces identical results to EPS  - testWebMercatorWkt2MatchesEpsgCode: full WKT2 string for 3857 prod.] continues to work

All 685 tests pass.