### PR TITLE
Add American Polyconic projection (poly)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
+++ b/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
@@ -84,6 +84,20 @@ public final class ProjMath {
     }
 
     /**
+     * Compute the radius of curvature in the prime vertical (N).
+     * Mirrors: lib/common/gN.js
+     *
+     * @param a Semi-major axis
+     * @param e Eccentricity of the ellipsoid
+     * @param sinphi Sine of the latitude
+     * @return The radius of curvature in the prime vertical
+     */
+    public static double gN(double a, double e, double sinphi) {
+        double temp = e * sinphi;
+        return a / Math.sqrt(1 - temp * temp);
+    }
+
+    /**
      * Compute the constant small t for use in the forward computations.
      * Mirrors: lib/common/tsfnz.js
      *

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Polyconic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Polyconic.java
@@ -1,0 +1,144 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * (American) Polyconic projection implementation.
+ * Mirrors: lib/projections/poly.js
+ *
+ * <p>A projection in which the parallels are arcs of circles whose radius equals
+ * the cotangent of the latitude. Each parallel has its own cone of projection, so
+ * scale is true along the central meridian and along each parallel. Used by several
+ * national grids, e.g. EPSG:5880 (SIRGAS 2000 / Brazil Polyconic).</p>
+ */
+public class Polyconic implements Projection {
+
+    private static final String[] NAMES = {"Polyconic", "American_Polyconic", "poly"};
+
+    private static final int MAX_ITER = 20;
+
+    private double a, b, es, e, lat0, long0, x0, y0;
+    private double e0, e1, e2, e3, ml0;
+    private boolean sphere;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.b = params.b;
+        this.lat0 = params.getLat0();
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.sphere = params.sphere;
+        this.over = params.over;
+
+        // Mirror poly.js: recompute es/e from the axes so the projection is
+        // self-consistent even when es was not propagated.
+        double temp = this.b / this.a;
+        this.es = 1 - temp * temp;
+        this.e = Math.sqrt(this.es);
+        this.e0 = ProjMath.e0fn(this.es);
+        this.e1 = ProjMath.e1fn(this.es);
+        this.e2 = ProjMath.e2fn(this.es);
+        this.e3 = ProjMath.e3fn(this.es);
+        this.ml0 = this.a * ProjMath.mlfn(this.e0, this.e1, this.e2, this.e3, this.lat0);
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lon = p.x;
+        double lat = p.y;
+        double x, y;
+
+        double dlon = ProjMath.adjustLon(lon - long0, over);
+        double el = dlon * Math.sin(lat);
+        if (sphere) {
+            if (Math.abs(lat) <= Values.EPSLN) {
+                x = a * dlon;
+                y = -1 * a * lat0;
+            } else {
+                x = a * Math.sin(el) / Math.tan(lat);
+                y = a * (ProjMath.adjustLat(lat - lat0) + (1 - Math.cos(el)) / Math.tan(lat));
+            }
+        } else {
+            if (Math.abs(lat) <= Values.EPSLN) {
+                x = a * dlon;
+                y = -1 * ml0;
+            } else {
+                double nl = ProjMath.gN(a, e, Math.sin(lat)) / Math.tan(lat);
+                x = nl * Math.sin(el);
+                y = a * ProjMath.mlfn(e0, e1, e2, e3, lat) - ml0 + nl * (1 - Math.cos(el));
+            }
+        }
+
+        return new Point(x + x0, y + y0, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double lon, lat = 0;
+        double al, bl, phi, dphi;
+        double x = p.x - x0;
+        double y = p.y - y0;
+
+        if (sphere) {
+            if (Math.abs(y + a * lat0) <= Values.EPSLN) {
+                lon = ProjMath.adjustLon(x / a + long0, over);
+                lat = 0;
+            } else {
+                al = lat0 + y / a;
+                bl = x * x / a / a + al * al;
+                phi = al;
+                double tanphi;
+                for (int i = MAX_ITER; i != 0; --i) {
+                    tanphi = Math.tan(phi);
+                    dphi = -1 * (al * (phi * tanphi + 1) - phi - 0.5 * (phi * phi + bl) * tanphi)
+                            / ((phi - al) / tanphi - 1);
+                    phi += dphi;
+                    if (Math.abs(dphi) <= Values.EPSLN) {
+                        lat = phi;
+                        break;
+                    }
+                }
+                lon = ProjMath.adjustLon(long0 + (Math.asin(x * Math.tan(phi) / a)) / Math.sin(lat), over);
+            }
+        } else {
+            if (Math.abs(y + ml0) <= Values.EPSLN) {
+                lat = 0;
+                lon = ProjMath.adjustLon(long0 + x / a, over);
+            } else {
+                al = (ml0 + y) / a;
+                bl = x * x / a / a + al * al;
+                phi = al;
+                double cl = 0, mln, mlnp, ma, con;
+                for (int i = MAX_ITER; i != 0; --i) {
+                    con = e * Math.sin(phi);
+                    cl = Math.sqrt(1 - con * con) * Math.tan(phi);
+                    mln = a * ProjMath.mlfn(e0, e1, e2, e3, phi);
+                    mlnp = e0 - 2 * e1 * Math.cos(2 * phi) + 4 * e2 * Math.cos(4 * phi)
+                            - 6 * e3 * Math.cos(6 * phi);
+                    ma = mln / a;
+                    dphi = (al * (cl * ma + 1) - ma - 0.5 * cl * (ma * ma + bl))
+                            / (es * Math.sin(2 * phi) * (ma * ma + bl - 2 * al * ma) / (4 * cl)
+                                + (al - ma) * (cl * mlnp - 2 / Math.sin(2 * phi)) - mlnp);
+                    phi -= dphi;
+                    if (Math.abs(dphi) <= Values.EPSLN) {
+                        lat = phi;
+                        break;
+                    }
+                }
+
+                cl = Math.sqrt(1 - es * Math.pow(Math.sin(lat), 2)) * Math.tan(lat);
+                lon = ProjMath.adjustLon(long0 + Math.asin(x * cl / a) / Math.sin(lat), over);
+            }
+        }
+
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -157,7 +157,8 @@ public final class ProjectionRegistry {
         add(LambertConformalConic::new);
         add(AlbersEqualArea::new);
         add(EquidistantConic::new);
-        
+        add(Polyconic::new);
+
         // Azimuthal projections
         add(Stereographic::new);
         add(LambertAzimuthalEqualArea::new);

--- a/src/test/java/org/datasyslab/proj4sedona/projection/PolyconicTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/PolyconicTest.java
@@ -1,0 +1,170 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.transform.Transform;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the (American) Polyconic projection (poly).
+ *
+ * <p>The {@code testData*} cases below are ported from proj4js
+ * ({@code test/testData.js}, SAD69 / Brazil Polyconic, EPSG:29101) and use the
+ * same reference coordinates and tolerances. proj4js drives every case as
+ * WGS84 &rarr; CRS (forward) and CRS &rarr; WGS84 (inverse); the tolerance is
+ * {@code 10^-acc} (xy acc = -2 &rarr; 100 m, ll acc = 3 &rarr; 0.001&deg;).</p>
+ */
+class PolyconicTest {
+
+    // proj4js WGS84 datum reference
+    private static final Proj WGS84 = new Proj("+proj=longlat +datum=WGS84 +no_defs");
+
+    // SAD69 / Brazil Polyconic (EPSG:29101), three WKT encodings from proj4js testData.js
+    private static final String SAD69_WKT1_ESRI =
+        "PROJCS[\"SAD69 / Brazil Polyconic\",GEOGCS[\"SAD69\",DATUM[\"D_South_American_1969\","
+            + "SPHEROID[\"GRS_1967_SAD69\",6378160,298.25]],PRIMEM[\"Greenwich\",0],"
+            + "UNIT[\"Degree\",0.017453292519943295]],PROJECTION[\"Polyconic\"],"
+            + "PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-54],"
+            + "PARAMETER[\"false_easting\",5000000],PARAMETER[\"false_northing\",10000000],"
+            + "UNIT[\"Meter\",1]]";
+    private static final String SAD69_WKT1_EPSG =
+        "PROJCS[\"SAD69 / Brazil Polyconic\",GEOGCS[\"SAD69\",DATUM[\"South_American_Datum_1969\","
+            + "SPHEROID[\"GRS 1967 (SAD69)\",6378160,298.25,AUTHORITY[\"EPSG\",\"7050\"]],"
+            + "AUTHORITY[\"EPSG\",\"6618\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],"
+            + "UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],"
+            + "AUTHORITY[\"EPSG\",\"4618\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],"
+            + "PROJECTION[\"Polyconic\"],PARAMETER[\"latitude_of_origin\",0],"
+            + "PARAMETER[\"central_meridian\",-54],PARAMETER[\"false_easting\",5000000],"
+            + "PARAMETER[\"false_northing\",10000000],AUTHORITY[\"EPSG\",\"29101\"],"
+            + "AXIS[\"X\",EAST],AXIS[\"Y\",NORTH]]";
+    private static final String SAD69_WKT2 =
+        "PROJCRS[\"SAD69 / Brazil Polyconic\",BASEGEOGCRS[\"SAD69\","
+            + "DATUM[\"South American Datum 1969\","
+            + "ELLIPSOID[\"GRS 1967 Modified\",6378160,298.25,LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4618]],"
+            + "CONVERSION[\"Brazil Polyconic\",METHOD[\"American Polyconic\",ID[\"EPSG\",9818]],"
+            + "PARAMETER[\"Latitude of natural origin\",0,"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],"
+            + "PARAMETER[\"Longitude of natural origin\",-54,"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],"
+            + "PARAMETER[\"False easting\",5000000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],"
+            + "PARAMETER[\"False northing\",10000000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],"
+            + "CS[Cartesian,2],AXIS[\"easting (X)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],"
+            + "AXIS[\"northing (Y)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],ID[\"EPSG\",29101]]";
+
+    // proj4js reference point and tolerances for EPSG:29101 (acc xy=-2, ll=3)
+    private static final double[] SAD69_LL = {-49.221772553812, -0.34551739237581};
+    private static final double[] SAD69_XY = {5531902.134932, 9961660.779347};
+    private static final double XY_EPSLN = Math.pow(10, 2);    // 100 m
+    private static final double LL_EPSLN = Math.pow(10, -3);   // 0.001 deg
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("poly"));
+        assertNotNull(ProjectionRegistry.get("Polyconic"));
+        assertNotNull(ProjectionRegistry.get("American_Polyconic"));
+    }
+
+    // ===== Ported from proj4js test/testData.js (SAD69 / Brazil Polyconic) =====
+
+    @Test
+    void testDataSad69Wkt1Esri() {
+        assertSad69(SAD69_WKT1_ESRI);
+    }
+
+    @Test
+    void testDataSad69Wkt1Epsg() {
+        assertSad69(SAD69_WKT1_EPSG);
+    }
+
+    @Test
+    void testDataSad69Wkt2() {
+        assertSad69(SAD69_WKT2);
+    }
+
+    /** Mirrors proj4js: forward = WGS84 -> CRS, inverse = CRS -> WGS84. */
+    private void assertSad69(String code) {
+        Proj proj = new Proj(code);
+
+        Point xy = Transform.transform(WGS84, proj, new Point(SAD69_LL[0], SAD69_LL[1]));
+        assertEquals(SAD69_XY[0], xy.x, XY_EPSLN, "x is close");
+        assertEquals(SAD69_XY[1], xy.y, XY_EPSLN, "y is close");
+
+        Point ll = Transform.transform(proj, WGS84, new Point(SAD69_XY[0], SAD69_XY[1]));
+        assertEquals(SAD69_LL[0], ll.x, LL_EPSLN, "lng is close");
+        assertEquals(SAD69_LL[1], ll.y, LL_EPSLN, "lat is close");
+    }
+
+    // ===== Issue #3088: EPSG:5880 SIRGAS 2000 / Brazil Polyconic =====
+    // Reference eastings/northings produced with proj4js 2.20.9 (projection only;
+    // SIRGAS 2000 and EPSG:5880 share the GRS80 datum, so no datum shift applies).
+
+    private static final String EPSG_5880 =
+        "+proj=poly +lat_0=0 +lon_0=-54 +x_0=5000000 +y_0=10000000 "
+            + "+ellps=GRS80 +units=m +no_defs";
+    private static final double METERS = 0.01; // 1 cm
+    private static final double RADIANS = 1e-9;
+
+    @Test
+    void testEpsg5880ForwardKnownValues() {
+        Proj poly = new Proj(EPSG_5880);
+
+        double[][] cases = {
+            {-54, -15, 5000000.000000, 8341010.410652},
+            {-47.9, -15.8, 5653463.734227, 8243016.222029},
+            {-60, -2, 4332488.696827, 9777630.779596},
+            {-54, 0, 5000000.000000, 10000000.000000},
+            {-43.2, -22.9, 6107064.064792, 7425917.997228},
+        };
+
+        for (double[] c : cases) {
+            Point f = poly.forward(new Point(c[0] * Values.D2R, c[1] * Values.D2R));
+            assertNotNull(f, "forward null for " + c[0] + "," + c[1]);
+            assertEquals(c[2], f.x, METERS, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], f.y, METERS, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    @Test
+    void testEpsg5880RoundTrip() {
+        Proj poly = new Proj(EPSG_5880);
+
+        double[][] coords = {
+            {-54, -15}, {-47.9, -15.8}, {-60, -2}, {-54, 0}, {-43.2, -22.9}, {-38, -3.7},
+        };
+
+        for (double[] coord : coords) {
+            double lon = coord[0] * Values.D2R;
+            double lat = coord[1] * Values.D2R;
+
+            Point forward = poly.forward(new Point(lon, lat));
+            assertNotNull(forward, "forward null for " + coord[0] + "," + coord[1]);
+
+            Point inverse = poly.inverse(forward.copy());
+            assertNotNull(inverse, "inverse null for " + coord[0] + "," + coord[1]);
+            assertEquals(lon, inverse.x, RADIANS, "lon for " + coord[0]);
+            assertEquals(lat, inverse.y, RADIANS, "lat for " + coord[1]);
+        }
+    }
+
+    @Test
+    void testEquatorAtCentralMeridian() {
+        Proj poly = new Proj(EPSG_5880);
+
+        // On the central meridian at the equator, easting/northing collapse to the
+        // false origin (x0, y0).
+        Point f = poly.forward(new Point(-54 * Values.D2R, 0));
+        assertEquals(5000000.0, f.x, METERS);
+        assertEquals(10000000.0, f.y, METERS);
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/PolyconicTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/PolyconicTest.java
@@ -167,4 +167,54 @@ class PolyconicTest {
         assertEquals(5000000.0, f.x, METERS);
         assertEquals(10000000.0, f.y, METERS);
     }
+
+    // ===== Spherical Polyconic =====
+    // Same definition as EPSG:5880 but on an authalic sphere (a == b), which forces
+    // poly.js's spherical branch. Reference values from proj4js 2.20.9.
+
+    private static final String SPHERE_POLY =
+        "+proj=poly +lat_0=0 +lon_0=-54 +x_0=5000000 +y_0=10000000 "
+            + "+a=6370997 +b=6370997 +units=m +no_defs";
+
+    @Test
+    void testSphericalForwardKnownValues() {
+        Proj poly = new Proj(SPHERE_POLY);
+
+        double[][] cases = {
+            {-54, -15, 5000000.000000, 8332076.885730},
+            {-47.9, -15.8, 5652570.219821, 8233661.860367},
+            {-60, -2, 4333238.660049, 9776391.854825},
+            {-54, 0, 5000000.000000, 10000000.000000},
+            {-43.2, -22.9, 6105264.163383, 7413084.662878},
+        };
+
+        for (double[] c : cases) {
+            Point f = poly.forward(new Point(c[0] * Values.D2R, c[1] * Values.D2R));
+            assertNotNull(f, "forward null for " + c[0] + "," + c[1]);
+            assertEquals(c[2], f.x, METERS, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], f.y, METERS, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    @Test
+    void testSphericalRoundTrip() {
+        Proj poly = new Proj(SPHERE_POLY);
+
+        double[][] coords = {
+            {-54, -15}, {-47.9, -15.8}, {-60, -2}, {-54, 0}, {-43.2, -22.9}, {-38, -3.7},
+        };
+
+        for (double[] coord : coords) {
+            double lon = coord[0] * Values.D2R;
+            double lat = coord[1] * Values.D2R;
+
+            Point forward = poly.forward(new Point(lon, lat));
+            assertNotNull(forward, "forward null for " + coord[0] + "," + coord[1]);
+
+            Point inverse = poly.inverse(forward.copy());
+            assertNotNull(inverse, "inverse null for " + coord[0] + "," + coord[1]);
+            assertEquals(lon, inverse.x, RADIANS, "lon for " + coord[0]);
+            assertEquals(lat, inverse.y, RADIANS, "lat for " + coord[1]);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Ports the (American) Polyconic projection from proj4js (`lib/projections/poly.js`).
Polyconic was the one projection used by EPSG:5880 (SIRGAS 2000 / Brazil Polyconic)
and EPSG:29101 (SAD69 / Brazil Polyconic), and was not implemented, so
`ST_Transform` to those CRSs failed with `Unknown projection: American Polyconic`
(also `poly` / `Polyconic` depending on how the CRS was specified).

## Changes

- **`Polyconic`** — forward/inverse for spherical and ellipsoidal cases, including
  the iterative Newton solve in the inverse. Registered as `Polyconic`,
  `American_Polyconic`, and `poly`.
- **`ProjMath.gN`** — radius of curvature in the prime vertical (`lib/common/gN.js`),
  the only helper `poly` needed that wasn't already present.
- **`ProjectionRegistry`** — registers `Polyconic` alongside the other conics.

## Tests

- The three SAD69 / Brazil Polyconic (EPSG:29101) cases from proj4js
  `test/testData.js` are ported with the same reference point and tolerances
  (WKT1 ESRI, WKT1 EPSG, WKT2), driven WGS84 ↔ CRS exactly like the proj4js harness.
- EPSG:5880 known-value and round-trip checks against proj4js 2.20.9 output.
- Full suite: 695 tests pass.

Reported downstream in apache/sedona#3088.
