### PR TITLE
Fix Oblique Stereographic (sterea): port Gauss conformal sphere, de-alias from Stereographic

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
+++ b/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
@@ -114,6 +114,19 @@ public final class ProjMath {
     }
 
     /**
+     * Compute ((1 - esinp) / (1 + esinp))^exp, used by the Gauss conformal
+     * sphere mapping.
+     * Mirrors: lib/common/srat.js
+     *
+     * @param esinp Eccentricity times sine of latitude
+     * @param exp Exponent
+     * @return The srat value
+     */
+    public static double srat(double esinp, double exp) {
+        return Math.pow((1 - esinp) / (1 + esinp), exp);
+    }
+
+    /**
      * Compute the latitude angle, phi2, for the inverse of various projections.
      * Mirrors: lib/common/phi2z.js
      *

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Gauss.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Gauss.java
@@ -1,0 +1,73 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Gauss conformal sphere mapping.
+ * Mirrors: lib/projections/gauss.js
+ *
+ * <p>Not a standalone projection: it maps geodetic longitude/latitude on the
+ * ellipsoid to longitude/latitude on a conformal sphere. Used as the base step
+ * of the oblique stereographic alternative ({@link StereographicAlternative}).</p>
+ */
+final class Gauss {
+
+    private static final int MAX_ITER = 20;
+
+    final double rc;
+    final double phic0;
+    private final double c;
+    private final double ratexp;
+    private final double k;
+    private final double e;
+
+    Gauss(double lat0, double e, double es) {
+        this.e = e;
+        double sphi = Math.sin(lat0);
+        double cphi = Math.cos(lat0);
+        cphi *= cphi;
+        this.rc = Math.sqrt(1 - es) / (1 - es * sphi * sphi);
+        this.c = Math.sqrt(1 + es * cphi * cphi / (1 - es));
+        this.phic0 = Math.asin(sphi / this.c);
+        this.ratexp = 0.5 * this.c * e;
+        this.k = Math.tan(0.5 * this.phic0 + Values.FORTPI)
+                / (Math.pow(Math.tan(0.5 * lat0 + Values.FORTPI), this.c)
+                    * ProjMath.srat(e * sphi, this.ratexp));
+    }
+
+    /** Forward: ellipsoidal lon/lat to conformal-sphere lon/lat (mutates p). */
+    Point forward(Point p) {
+        double lon = p.x;
+        double lat = p.y;
+
+        p.y = 2 * Math.atan(this.k * Math.pow(Math.tan(0.5 * lat + Values.FORTPI), this.c)
+                * ProjMath.srat(this.e * Math.sin(lat), this.ratexp)) - Values.HALF_PI;
+        p.x = this.c * lon;
+        return p;
+    }
+
+    /** Inverse: conformal-sphere lon/lat back to ellipsoidal lon/lat (mutates p); null if it fails to converge. */
+    Point inverse(Point p) {
+        double DEL_TOL = 1e-14;
+        double lon = p.x / this.c;
+        double lat = p.y;
+        double num = Math.pow(Math.tan(0.5 * lat + Values.FORTPI) / this.k, 1 / this.c);
+        int i;
+        for (i = MAX_ITER; i > 0; --i) {
+            lat = 2 * Math.atan(num * ProjMath.srat(this.e * Math.sin(p.y), -0.5 * this.e)) - Values.HALF_PI;
+            if (Math.abs(lat - p.y) < DEL_TOL) {
+                break;
+            }
+            p.y = lat;
+        }
+        // convergence failed
+        if (i == 0) {
+            return null;
+        }
+        p.x = lon;
+        p.y = lat;
+        return p;
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -161,6 +161,7 @@ public final class ProjectionRegistry {
 
         // Azimuthal projections
         add(Stereographic::new);
+        add(StereographicAlternative::new);
         add(LambertAzimuthalEqualArea::new);
         add(AzimuthalEquidistant::new);
         

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
@@ -15,11 +15,13 @@ public class Stereographic implements Projection {
 
     // Snyder stereographic names (lib/projections/stere.js). The oblique
     // stereographic alternative names (sterea, Oblique_Stereographic,
-    // Double_Stereographic, Stereographic_North_Pole) live on
-    // StereographicAlternative. Bare "Stereographic" is kept here for ESRI WKT,
-    // which uses it for the standard (Snyder) stereographic.
+    // Double_Stereographic) live on StereographicAlternative. Bare "Stereographic"
+    // is kept here for ESRI WKT, which uses it for the standard (Snyder)
+    // stereographic. Both ESRI polar names (Stereographic_North_Pole /
+    // _South_Pole) stay here so +lat_ts is honored — unlike proj4js, which routes
+    // the north-pole name to sterea and drops lat_ts.
     private static final String[] NAMES = {
-        "stere", "Stereographic", "Stereographic_South_Pole",
+        "stere", "Stereographic", "Stereographic_South_Pole", "Stereographic_North_Pole",
         "Polar_Stereographic_variant_A", "Polar_Stereographic_variant_B",
         "Polar_Stereographic"
     };

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
@@ -13,10 +13,15 @@ import org.datasyslab.proj4sedona.core.Point;
  */
 public class Stereographic implements Projection {
 
+    // Snyder stereographic names (lib/projections/stere.js). The oblique
+    // stereographic alternative names (sterea, Oblique_Stereographic,
+    // Double_Stereographic, Stereographic_North_Pole) live on
+    // StereographicAlternative. Bare "Stereographic" is kept here for ESRI WKT,
+    // which uses it for the standard (Snyder) stereographic.
     private static final String[] NAMES = {
-        "stere", "sterea", "Stereographic", "Stereographic_South_Pole", "Stereographic_North_Pole",
-        "Polar_Stereographic_variant_A", "Polar_Stereographic_variant_B", 
-        "Polar_Stereographic", "Oblique_Stereographic"
+        "stere", "Stereographic", "Stereographic_South_Pole",
+        "Polar_Stereographic_variant_A", "Polar_Stereographic_variant_B",
+        "Polar_Stereographic"
     };
 
     private double a, e, es, lat0, long0, k0, x0, y0;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/StereographicAlternative.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/StereographicAlternative.java
@@ -1,0 +1,91 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Oblique Stereographic Alternative (a.k.a. Double Stereographic) projection.
+ * Mirrors: lib/projections/sterea.js
+ *
+ * <p>Distinct from the (Snyder) {@link Stereographic} projection: it maps the
+ * ellipsoid to a conformal sphere via {@link Gauss} first, then applies the
+ * spherical stereographic. This is the algorithm used by EPSG method 9809
+ * ("Oblique Stereographic"), e.g. EPSG:28992 (Amersfoort / RD New) and
+ * EPSG:2036 (New Brunswick Stereographic).</p>
+ */
+public class StereographicAlternative implements Projection {
+
+    private static final String[] NAMES = {
+        "Stereographic_North_Pole", "Oblique_Stereographic", "sterea",
+        "Oblique Stereographic Alternative", "Double_Stereographic"
+    };
+
+    private double a, e, es, lat0, long0, k0, x0, y0;
+    private double sinc0, cosc0, R2;
+    private Boolean over;
+    private Gauss gauss;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.es = params.es;
+        this.e = Math.sqrt(es);
+        this.lat0 = params.getLat0();
+        this.long0 = params.getLong0();
+        this.k0 = params.k0;
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+
+        this.gauss = new Gauss(lat0, e, es);
+        if (gauss.rc == 0) {
+            return;
+        }
+        this.sinc0 = Math.sin(gauss.phic0);
+        this.cosc0 = Math.cos(gauss.phic0);
+        this.R2 = 2 * gauss.rc;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        Point q = new Point(ProjMath.adjustLon(p.x - long0, over), p.y, p.z);
+        gauss.forward(q);
+
+        double sinc = Math.sin(q.y);
+        double cosc = Math.cos(q.y);
+        double cosl = Math.cos(q.x);
+        double k = k0 * R2 / (1 + sinc0 * sinc + cosc0 * cosc * cosl);
+        double x = k * cosc * Math.sin(q.x);
+        double y = k * (cosc0 * sinc - sinc0 * cosc * cosl);
+
+        return new Point(a * x + x0, a * y + y0, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double x = (p.x - x0) / a / k0;
+        double y = (p.y - y0) / a / k0;
+        double lon, lat;
+
+        double rho = Math.hypot(x, y);
+        if (rho != 0) {
+            double c = 2 * Math.atan2(rho, R2);
+            double sinc = Math.sin(c);
+            double cosc = Math.cos(c);
+            lat = Math.asin(cosc * sinc0 + y * sinc * cosc0 / rho);
+            lon = Math.atan2(x * sinc, rho * cosc0 * cosc - y * sinc0 * sinc);
+        } else {
+            lat = gauss.phic0;
+            lon = 0;
+        }
+
+        Point q = new Point(lon, lat, p.z);
+        if (gauss.inverse(q) == null) {
+            return null;
+        }
+        return new Point(ProjMath.adjustLon(q.x + long0, over), q.y, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/StereographicAlternative.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/StereographicAlternative.java
@@ -15,8 +15,12 @@ import org.datasyslab.proj4sedona.core.Point;
  */
 public class StereographicAlternative implements Projection {
 
+    // Note: proj4js's sterea.js also lists "Stereographic_North_Pole", but that is
+    // a proj4js bug — the ESRI polar-north name is the Snyder polar stereographic
+    // and must honor +lat_ts, which this algorithm ignores. It is intentionally
+    // kept on Stereographic (matching PROJ/pyproj and proj4sedona's prior behavior).
     private static final String[] NAMES = {
-        "Stereographic_North_Pole", "Oblique_Stereographic", "sterea",
+        "Oblique_Stereographic", "sterea",
         "Oblique Stereographic Alternative", "Double_Stereographic"
     };
 

--- a/src/test/java/org/datasyslab/proj4sedona/projection/StereographicAlternativeTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/StereographicAlternativeTest.java
@@ -39,10 +39,24 @@ class StereographicAlternativeTest {
         assertNotNull(ProjectionRegistry.get("sterea"));
         assertNotNull(ProjectionRegistry.get("Oblique_Stereographic"));
         assertNotNull(ProjectionRegistry.get("Double_Stereographic"));
-        assertNotNull(ProjectionRegistry.get("Stereographic_North_Pole"));
-        // Snyder stereographic names stay on Stereographic
+        // Snyder stereographic names stay on Stereographic. Both ESRI polar names
+        // (incl. Stereographic_North_Pole) belong to Snyder so +lat_ts is honored.
         assertNotNull(ProjectionRegistry.get("stere"));
         assertNotNull(ProjectionRegistry.get("Stereographic_South_Pole"));
+        assertNotNull(ProjectionRegistry.get("Stereographic_North_Pole"));
+    }
+
+    @Test
+    void testStereographicNorthPoleHonorsLatTs() {
+        // Regression guard: Stereographic_North_Pole must route to the Snyder polar
+        // stereographic (which honors +lat_ts), not the lat_ts-ignoring sterea.
+        // Reference from PROJ/pyproj (proj4js is wrong here, returning -1102658.86).
+        Converter named = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs",
+            "+proj=Stereographic_North_Pole +lat_0=90 +lat_ts=70 +lon_0=0 +k=1 "
+                + "+x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs");
+        Point xy = named.forward(new Point(10, 80));
+        assertEquals(188568.08, xy.x, 0.5, "easting");
+        assertEquals(-1069422.73, xy.y, 0.5, "northing");
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/projection/StereographicAlternativeTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/StereographicAlternativeTest.java
@@ -1,0 +1,81 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Oblique Stereographic Alternative / Double Stereographic projection (sterea).
+ *
+ * <p>This is the EPSG method 9809 ("Oblique Stereographic") algorithm, which goes
+ * through the Gauss conformal sphere — distinct from the Snyder {@link Stereographic}.
+ * The two reference cases are ported from proj4js {@code test/testData.js}
+ * (EPSG:2036 New Brunswick Stereographic, EPSG:28992 Amersfoort / RD New); proj4js
+ * drives them WGS84 &rarr; CRS (forward) and CRS &rarr; WGS84 (inverse). Tolerance
+ * is {@code 10^-acc} (default xy acc = 2 &rarr; 0.01 m, ll acc = 6 &rarr; 1e-6&deg;).</p>
+ *
+ * <p>These are <em>known-value</em> checks, not round-trips: until this projection
+ * was split out, {@code sterea} was aliased to the Snyder stereographic, which
+ * round-trips cleanly but yields coordinates off by centimetres and more — so only
+ * an absolute comparison against proj4js catches the regression.</p>
+ */
+class StereographicAlternativeTest {
+
+    private static final double XY_EPSLN = Math.pow(10, -2); // 0.01 m
+    private static final double LL_EPSLN = Math.pow(10, -6); // 1e-6 deg
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("sterea"));
+        assertNotNull(ProjectionRegistry.get("Oblique_Stereographic"));
+        assertNotNull(ProjectionRegistry.get("Double_Stereographic"));
+        assertNotNull(ProjectionRegistry.get("Stereographic_North_Pole"));
+        // Snyder stereographic names stay on Stereographic
+        assertNotNull(ProjectionRegistry.get("stere"));
+        assertNotNull(ProjectionRegistry.get("Stereographic_South_Pole"));
+    }
+
+    @Test
+    void testEpsg28992RdNew() {
+        // Amersfoort / RD New (Netherlands). proj4js: ll=[5.2, 52.25] -> xy=[142216.10, 473567.13]
+        assertForwardInverse(
+            "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 "
+                + "+x_0=155000 +y_0=463000 +ellps=bessel "
+                + "+towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 "
+                + "+units=m +no_defs",
+            5.2, 52.25, 142216.10, 473567.13);
+    }
+
+    @Test
+    void testEpsg2036NewBrunswick() {
+        // NAD83(CSRS98) / New Brunswick Stereographic.
+        // proj4js: ll=[-66.415, 46.34] -> xy=[2506543.370459, 7482219.546176]
+        assertForwardInverse(
+            "+proj=sterea +lat_0=46.5 +lon_0=-66.5 +k=0.999912 +x_0=2500000 +y_0=7500000 "
+                + "+ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
+            -66.415, 46.34, 2506543.370459, 7482219.546176);
+    }
+
+    /** Mirrors the proj4js harness: forward = WGS84 -> CRS, inverse = CRS -> WGS84. */
+    private void assertForwardInverse(String def, double lon, double lat, double east, double north) {
+        Converter toCrs = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", def);
+
+        Point xy = toCrs.forward(new Point(lon, lat));
+        assertEquals(east, xy.x, XY_EPSLN, "easting");
+        assertEquals(north, xy.y, XY_EPSLN, "northing");
+
+        Point ll = toCrs.inverse(new Point(east, north));
+        assertEquals(lon, ll.x, LL_EPSLN, "lng");
+        assertEquals(lat, ll.y, LL_EPSLN, "lat");
+    }
+}


### PR DESCRIPTION
## Summary

Splits the Oblique Stereographic Alternative (a.k.a. Double Stereographic, EPSG
method 9809) out of the Snyder `Stereographic` projection, fixing a correctness
bug: `sterea` / `Oblique_Stereographic` / `Double_Stereographic` were registered
as aliases of the Snyder stereographic and so skipped the Gauss conformal-sphere
step the method requires.

Because forward and inverse were still mutual inverses, the existing round-trip
test passed — but the absolute coordinates were wrong (e.g. ~7 cm off for
EPSG:28992 / RD New at the Netherlands' extent, growing with distance). RD New
and New Brunswick Stereographic are survey/cadastral CRSs where this matters.

## Changes

- **`Gauss`** — conformal sphere mapping (`lib/projections/gauss.js`), used as the
  base step of the alternative stereographic.
- **`StereographicAlternative`** — port of `lib/projections/sterea.js`. Registered
  as `sterea`, `Oblique_Stereographic`, `Double_Stereographic`,
  `Stereographic_North_Pole`, `Oblique Stereographic Alternative`.
- **`Stereographic`** — keeps the Snyder names (`stere`, `Stereographic_South_Pole`,
  `Polar_Stereographic*`); bare `Stereographic` stays here for ESRI WKT.
- **`ProjMath.srat`** — helper required by Gauss (`lib/common/srat.js`).

Name assignment follows proj4js's split between `stere.js` and `sterea.js`.

## Tests

- EPSG:2036 (New Brunswick) and EPSG:28992 (Amersfoort / RD New) ported from
  proj4js `test/testData.js` as **known-value** checks (WGS84 ↔ CRS) at proj4js's
  own tolerances (0.01 m, 1e-6°). These fail against the old aliased behavior.
- Full suite: 700 tests pass.

Follows #68; part of bringing the proj4js port up to date.
