### PR TITLE
Add Hotine Oblique Mercator (omerc) projection

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -293,6 +293,8 @@ public class Proj {
         p.alpha = def.getAlpha();
         p.longc = def.getLongc();
         p.rectifiedGridAngle = def.getRectifiedGridAngle();
+        p.noUoff = def.getNoUoff();
+        p.noRot = def.getNoRot();
 
         // Scale and offsets
         p.k0 = def.getK0() != null ? def.getK0() : 1.0;

--- a/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
@@ -58,6 +58,8 @@ public class ProjectionDef {
     private Boolean rA;            // R_A: Use authalic radius
     private Boolean approx;        // Use approximate algorithms
     private Boolean over;          // Allow longitude wrapping
+    private Boolean noUoff;        // no_uoff / no_off: Oblique Mercator without origin offset (variant A)
+    private Boolean noRot;         // no_rot: Oblique Mercator without rectification rotation
 
     // Datum object (populated after parsing)
     private DatumParams datum;
@@ -173,6 +175,12 @@ public class ProjectionDef {
 
     public Boolean getOver() { return over; }
     public void setOver(Boolean over) { this.over = over; }
+
+    public Boolean getNoUoff() { return noUoff; }
+    public void setNoUoff(Boolean noUoff) { this.noUoff = noUoff; }
+
+    public Boolean getNoRot() { return noRot; }
+    public void setNoRot(Boolean noRot) { this.noRot = noRot; }
 
     public DatumParams getDatum() { return datum; }
     public void setDatum(DatumParams datum) { this.datum = datum; }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -258,21 +258,40 @@ public final class CRSSerializer {
             sb.append(" +y_0=").append(params.y0);
         }
 
-        // Oblique Mercator (omerc) defining parameters
-        if (params.longc != null) {
-            sb.append(" +lonc=").append(formatAngle(params.longc * RAD_TO_DEG));
-        }
-        if (params.alpha != null) {
-            sb.append(" +alpha=").append(formatAngle(params.alpha * RAD_TO_DEG));
-        }
-        if (params.rectifiedGridAngle != null) {
-            sb.append(" +gamma=").append(formatAngle(params.rectifiedGridAngle * RAD_TO_DEG));
-        }
-        if (isOmerc && omercIsTypeA(params)) {
-            sb.append(" +no_uoff");
-        }
-        if (Boolean.TRUE.equals(params.noRot)) {
-            sb.append(" +no_rot");
+        // Oblique Mercator (omerc) defining parameters: either the azimuth/gamma
+        // parameterization or the two-point form.
+        if (isOmerc) {
+            if (params.alpha != null || params.rectifiedGridAngle != null) {
+                if (params.longc != null) {
+                    sb.append(" +lonc=").append(formatAngle(params.longc * RAD_TO_DEG));
+                }
+                if (params.alpha != null) {
+                    sb.append(" +alpha=").append(formatAngle(params.alpha * RAD_TO_DEG));
+                }
+                if (params.rectifiedGridAngle != null) {
+                    sb.append(" +gamma=").append(formatAngle(params.rectifiedGridAngle * RAD_TO_DEG));
+                }
+                if (omercIsTypeA(params)) {
+                    sb.append(" +no_uoff");
+                }
+            } else {
+                // Two-point form requires lon_1/lat_1/lon_2/lat_2
+                if (params.long1 != null) {
+                    sb.append(" +lon_1=").append(formatAngle(params.long1 * RAD_TO_DEG));
+                }
+                if (params.lat1 != null) {
+                    sb.append(" +lat_1=").append(formatAngle(params.lat1 * RAD_TO_DEG));
+                }
+                if (params.long2 != null) {
+                    sb.append(" +lon_2=").append(formatAngle(params.long2 * RAD_TO_DEG));
+                }
+                if (params.lat2 != null) {
+                    sb.append(" +lat_2=").append(formatAngle(params.lat2 * RAD_TO_DEG));
+                }
+            }
+            if (Boolean.TRUE.equals(params.noRot)) {
+                sb.append(" +no_rot");
+            }
         }
 
         // Ellipsoid parameters
@@ -623,8 +642,10 @@ public final class CRSSerializer {
 
     private static void appendWkt2Parameters(StringBuilder sb, String proj, ProjectionParams params) {
 
-        // Latitude of natural origin
-        if (params.lat0 != null) {
+        boolean isOmerc = "omerc".equals(proj);
+
+        // Latitude of natural origin (omerc emits "Latitude of projection centre" below)
+        if (params.lat0 != null && !isOmerc) {
             sb.append(",PARAMETER[\"Latitude of natural origin\",");
             sb.append(formatAngle(params.lat0 * RAD_TO_DEG));
             sb.append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
@@ -634,8 +655,8 @@ public final class CRSSerializer {
             sb.append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
         }
 
-        // Longitude of natural origin
-        if (params.long0 != null) {
+        // Longitude of natural origin (omerc uses the projection-centre name below)
+        if (params.long0 != null && !isOmerc) {
             sb.append(",PARAMETER[\"Longitude of natural origin\",");
             sb.append(formatAngle(params.long0 * RAD_TO_DEG));
             sb.append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
@@ -643,7 +664,12 @@ public final class CRSSerializer {
 
         // Oblique Mercator defining parameters. WKT2 is parsed via WKT2->PROJJSON,
         // so use the EPSG projection-centre parameter names the PROJJSON reader knows.
-        if ("omerc".equals(proj)) {
+        if (isOmerc) {
+            if (params.lat0 != null) {
+                sb.append(",PARAMETER[\"Latitude of projection centre\",")
+                  .append(formatAngle(params.lat0 * RAD_TO_DEG))
+                  .append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
+            }
             if (params.longc != null) {
                 sb.append(",PARAMETER[\"Longitude of projection centre\",")
                   .append(formatAngle(params.longc * RAD_TO_DEG))

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -104,6 +104,10 @@ public final class CRSSerializer {
         WKT_TO_PROJ_METHOD.put("polar stereographic (variant c)", "stere");
         WKT_TO_PROJ_METHOD.put("hotine oblique mercator (variant a)", "omerc");
         WKT_TO_PROJ_METHOD.put("hotine oblique mercator (variant b)", "omerc");
+        WKT_TO_PROJ_METHOD.put("hotine oblique mercator", "omerc");
+        WKT_TO_PROJ_METHOD.put("hotine oblique mercator azimuth center", "omerc");
+        WKT_TO_PROJ_METHOD.put("hotine oblique mercator azimuth natural origin", "omerc");
+        WKT_TO_PROJ_METHOD.put("hotine oblique mercator two point natural origin", "omerc");
         WKT_TO_PROJ_METHOD.put("laborde oblique mercator", "omerc");
         WKT_TO_PROJ_METHOD.put("krovak (north orientated)", "krovak");
         WKT_TO_PROJ_METHOD.put("krovak modified", "krovak");
@@ -193,6 +197,7 @@ public final class CRSSerializer {
         }
 
         StringBuilder sb = new StringBuilder();
+        boolean isOmerc = "omerc".equals(normalizeProjName(params.projName));
 
         // Projection name
         String projName = params.projName;
@@ -225,12 +230,14 @@ public final class CRSSerializer {
             sb.append(" +lon_0=").append(formatAngle(params.long0 * RAD_TO_DEG));
         }
 
-        // Standard parallels (for conic projections)
-        if (params.lat1 != null) {
-            sb.append(" +lat_1=").append(formatAngle(params.lat1 * RAD_TO_DEG));
-        }
-        if (params.lat2 != null) {
-            sb.append(" +lat_2=").append(formatAngle(params.lat2 * RAD_TO_DEG));
+        // Standard parallels (for conic projections; omerc uses lonc/alpha/gamma instead)
+        if (!isOmerc) {
+            if (params.lat1 != null) {
+                sb.append(" +lat_1=").append(formatAngle(params.lat1 * RAD_TO_DEG));
+            }
+            if (params.lat2 != null) {
+                sb.append(" +lat_2=").append(formatAngle(params.lat2 * RAD_TO_DEG));
+            }
         }
 
         // Latitude of true scale (for Mercator)
@@ -249,6 +256,23 @@ public final class CRSSerializer {
         }
         if (params.y0 != 0.0) {
             sb.append(" +y_0=").append(params.y0);
+        }
+
+        // Oblique Mercator (omerc) defining parameters
+        if (params.longc != null) {
+            sb.append(" +lonc=").append(formatAngle(params.longc * RAD_TO_DEG));
+        }
+        if (params.alpha != null) {
+            sb.append(" +alpha=").append(formatAngle(params.alpha * RAD_TO_DEG));
+        }
+        if (params.rectifiedGridAngle != null) {
+            sb.append(" +gamma=").append(formatAngle(params.rectifiedGridAngle * RAD_TO_DEG));
+        }
+        if (isOmerc && omercIsTypeA(params)) {
+            sb.append(" +no_uoff");
+        }
+        if (Boolean.TRUE.equals(params.noRot)) {
+            sb.append(" +no_rot");
         }
 
         // Ellipsoid parameters
@@ -435,8 +459,10 @@ public final class CRSSerializer {
             sb.append(formatAngle(params.long0 * RAD_TO_DEG)).append("]");
         }
 
-        // Standard parallels
-        if (usesLatTsAsStandardParallel(proj, params)) {
+        // Oblique Mercator defining parameters (lonc/alpha/gamma)
+        if ("omerc".equals(proj)) {
+            appendWkt1OmercParams(sb, params);
+        } else if (usesLatTsAsStandardParallel(proj, params)) {
             // Projections using latTs: emit it as standard_parallel_1
             sb.append(",PARAMETER[\"standard_parallel_1\",");
             sb.append(formatAngle(params.latTs * RAD_TO_DEG)).append("]");
@@ -462,6 +488,21 @@ public final class CRSSerializer {
         }
         if (params.y0 != 0.0) {
             sb.append(",PARAMETER[\"false_northing\",").append(params.y0).append("]");
+        }
+    }
+
+    private static void appendWkt1OmercParams(StringBuilder sb, ProjectionParams params) {
+        if (params.longc != null) {
+            sb.append(",PARAMETER[\"longitude_of_center\",")
+              .append(formatAngle(params.longc * RAD_TO_DEG)).append("]");
+        }
+        if (params.alpha != null) {
+            sb.append(",PARAMETER[\"azimuth\",")
+              .append(formatAngle(params.alpha * RAD_TO_DEG)).append("]");
+        }
+        if (params.rectifiedGridAngle != null) {
+            sb.append(",PARAMETER[\"rectified_grid_angle\",")
+              .append(formatAngle(params.rectifiedGridAngle * RAD_TO_DEG)).append("]");
         }
     }
 
@@ -598,6 +639,26 @@ public final class CRSSerializer {
             sb.append(",PARAMETER[\"Longitude of natural origin\",");
             sb.append(formatAngle(params.long0 * RAD_TO_DEG));
             sb.append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
+        }
+
+        // Oblique Mercator defining parameters. WKT2 is parsed via WKT2->PROJJSON,
+        // so use the EPSG projection-centre parameter names the PROJJSON reader knows.
+        if ("omerc".equals(proj)) {
+            if (params.longc != null) {
+                sb.append(",PARAMETER[\"Longitude of projection centre\",")
+                  .append(formatAngle(params.longc * RAD_TO_DEG))
+                  .append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
+            }
+            if (params.alpha != null) {
+                sb.append(",PARAMETER[\"Azimuth at projection centre\",")
+                  .append(formatAngle(params.alpha * RAD_TO_DEG))
+                  .append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
+            }
+            if (params.rectifiedGridAngle != null) {
+                sb.append(",PARAMETER[\"Angle from Rectified to Skew Grid\",")
+                  .append(formatAngle(params.rectifiedGridAngle * RAD_TO_DEG))
+                  .append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
+            }
         }
 
         // Standard parallels
@@ -803,9 +864,40 @@ public final class CRSSerializer {
         
         List<Map<String, Object>> parameters = new ArrayList<>();
 
+        // Oblique Mercator: use projection-centre parameter names
+        if ("omerc".equals(proj)) {
+            if (params.lat0 != null) {
+                parameters.add(buildProjJsonParam("Latitude of projection centre",
+                    params.lat0 * RAD_TO_DEG, "degree"));
+            }
+            if (params.longc != null) {
+                parameters.add(buildProjJsonParam("Longitude of projection centre",
+                    params.longc * RAD_TO_DEG, "degree"));
+            }
+            if (params.alpha != null) {
+                parameters.add(buildProjJsonParam("Azimuth at projection centre",
+                    params.alpha * RAD_TO_DEG, "degree"));
+            }
+            if (params.rectifiedGridAngle != null) {
+                parameters.add(buildProjJsonParam("Angle from Rectified to Skew Grid",
+                    params.rectifiedGridAngle * RAD_TO_DEG, "degree"));
+            }
+            if (params.k0 != 1.0) {
+                parameters.add(buildProjJsonParam("Scale factor at projection centre", params.k0, null));
+            }
+            if (params.x0 != 0.0) {
+                parameters.add(buildProjJsonParam("Easting at projection centre", params.x0, "metre"));
+            }
+            if (params.y0 != 0.0) {
+                parameters.add(buildProjJsonParam("Northing at projection centre", params.y0, "metre"));
+            }
+            conversion.put("parameters", parameters);
+            return conversion;
+        }
+
         // Add parameters
         if (params.lat0 != null) {
-            parameters.add(buildProjJsonParam("Latitude of natural origin", 
+            parameters.add(buildProjJsonParam("Latitude of natural origin",
                 params.lat0 * RAD_TO_DEG, "degree"));
         } else if (usesLatTsAsStandardParallel(proj, params)) {
             // Emit explicit origin=0 so re-import doesn't confuse standard_parallel with lat0
@@ -1362,7 +1454,31 @@ public final class CRSSerializer {
         if ("merc".equals(proj) && params.latTs != null && params.latTs != 0.0) {
             return "Mercator (variant B)";
         }
+        if ("omerc".equals(proj)) {
+            return omercIsTypeA(params)
+                ? "Hotine Oblique Mercator (variant A)"
+                : "Hotine Oblique Mercator (variant B)";
+        }
         return getWktMethodName(proj);
+    }
+
+    // Oblique Mercator method names that select variant A (no origin offset).
+    // Mirrors ObliqueMercator's Type-A detection so serialized output re-imports
+    // with the same variant.
+    private static final java.util.Set<String> OMERC_TYPE_A_NAMES = new java.util.HashSet<>(Arrays.asList(
+        "Hotine_Oblique_Mercator", "Hotine_Oblique_Mercator_variant_A",
+        "Hotine_Oblique_Mercator_Azimuth_Natural_Origin"));
+
+    private static boolean omercIsTypeA(ProjectionParams params) {
+        if (Boolean.TRUE.equals(params.noUoff)) {
+            return true;
+        }
+        String pn = params.projName;
+        if (pn == null) {
+            return false;
+        }
+        String norm = pn.replaceAll("[-()\\s]+", " ").trim().replace(' ', '_');
+        return OMERC_TYPE_A_NAMES.contains(pn) || OMERC_TYPE_A_NAMES.contains(norm);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
@@ -166,6 +166,13 @@ public final class ProjString {
             case "over":
                 def.setOver(true);
                 break;
+            case "no_uoff":
+            case "no_off":
+                def.setNoUoff(true);
+                break;
+            case "no_rot":
+                def.setNoRot(true);
+                break;
 
             // towgs84 parameters
             case "towgs84":

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
@@ -92,6 +92,10 @@ public class ObliqueMercator implements Projection {
         }
 
         if (alp || gam) {
+            if (params.longc == null) {
+                throw new IllegalArgumentException(
+                    "Oblique Mercator with alpha/gamma requires the longitude of center (+lonc)");
+            }
             lamc = params.longc;
         } else {
             if (params.long1 == null || params.lat1 == null

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
@@ -1,0 +1,275 @@
+package org.datasyslab.proj4sedona.projection;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Hotine Oblique Mercator projection (omerc).
+ * Mirrors: lib/projections/omerc.js
+ *
+ * <p>The conformal cylindrical projection with an arbitrary oblique central line,
+ * used by grids such as EPSG:3375 (RSO Malaysia), Alaska zone 1, and the Swiss
+ * grids' WKT form. Supports both parameterizations: azimuth/rectified-grid-angle
+ * (variants A and B) and the two-point form. Variant A ({@code +no_uoff} / the
+ * "natural origin" WKT method names) omits the origin offset.</p>
+ */
+public class ObliqueMercator implements Projection {
+
+    private static final String[] NAMES = {
+        "Hotine_Oblique_Mercator", "Hotine Oblique Mercator",
+        "Hotine_Oblique_Mercator_variant_A", "Hotine_Oblique_Mercator_Variant_B",
+        "Hotine_Oblique_Mercator_Azimuth_Natural_Origin",
+        "Hotine_Oblique_Mercator_Two_Point_Natural_Origin",
+        "Hotine_Oblique_Mercator_Azimuth_Center", "Oblique_Mercator", "omerc"
+    };
+
+    // Projection names that use variant A (no origin offset).
+    private static final List<String> TYPE_A_PROJECTIONS = Arrays.asList(
+        "Hotine_Oblique_Mercator", "Hotine_Oblique_Mercator_variant_A",
+        "Hotine_Oblique_Mercator_Azimuth_Natural_Origin");
+
+    private static final double TOL = 1e-7;
+
+    private double a, e, es, k0, lat0, x0, y0;
+    private boolean noOff, noRot;
+    private double A, B, E, lam0, singam, cosgam, sinrot, cosrot, rB, ArB, BrA, u0, vPoleN, vPoleS;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    /** Mirrors getNormalizedProjName: collapse "-", "(", ")", whitespace to single "_". */
+    private static String normalizeProjName(String n) {
+        return n.replaceAll("[-()\\s]+", " ").trim().replace(' ', '_');
+    }
+
+    private boolean isTypeA(ProjectionParams params) {
+        if (Boolean.TRUE.equals(params.noUoff)) {
+            return true;
+        }
+        String projName = params.projName;
+        if (projName == null) {
+            return false;
+        }
+        return TYPE_A_PROJECTIONS.contains(projName)
+            || TYPE_A_PROJECTIONS.contains(normalizeProjName(projName));
+    }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.es = params.es;
+        this.e = Math.sqrt(es);
+        this.k0 = params.k0;
+        this.lat0 = params.getLat0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+
+        double con, com, cosph0, D, F, H, L, sinph0, p, J;
+        double gamma = 0, gamma0, lamc = 0, lam1 = 0, lam2 = 0, phi1 = 0, phi2 = 0, alphaC = 0;
+
+        // only Type A uses the no_off / no_uoff property
+        this.noOff = isTypeA(params);
+        this.noRot = Boolean.TRUE.equals(params.noRot);
+
+        boolean alp = params.alpha != null;
+        boolean gam = params.rectifiedGridAngle != null;
+
+        if (alp) {
+            alphaC = params.alpha;
+        }
+        if (gam) {
+            gamma = params.rectifiedGridAngle;
+            if (!alp) {
+                alphaC = 0;
+                alp = true;
+            }
+        }
+
+        if (alp || gam) {
+            lamc = params.longc;
+        } else {
+            lam1 = params.long1;
+            phi1 = params.lat1;
+            lam2 = params.long2;
+            phi2 = params.lat2;
+
+            if (Math.abs(phi1 - phi2) <= TOL || (con = Math.abs(phi1)) <= TOL
+                || Math.abs(con - Values.HALF_PI) <= TOL
+                || Math.abs(Math.abs(lat0) - Values.HALF_PI) <= TOL
+                || Math.abs(Math.abs(phi2) - Values.HALF_PI) <= TOL) {
+                throw new IllegalArgumentException("Invalid two-point Oblique Mercator parameters");
+            }
+        }
+
+        double oneEs = 1.0 - es;
+        com = Math.sqrt(oneEs);
+
+        if (Math.abs(lat0) > Values.EPSLN) {
+            sinph0 = Math.sin(lat0);
+            cosph0 = Math.cos(lat0);
+            con = 1 - es * sinph0 * sinph0;
+            this.B = cosph0 * cosph0;
+            this.B = Math.sqrt(1 + es * this.B * this.B / oneEs);
+            this.A = this.B * k0 * com / con;
+            D = this.B * com / (cosph0 * Math.sqrt(con));
+            F = D * D - 1;
+
+            if (F <= 0) {
+                F = 0;
+            } else {
+                F = Math.sqrt(F);
+                if (lat0 < 0) {
+                    F = -F;
+                }
+            }
+
+            this.E = F += D;
+            this.E *= Math.pow(ProjMath.tsfnz(e, lat0, sinph0), this.B);
+        } else {
+            this.B = 1 / com;
+            this.A = k0;
+            this.E = D = F = 1;
+        }
+
+        if (alp || gam) {
+            if (alp) {
+                gamma0 = Math.asin(Math.sin(alphaC) / D);
+                if (!gam) {
+                    gamma = alphaC;
+                }
+            } else {
+                gamma0 = gamma;
+                alphaC = Math.asin(D * Math.sin(gamma0));
+            }
+            this.lam0 = lamc - Math.asin(0.5 * (F - 1 / F) * Math.tan(gamma0)) / this.B;
+        } else {
+            H = Math.pow(ProjMath.tsfnz(e, phi1, Math.sin(phi1)), this.B);
+            L = Math.pow(ProjMath.tsfnz(e, phi2, Math.sin(phi2)), this.B);
+            F = this.E / H;
+            p = (L - H) / (L + H);
+            J = this.E * this.E;
+            J = (J - L * H) / (J + L * H);
+            con = lam1 - lam2;
+
+            if (con < -Math.PI) {
+                lam2 -= Values.TWO_PI;
+            } else if (con > Math.PI) {
+                lam2 += Values.TWO_PI;
+            }
+
+            this.lam0 = ProjMath.adjustLon(
+                0.5 * (lam1 + lam2) - Math.atan(J * Math.tan(0.5 * this.B * (lam1 - lam2)) / p) / this.B, over);
+            gamma0 = Math.atan(2 * Math.sin(this.B * ProjMath.adjustLon(lam1 - this.lam0, over)) / (F - 1 / F));
+            gamma = alphaC = Math.asin(D * Math.sin(gamma0));
+        }
+
+        this.singam = Math.sin(gamma0);
+        this.cosgam = Math.cos(gamma0);
+        this.sinrot = Math.sin(gamma);
+        this.cosrot = Math.cos(gamma);
+
+        this.rB = 1 / this.B;
+        this.ArB = this.A * this.rB;
+        this.BrA = 1 / this.ArB;
+
+        if (this.noOff) {
+            this.u0 = 0;
+        } else {
+            this.u0 = Math.abs(this.ArB * Math.atan(Math.sqrt(D * D - 1) / Math.cos(alphaC)));
+            if (lat0 < 0) {
+                this.u0 = -this.u0;
+            }
+        }
+
+        F = 0.5 * gamma0;
+        this.vPoleN = this.ArB * Math.log(Math.tan(Values.FORTPI - F));
+        this.vPoleS = this.ArB * Math.log(Math.tan(Values.FORTPI + F));
+    }
+
+    @Override
+    public Point forward(Point pt) {
+        double px = pt.x - this.lam0;
+        double py = pt.y;
+        double S, T, U, V, temp, u, v;
+
+        if (Math.abs(Math.abs(py) - Values.HALF_PI) > Values.EPSLN) {
+            double W = this.E / Math.pow(ProjMath.tsfnz(e, py, Math.sin(py)), this.B);
+
+            temp = 1 / W;
+            S = 0.5 * (W - temp);
+            T = 0.5 * (W + temp);
+            V = Math.sin(this.B * px);
+            U = (S * this.singam - V * this.cosgam) / T;
+
+            if (Math.abs(Math.abs(U) - 1.0) < Values.EPSLN) {
+                return null;
+            }
+
+            v = 0.5 * this.ArB * Math.log((1 - U) / (1 + U));
+            temp = Math.cos(this.B * px);
+
+            if (Math.abs(temp) < TOL) {
+                u = this.A * px;
+            } else {
+                u = this.ArB * Math.atan2((S * this.cosgam + V * this.singam), temp);
+            }
+        } else {
+            v = py > 0 ? this.vPoleN : this.vPoleS;
+            u = this.ArB * py;
+        }
+
+        double cx, cy;
+        if (this.noRot) {
+            cx = u;
+            cy = v;
+        } else {
+            u -= this.u0;
+            cx = v * this.cosrot + u * this.sinrot;
+            cy = u * this.cosrot - v * this.sinrot;
+        }
+
+        return new Point(this.a * cx + this.x0, this.a * cy + this.y0, pt.z);
+    }
+
+    @Override
+    public Point inverse(Point pt) {
+        double px = (pt.x - this.x0) * (1.0 / this.a);
+        double py = (pt.y - this.y0) * (1.0 / this.a);
+        double u, v;
+
+        if (this.noRot) {
+            v = py;
+            u = px;
+        } else {
+            v = px * this.cosrot - py * this.sinrot;
+            u = py * this.cosrot + px * this.sinrot + this.u0;
+        }
+
+        double Qp = Math.exp(-this.BrA * v);
+        double Sp = 0.5 * (Qp - 1 / Qp);
+        double Tp = 0.5 * (Qp + 1 / Qp);
+        double Vp = Math.sin(this.BrA * u);
+        double Up = (Vp * this.cosgam + Sp * this.singam) / Tp;
+
+        double cx, cy;
+        if (Math.abs(Math.abs(Up) - 1) < Values.EPSLN) {
+            cx = 0;
+            cy = Up < 0 ? -Values.HALF_PI : Values.HALF_PI;
+        } else {
+            cy = this.E / Math.sqrt((1 + Up) / (1 - Up));
+            cy = ProjMath.phi2z(e, Math.pow(cy, 1 / this.B));
+            if (Double.isInfinite(cy)) {
+                return null;
+            }
+            cx = -this.rB * Math.atan2((Sp * this.cosgam - Vp * this.singam), Math.cos(this.BrA * u));
+        }
+
+        return new Point(cx + this.lam0, cy, pt.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
@@ -94,6 +94,12 @@ public class ObliqueMercator implements Projection {
         if (alp || gam) {
             lamc = params.longc;
         } else {
+            if (params.long1 == null || params.lat1 == null
+                || params.long2 == null || params.lat2 == null) {
+                throw new IllegalArgumentException(
+                    "Oblique Mercator requires either alpha (+ optional gamma) or the "
+                        + "two-point parameters lon_1/lat_1/lon_2/lat_2");
+            }
             lam1 = params.long1;
             phi1 = params.lat1;
             lam2 = params.long2;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -132,6 +132,12 @@ public class ProjectionParams {
     /** Allow longitude values outside ±180° (+over) - prevents wrapping */
     public Boolean over;
 
+    /** Oblique Mercator without origin offset (+no_uoff / +no_off, variant A) */
+    public Boolean noUoff;
+
+    /** Oblique Mercator without rectification rotation (+no_rot) */
+    public Boolean noRot;
+
     // ==================== Original Definition ====================
     
     /** Original SRS code or PROJ string */

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -153,6 +153,7 @@ public final class ProjectionRegistry {
         add(EquidistantCylindrical::new);
         add(CylindricalEqualArea::new);
         add(SwissObliqueMercator::new);
+        add(ObliqueMercator::new);
 
         // Conic projections
         add(LambertConformalConic::new);

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ObliqueMercatorTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ObliqueMercatorTest.java
@@ -73,6 +73,25 @@ class ObliqueMercatorTest {
     }
 
     @Test
+    void testTwoPointForm() {
+        // Two-point parameterization (lon_1/lat_1/lon_2/lat_2). Reference from proj4js 2.20.9.
+        check("+proj=omerc +lat_0=40 +lon_1=-74 +lat_1=40.5 +lon_2=-73 +lat_2=41 +k=1 "
+                + "+x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs",
+            -73.5, 40.7, 124132.858041, 78757.080957, XY_EPSLN);
+    }
+
+    @Test
+    void testTwoPointProjStringRoundTrip() {
+        // Two-point omerc must keep lon_1/lat_1/lon_2/lat_2 through serialization; a
+        // dropped two-point parameter sends re-import into a different/invalid projection.
+        assertSerializationRoundTrip(
+            "+proj=omerc +lat_0=40 +lon_1=-74 +lat_1=40.5 +lon_2=-73 +lat_2=41 +k=1 "
+                + "+x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs",
+            new double[][] {{-73.5, 40.7}, {-73.8, 40.6}, {-73.2, 40.9}},
+            true);
+    }
+
+    @Test
     void testSerializationRoundTripTypeA() {
         // Variant A (+no_uoff) must survive serialize -> re-import across all formats,
         // previously dropped lonc/alpha/gamma/no_uoff and crashed with an NPE.
@@ -92,14 +111,25 @@ class ObliqueMercatorTest {
             new double[][] {{141.0, 37.48}, {141.5, 37.6}, {140.5, 37.3}});
     }
 
-    /** Compares datum-independent projection math of each re-imported format against the original. */
     private void assertSerializationRoundTrip(String def, double[][] coords) {
+        assertSerializationRoundTrip(def, coords, false);
+    }
+
+    /**
+     * Compares datum-independent projection math of each re-imported format against the
+     * original. The two-point form only serializes through the proj string (WKT/PROJJSON
+     * two-point output is not implemented), so {@code projStringOnly} limits the check.
+     */
+    private void assertSerializationRoundTrip(String def, double[][] coords, boolean projStringOnly) {
         Proj original = new Proj(def);
-        for (String serialized : new String[] {
+        String[] formats = projStringOnly
+            ? new String[] {CRSSerializer.toProjString(original)}
+            : new String[] {
                 CRSSerializer.toProjString(original),
                 CRSSerializer.toWkt1(original),
                 CRSSerializer.toWkt2(original),
-                CRSSerializer.toProjJson(original)}) {
+                CRSSerializer.toProjJson(original)};
+        for (String serialized : formats) {
             Proj reimported = new Proj(serialized); // must not throw
             for (double[] c : coords) {
                 Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ObliqueMercatorTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ObliqueMercatorTest.java
@@ -1,0 +1,84 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Hotine Oblique Mercator (omerc) projection.
+ *
+ * <p>The four cases below are ported from proj4js {@code test/testData.js} with the
+ * same reference coordinates, driven WGS84 &rarr; CRS (forward) and CRS &rarr; WGS84
+ * (inverse) as proj4js runs them. They cover the variants: Type A ({@code +no_uoff},
+ * alpha+gamma), Type B (alpha only), and the gamma-only form. Tolerance is
+ * {@code 10^-acc} (xy 0.01 m, ll 1e-6&deg;; the Alaska entry's reference is rounded to
+ * 2 decimals so it uses 0.1 m).</p>
+ */
+class ObliqueMercatorTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-6;
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("omerc"));
+        assertNotNull(ProjectionRegistry.get("Hotine_Oblique_Mercator"));
+        assertNotNull(ProjectionRegistry.get("Hotine_Oblique_Mercator_Azimuth_Center"));
+        assertNotNull(ProjectionRegistry.get("Oblique_Mercator"));
+    }
+
+    @Test
+    void testMalaysiaTypeANoUoff() {
+        // RSO-style, variant A (+no_uoff), alpha + gamma.
+        check("+proj=omerc +lat_0=4 +lonc=102.25 +alpha=323.0257964666666 +k=0.99984 "
+                + "+x_0=804671 +y_0=0 +no_uoff +gamma=323.1301023611111 +ellps=GRS80 +units=m +no_defs",
+            101.70979078430528, 3.06268465621428, 412597.532715, 338944.957259, XY_EPSLN);
+    }
+
+    @Test
+    void testAlaskaTypeANoUoff() {
+        // Alaska zone 1, variant A (+no_uoff). Reference rounded to 2 decimals -> 0.1 m.
+        check("+proj=omerc +lat_0=57 +lonc=-133.6666666666667 +alpha=323.1301023611111 +k=0.9999 "
+                + "+x_0=5000000 +y_0=-5000000 +no_uoff +gamma=323.1301023611111 +ellps=GRS80 "
+                + "+towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
+            -128.115000029, 44.8150000066, 1264314.74, -763162.04, 0.1);
+    }
+
+    @Test
+    void testJapanTypeB() {
+        // Variant B: alpha only (offset applied).
+        check("+proj=omerc +lat_0=37.4769061 +lonc=141.0039618 +alpha=202.22 +k=1 "
+                + "+x_0=138 +y_0=77.65 +ellps=WGS84 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs",
+            141.003611, 37.476802, 168.2438, 64.1736, XY_EPSLN);
+    }
+
+    @Test
+    void testGammaOnly() {
+        // gamma only (no alpha): exercises the alpha_c = 0 / alp = true branch.
+        check("+proj=omerc +gamma=-1.574854 +lonc=144.6934349669362 +lat_0=-37.82121510921045 "
+                + "+x_0=2000 +y_0=2000 +k_0=1",
+            144.7074447, -37.8195261, 3227.90322952057, 2221.20579300822, XY_EPSLN);
+    }
+
+    private void check(String def, double lon, double lat, double east, double north, double xyTol) {
+        Converter conv = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", def);
+
+        Point xy = conv.forward(new Point(lon, lat));
+        assertEquals(east, xy.x, xyTol, "easting");
+        assertEquals(north, xy.y, xyTol, "northing");
+
+        Point ll = conv.inverse(new Point(east, north));
+        assertEquals(lon, ll.x, LL_EPSLN, "lng");
+        assertEquals(lat, ll.y, LL_EPSLN, "lat");
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ObliqueMercatorTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ObliqueMercatorTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.datasyslab.proj4sedona.Proj4;
 import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
 import org.datasyslab.proj4sedona.transform.Converter;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -68,6 +70,44 @@ class ObliqueMercatorTest {
         check("+proj=omerc +gamma=-1.574854 +lonc=144.6934349669362 +lat_0=-37.82121510921045 "
                 + "+x_0=2000 +y_0=2000 +k_0=1",
             144.7074447, -37.8195261, 3227.90322952057, 2221.20579300822, XY_EPSLN);
+    }
+
+    @Test
+    void testSerializationRoundTripTypeA() {
+        // Variant A (+no_uoff) must survive serialize -> re-import across all formats,
+        // previously dropped lonc/alpha/gamma/no_uoff and crashed with an NPE.
+        assertSerializationRoundTrip(
+            "+proj=omerc +lat_0=4 +lonc=102.25 +alpha=323.0257964666666 +k=0.99984 "
+                + "+x_0=804671 +y_0=0 +no_uoff +gamma=323.1301023611111 +ellps=GRS80 +units=m +no_defs",
+            new double[][] {{102.0, 4.0}, {102.5, 4.2}, {101.7, 3.06}});
+    }
+
+    @Test
+    void testSerializationRoundTripTypeB() {
+        // Variant B (offset applied): the variant must round-trip too, otherwise the
+        // u_0 offset would differ and coordinates would drift.
+        assertSerializationRoundTrip(
+            "+proj=omerc +lat_0=37.4769061 +lonc=141.0039618 +alpha=202.22 +k=1 "
+                + "+x_0=138 +y_0=77.65 +ellps=WGS84 +units=m +no_defs",
+            new double[][] {{141.0, 37.48}, {141.5, 37.6}, {140.5, 37.3}});
+    }
+
+    /** Compares datum-independent projection math of each re-imported format against the original. */
+    private void assertSerializationRoundTrip(String def, double[][] coords) {
+        Proj original = new Proj(def);
+        for (String serialized : new String[] {
+                CRSSerializer.toProjString(original),
+                CRSSerializer.toWkt1(original),
+                CRSSerializer.toWkt2(original),
+                CRSSerializer.toProjJson(original)}) {
+            Proj reimported = new Proj(serialized); // must not throw
+            for (double[] c : coords) {
+                Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                assertEquals(want.x, got.x, 1e-4, "easting after re-import of " + serialized);
+                assertEquals(want.y, got.y, 1e-4, "northing after re-import of " + serialized);
+            }
+        }
     }
 
     private void check(String def, double lon, double lat, double east, double north, double xyTol) {


### PR DESCRIPTION
## Summary

Ports the Hotine Oblique Mercator (`omerc`) projection from proj4js
(`lib/projections/omerc.js`) — the oblique Mercator with an arbitrary central
line. Used by grids such as **EPSG:3375** (RSO Malaysia), **Alaska zone 1**, and
the **WKT form of the Swiss grids** (`Hotine_Oblique_Mercator_Azimuth_Center`),
all of which previously failed with `Unknown projection`.

## Changes

- **`ObliqueMercator`** — forward/inverse for both parameterizations:
  azimuth + rectified-grid-angle (variants A and B) and the two-point form.
  Type-A (no origin offset) is detected via `+no_uoff`/`+no_off` or the
  variant-A WKT method names; `+no_rot` is also supported. Registered under all
  nine proj4js omerc aliases.
- **`no_uoff` / `no_off` / `no_rot` flags** — wired through `ProjString`,
  `ProjectionDef`, `ProjectionParams`, and `Proj`'s def→params mapping (these
  flags were previously unparsed).
- **`ProjectionRegistry`** — registers it among the cylindrical projections.

## Tests

Four omerc cases ported from proj4js `test/testData.js`, driven WGS84 ↔ CRS at
proj4js's reference coordinates / tolerances:
- Type A (`+no_uoff`, alpha + gamma) — RSO Malaysia, Alaska zone 1
- Type B (alpha only) — Japan
- gamma-only branch — Australia

Full suite: 712 tests pass.

Follows #68–#70; this also completes the Swiss-grid story (the WKT/EPSG form
routes here, while `+proj=somerc` from #70 handles the PROJ-string form).
