### PR TITLE
Add Swiss Oblique Mercator (somerc) projection

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -152,7 +152,8 @@ public final class ProjectionRegistry {
         add(UTM::new);
         add(EquidistantCylindrical::new);
         add(CylindricalEqualArea::new);
-        
+        add(SwissObliqueMercator::new);
+
         // Conic projections
         add(LambertConformalConic::new);
         add(AlbersEqualArea::new);

--- a/src/main/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercator.java
@@ -1,0 +1,96 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Swiss Oblique Mercator (somerc) projection.
+ * Mirrors: lib/projections/somerc.js
+ *
+ * <p>The conformal cylindrical projection with an oblique axis used by the Swiss
+ * national grids — e.g. EPSG:21781 (CH1903 / LV03) and EPSG:2056 (CH1903+ / LV95).
+ * This is the {@code +proj=somerc} algorithm (the canonical PROJ definition for
+ * those CRSs), based on the swisstopo formulas.</p>
+ */
+public class SwissObliqueMercator implements Projection {
+
+    private static final String[] NAMES = {"somerc"};
+
+    private static final int MAX_ITER = 20;
+
+    private double e, R, alpha, b0, K, lambda0, x0, y0;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        double phy0 = params.getLat0();
+        this.lambda0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        double sinPhy0 = Math.sin(phy0);
+        double semiMajorAxis = params.a;
+        double invF = params.rf;
+        double flattening = 1 / invF;
+        double e2 = 2 * flattening - Math.pow(flattening, 2);
+        this.e = Math.sqrt(e2);
+        this.R = params.k0 * semiMajorAxis * Math.sqrt(1 - e2) / (1 - e2 * Math.pow(sinPhy0, 2));
+        this.alpha = Math.sqrt(1 + e2 / (1 - e2) * Math.pow(Math.cos(phy0), 4));
+        this.b0 = Math.asin(sinPhy0 / this.alpha);
+        double k1 = Math.log(Math.tan(Math.PI / 4 + this.b0 / 2));
+        double k2 = Math.log(Math.tan(Math.PI / 4 + phy0 / 2));
+        double k3 = Math.log((1 + e * sinPhy0) / (1 - e * sinPhy0));
+        this.K = k1 - this.alpha * k2 + this.alpha * e / 2 * k3;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double Sa1 = Math.log(Math.tan(Math.PI / 4 - p.y / 2));
+        double Sa2 = this.e / 2 * Math.log((1 + this.e * Math.sin(p.y)) / (1 - this.e * Math.sin(p.y)));
+        double S = -this.alpha * (Sa1 + Sa2) + this.K;
+
+        // spheric latitude
+        double b = 2 * (Math.atan(Math.exp(S)) - Math.PI / 4);
+
+        // spheric longitude
+        double I = this.alpha * (p.x - this.lambda0);
+
+        // pseudo equatorial rotation
+        double rotI = Math.atan(Math.sin(I) / (Math.sin(this.b0) * Math.tan(b) + Math.cos(this.b0) * Math.cos(I)));
+        double rotB = Math.asin(Math.cos(this.b0) * Math.sin(b) - Math.sin(this.b0) * Math.cos(b) * Math.cos(I));
+
+        double y = this.R / 2 * Math.log((1 + Math.sin(rotB)) / (1 - Math.sin(rotB))) + this.y0;
+        double x = this.R * rotI + this.x0;
+        return new Point(x, y, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double Y = p.x - this.x0;
+        double X = p.y - this.y0;
+
+        double rotI = Y / this.R;
+        double rotB = 2 * (Math.atan(Math.exp(X / this.R)) - Math.PI / 4);
+
+        double b = Math.asin(Math.cos(this.b0) * Math.sin(rotB) + Math.sin(this.b0) * Math.cos(rotB) * Math.cos(rotI));
+        double I = Math.atan(Math.sin(rotI) / (Math.cos(this.b0) * Math.cos(rotI) - Math.sin(this.b0) * Math.tan(rotB)));
+
+        double lambda = this.lambda0 + I / this.alpha;
+
+        double S;
+        double phy = b;
+        double prevPhy = -1000;
+        int iteration = 0;
+        while (Math.abs(phy - prevPhy) > 0.0000001) {
+            if (++iteration > MAX_ITER) {
+                return null;
+            }
+            S = 1 / this.alpha * (Math.log(Math.tan(Math.PI / 4 + b / 2)) - this.K)
+                    + this.e * Math.log(Math.tan(Math.PI / 4 + Math.asin(this.e * Math.sin(phy)) / 2));
+            prevPhy = phy;
+            phy = 2 * Math.atan(Math.exp(S)) - Math.PI / 2;
+        }
+
+        return new Point(lambda, phy, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercator.java
@@ -13,7 +13,10 @@ import org.datasyslab.proj4sedona.core.Point;
  */
 public class SwissObliqueMercator implements Projection {
 
-    private static final String[] NAMES = {"somerc"};
+    // proj4js names somerc only "somerc". The extra alias lets a CRS round-trip
+    // through proj4sedona's WKT/PROJJSON serializer, which emits the EPSG method
+    // name "Swiss Oblique Mercator" (registry lookup normalizes spaces/underscores).
+    private static final String[] NAMES = {"somerc", "Swiss_Oblique_Mercator"};
 
     private static final int MAX_ITER = 20;
 

--- a/src/test/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercatorTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercatorTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.datasyslab.proj4sedona.Proj4;
 import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
 import org.datasyslab.proj4sedona.transform.Converter;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -67,13 +69,48 @@ class SwissObliqueMercatorTest {
 
     @Test
     void testLv03RoundTrip() {
-        Converter conv = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", LV03);
+        assertProjectionRoundTrip(LV03);
+    }
+
+    @Test
+    void testLv95RoundTrip() {
+        // LV95 differs from LV03 only by false easting/northing; exercise x0/y0
+        // handling in both directions here too.
+        assertProjectionRoundTrip(LV95);
+    }
+
+    private void assertProjectionRoundTrip(String def) {
+        Converter conv = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", def);
         double[][] coords = {{7.439583333, 46.952405556}, {8.55, 47.37}, {6.14, 46.2}, {9.5, 47.5}};
         for (double[] c : coords) {
             Point xy = conv.forward(new Point(c[0], c[1]));
             Point ll = conv.inverse(new Point(xy.x, xy.y));
             assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
             assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        // Regression guard for the round-trip bug: proj4sedona's serializer emits the
+        // method name "Swiss Oblique Mercator", which must re-import (previously failed
+        // with "Unknown projection: Swiss Oblique Mercator"). Compare the projection
+        // math (datum-independent) of the re-imported def against the original, so this
+        // does not depend on whether a given serialization preserves +towgs84.
+        Proj original = new Proj(LV03);
+        double[][] coords = {{7.439583333, 46.952405556}, {8.55, 47.37}, {6.14, 46.2}};
+        for (String serialized : new String[] {
+                CRSSerializer.toProjString(original),
+                CRSSerializer.toWkt1(original),
+                CRSSerializer.toWkt2(original),
+                CRSSerializer.toProjJson(original)}) {
+            Proj reimported = new Proj(serialized); // must not throw
+            for (double[] c : coords) {
+                Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+                assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+            }
         }
     }
 

--- a/src/test/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercatorTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercatorTest.java
@@ -1,0 +1,88 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Swiss Oblique Mercator (somerc) projection.
+ *
+ * <p>proj4js has no somerc-specific case in {@code test/testData.js} (it exercises
+ * the Swiss grid through the Hotine omerc WKT, a different algorithm that differs
+ * by ~9 cm). The reference eastings/northings below are therefore taken from
+ * proj4js 2.20.9's own {@code +proj=somerc} output — the canonical PROJ definition
+ * for EPSG:21781 / EPSG:2056 — driven WGS84 &rarr; CRS, matching how proj4js runs
+ * its cases. Tolerance is 0.01 m (xy) / 1e-7&deg; (ll).</p>
+ */
+class SwissObliqueMercatorTest {
+
+    private static final double XY_EPSLN = 0.01;     // 1 cm
+    private static final double LL_EPSLN = 1e-7;      // deg
+
+    // CH1903 / LV03 (EPSG:21781) and CH1903+ / LV95 (EPSG:2056)
+    private static final String LV03 =
+        "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 "
+            + "+x_0=600000 +y_0=200000 +ellps=bessel "
+            + "+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs";
+    private static final String LV95 =
+        "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 "
+            + "+x_0=2600000 +y_0=1200000 +ellps=bessel "
+            + "+towgs84=674.374,15.056,405.346,0,0,0,0 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("somerc"));
+    }
+
+    @Test
+    void testLv03KnownValues() {
+        // ll (deg) -> easting, northing (m), per proj4js 2.20.9 +proj=somerc
+        double[][] cases = {
+            {7.439583333, 46.952405556, 600072.389677, 200147.055632},
+            {8.55, 47.37, 683941.530345, 247167.393043},
+            {6.14, 46.2, 499760.951660, 117336.097859},
+        };
+        assertForward(LV03, cases);
+    }
+
+    @Test
+    void testLv95KnownValues() {
+        double[][] cases = {
+            {7.439583333, 46.952405556, 2600072.389677, 1200147.055632},
+            {8.55, 47.37, 2683941.530345, 1247167.393043},
+            {6.14, 46.2, 2499760.951660, 1117336.097859},
+        };
+        assertForward(LV95, cases);
+    }
+
+    @Test
+    void testLv03RoundTrip() {
+        Converter conv = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", LV03);
+        double[][] coords = {{7.439583333, 46.952405556}, {8.55, 47.37}, {6.14, 46.2}, {9.5, 47.5}};
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+
+    private void assertForward(String def, double[][] cases) {
+        Converter conv = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", def);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Swiss Oblique Mercator (`somerc`) projection from proj4js
(`lib/projections/somerc.js`). `+proj=somerc` is the canonical PROJ definition
for the Swiss national grids — **EPSG:21781** (CH1903 / LV03) and **EPSG:2056**
(CH1903+ / LV95) — which previously failed with `Unknown projection: somerc`.

## Changes

- **`SwissObliqueMercator`** — forward/inverse via the swisstopo oblique
  conformal-cylindrical formulas, with the iterative inverse for latitude.
  Self-contained: no new common helpers. Registered under `somerc`.
- **`ProjectionRegistry`** — registers it among the cylindrical projections.

## Tests

proj4js's `test/testData.js` has **no somerc-specific case**: it exercises the
Swiss grid through the Hotine omerc WKT, which is a different algorithm (≈9 cm
apart). The known-value tests therefore use proj4js 2.20.9's own `+proj=somerc`
output as the oracle (EPSG:21781 and EPSG:2056, WGS84 → CRS), plus a round-trip,
at 0.01 m / 1e-7° tolerance.

- Full suite: 705 tests pass.

Follows #68 and #69; continues bringing the proj4js port up to date. (omerc /
Hotine Oblique Mercator — the WKT method behind the same Swiss CRSs — remains a
separate follow-up.)
