### PR TITLE
Fix: register sterea as alias for Stereographic projection

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
@@ -14,7 +14,7 @@ import org.datasyslab.proj4sedona.core.Point;
 public class Stereographic implements Projection {
 
     private static final String[] NAMES = {
-        "stere", "Stereographic", "Stereographic_South_Pole", "Stereographic_North_Pole",
+        "stere", "sterea", "Stereographic", "Stereographic_South_Pole", "Stereographic_North_Pole",
         "Polar_Stereographic_variant_A", "Polar_Stereographic_variant_B", 
         "Polar_Stereographic", "Oblique_Stereographic"
     };

--- a/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
@@ -94,7 +94,26 @@ class AllProjectionsTest {
     @Test
     void testStereographicRegisteredNames() {
         assertNotNull(ProjectionRegistry.get("stere"));
+        assertNotNull(ProjectionRegistry.get("sterea"),
+            "sterea should be registered as alias for Stereographic (issue #56)");
         assertNotNull(ProjectionRegistry.get("Polar_Stereographic"));
+    }
+
+    @Test
+    void testStereaRoundTrip() {
+        // Issue #56: +proj=sterea must be accepted since it is output by toProjString
+        Converter conv = Proj4.proj4(
+            "+proj=longlat +datum=WGS84",
+            "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 "
+                + "+k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel "
+                + "+towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 "
+                + "+units=m +no_defs"
+        );
+        Point original = new Point(5.387638889, 52.156160556);
+        Point projected = conv.forward(original);
+        Point restored = conv.inverse(projected);
+        assertEquals(original.x, restored.x, DEGREE_TOLERANCE);
+        assertEquals(original.y, restored.y, DEGREE_TOLERANCE);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #56: `+proj=sterea` cannot be re-imported (round-trip failure).

## Problem

proj4sedona outputs `+proj=sterea` for Oblique Stereographic projections (e.g., EPSG:28992 Amersfoort / RD New), but cannot re-import its own output because the `Stereographic` class is only registered under `stere`, not `sterea`.

## Fix

Added `sterea` to the `NAMES` array in `Stereographic.java` so the projection registry recognizes `+proj=sterea` as a valid lookup key.

## Changes

- **`Stereographic.java`** - Added `"sterea"` to the `NAMES` array
- **`AllProjectionsTest.java`** - Added `testStereaRoundTrip` test using EPSG:28992 parameters and updated `testStereographicRegisteredNames` to verify the alias

## Testing

All 25 tests in `AllProjectionsTest` pass.