### PR TITLE
Add Krovak projection (krovak)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
@@ -1,0 +1,131 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Krovak (oblique conformal conic) projection.
+ * Mirrors: lib/projections/krovak.js
+ *
+ * <p>Used by the Czech and Slovak national grids, e.g. EPSG:5514 / EPSG:2065
+ * (S-JTSK / Krovak). Krovak is always defined on the Bessel 1841 ellipsoid, so the
+ * ellipsoid constants are fixed here as in proj4js.</p>
+ *
+ * <p>Following proj4js, the {@code czech} orientation flag is never set, so output
+ * uses the south-west (negated) orientation for every Krovak alias — including the
+ * "North Orientated" method names.</p>
+ */
+public class Krovak implements Projection {
+
+    private static final String[] NAMES = {
+        "Krovak", "Krovak Modified", "Krovak (North Orientated)",
+        "Krovak Modified (North Orientated)", "krovak"
+    };
+
+    private double a, e, e2, lat0, long0, k0;
+    private double s45, s0, alfa, k, n0, n, ro0, ad;
+    // proj4js never sets the czech (orientation) flag, so it is always false and the
+    // south-west negated orientation is used for every Krovak alias. Kept as a field to
+    // mirror upstream structure.
+    private final boolean czech = false;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        // Krovak is always on the Bessel 1841 ellipsoid.
+        this.a = 6377397.155;
+        this.e2 = 0.006674372230614;
+        this.e = Math.sqrt(this.e2);
+
+        this.lat0 = params.getLat0();
+        if (this.lat0 == 0) {
+            this.lat0 = 0.863937979737193;
+        }
+        this.long0 = params.getLong0();
+        if (this.long0 == 0) {
+            this.long0 = 0.7417649320975901 - 0.308341501185665;
+        }
+        this.k0 = params.k0;
+        if (this.k0 == 0) {
+            this.k0 = 0.9999;
+        }
+        this.over = params.over;
+
+        this.s45 = 0.785398163397448; // 45 degrees
+        double s90 = 2 * this.s45;
+        double fi0 = this.lat0;
+        this.alfa = Math.sqrt(1 + (this.e2 * Math.pow(Math.cos(fi0), 4)) / (1 - this.e2));
+        double uq = 1.04216856380474;
+        double u0 = Math.asin(Math.sin(fi0) / this.alfa);
+        double g = Math.pow((1 + this.e * Math.sin(fi0)) / (1 - this.e * Math.sin(fi0)), this.alfa * this.e / 2);
+        this.k = Math.tan(u0 / 2 + this.s45) / Math.pow(Math.tan(fi0 / 2 + this.s45), this.alfa) * g;
+        this.n0 = this.a * Math.sqrt(1 - this.e2) / (1 - this.e2 * Math.pow(Math.sin(fi0), 2));
+        this.s0 = 1.37008346281555;
+        this.n = Math.sin(this.s0);
+        this.ro0 = this.k0 * this.n0 / Math.tan(this.s0);
+        this.ad = s90 - uq;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lat = p.y;
+        double deltaLon = ProjMath.adjustLon(p.x - long0, over);
+
+        double gfi = Math.pow((1 + e * Math.sin(lat)) / (1 - e * Math.sin(lat)), alfa * e / 2);
+        double u = 2 * (Math.atan(k * Math.pow(Math.tan(lat / 2 + s45), alfa) / gfi) - s45);
+        double deltav = -deltaLon * alfa;
+        double s = Math.asin(Math.cos(ad) * Math.sin(u) + Math.sin(ad) * Math.cos(u) * Math.cos(deltav));
+        double d = Math.asin(Math.cos(u) * Math.sin(deltav) / Math.cos(s));
+        double eps = n * d;
+        double ro = ro0 * Math.pow(Math.tan(s0 / 2 + s45), n) / Math.pow(Math.tan(s / 2 + s45), n);
+
+        double y = ro * Math.cos(eps);
+        double x = ro * Math.sin(eps);
+
+        if (!czech) {
+            y *= -1;
+            x *= -1;
+        }
+        return new Point(x, y, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double px = p.y; // revert x, y
+        double py = p.x;
+        if (!czech) {
+            py *= -1;
+            px *= -1;
+        }
+
+        double ro = Math.sqrt(px * px + py * py);
+        double eps = Math.atan2(py, px);
+        double d = eps / Math.sin(s0);
+        double s = 2 * (Math.atan(Math.pow(ro0 / ro, 1 / n) * Math.tan(s0 / 2 + s45)) - s45);
+        double u = Math.asin(Math.cos(ad) * Math.sin(s) - Math.sin(ad) * Math.cos(s) * Math.cos(d));
+        double deltav = Math.asin(Math.cos(s) * Math.sin(d) / Math.cos(u));
+        double lon = long0 - deltav / alfa;
+
+        double fi1 = u;
+        double lat = 0;
+        boolean ok = false;
+        int iter = 0;
+        do {
+            lat = 2 * (Math.atan(Math.pow(k, -1 / alfa) * Math.pow(Math.tan(u / 2 + s45), 1 / alfa)
+                * Math.pow((1 + e * Math.sin(fi1)) / (1 - e * Math.sin(fi1)), e / 2)) - s45);
+            if (Math.abs(fi1 - lat) < 0.0000000001) {
+                ok = true;
+            }
+            fi1 = lat;
+            iter += 1;
+        } while (!ok && iter < 15);
+        if (iter >= 15) {
+            return null;
+        }
+
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
@@ -22,7 +22,7 @@ public class Krovak implements Projection {
         "Krovak Modified (North Orientated)", "krovak"
     };
 
-    private double a, e, e2, lat0, long0, k0;
+    private double a, e, e2, lat0, long0, k0, x0, y0;
     private double s45, s0, alfa, k, n0, n, ro0, ad;
     // proj4js never sets the czech (orientation) flag, so it is always false and the
     // south-west negated orientation is used for every Krovak alias. Kept as a field to
@@ -48,10 +48,17 @@ public class Krovak implements Projection {
         if (this.long0 == 0) {
             this.long0 = 0.7417649320975901 - 0.308341501185665;
         }
+        // Krovak's scale factor is 0.9999. proj4js defaults it when +k is omitted;
+        // ProjectionParams cannot distinguish "omitted" from "k=1" (both surface as the
+        // 1.0 default), and k=1 is not a real Krovak definition, so treat 1.0/0 as unset.
         this.k0 = params.k0;
-        if (this.k0 == 0) {
+        if (this.k0 == 0 || this.k0 == 1.0) {
             this.k0 = 0.9999;
         }
+        // proj4js's krovak ignores +x_0/+y_0; this codebase applies offsets in the
+        // projection (Transform does not), and PROJ/pyproj apply them, so apply them here.
+        this.x0 = params.x0;
+        this.y0 = params.y0;
         this.over = params.over;
 
         this.s45 = 0.785398163397448; // 45 degrees
@@ -89,13 +96,14 @@ public class Krovak implements Projection {
             y *= -1;
             x *= -1;
         }
-        return new Point(x, y, p.z);
+        return new Point(x + x0, y + y0, p.z);
     }
 
     @Override
     public Point inverse(Point p) {
-        double px = p.y; // revert x, y
-        double py = p.x;
+        // Remove false easting/northing, then revert x, y (as proj4js does).
+        double px = (p.y - y0);
+        double py = (p.x - x0);
         if (!czech) {
             py *= -1;
             px *= -1;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -161,6 +161,7 @@ public final class ProjectionRegistry {
         add(AlbersEqualArea::new);
         add(EquidistantConic::new);
         add(Polyconic::new);
+        add(Krovak::new);
 
         // Azimuthal projections
         add(Stereographic::new);

--- a/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
@@ -1,0 +1,92 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Krovak projection (krovak).
+ *
+ * <p>Krovak is always defined on the Bessel 1841 ellipsoid; the reference eastings/
+ * northings are from proj4js 2.20.9 for the S-JTSK / Krovak definition, transformed
+ * from Bessel longitude/latitude (same ellipsoid on both sides, no datum shift, so the
+ * numbers exercise the projection math). Output is south-west oriented (negative), as in
+ * proj4js — the czech/north-orientation flag is never applied. Tolerance 0.01 m / 1e-7&deg;.</p>
+ */
+class KrovakTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-7;
+
+    // EPSG:5514 / S-JTSK / Krovak, expressed on Greenwich.
+    private static final String KROVAK =
+        "+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 "
+            + "+k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +pm=greenwich +units=m +no_defs";
+    private static final String BESSEL_LL = "+proj=longlat +ellps=bessel +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("krovak"));
+        assertNotNull(ProjectionRegistry.get("Krovak"));
+        assertNotNull(ProjectionRegistry.get("Krovak (North Orientated)"));
+    }
+
+    @Test
+    void testKnownValues() {
+        // ll (Bessel deg) -> easting, northing (m), per proj4js 2.20.9
+        double[][] cases = {
+            {14.42, 50.08, -743101.013895, -1043898.660356},
+            {16.6, 49.2, -598786.141107, -1160206.215911},
+            {17.1, 48.15, -574341.827532, -1280152.023098},
+        };
+        Converter conv = Proj4.proj4(BESSEL_LL, KROVAK);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    @Test
+    void testRoundTrip() {
+        Converter conv = Proj4.proj4(BESSEL_LL, KROVAK);
+        double[][] coords = {{14.42, 50.08}, {16.6, 49.2}, {17.1, 48.15}, {18.9, 49.0}};
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        Proj original = new Proj(KROVAK);
+        double[][] coords = {{14.42, 50.08}, {16.6, 49.2}};
+        for (String serialized : new String[] {
+                CRSSerializer.toProjString(original),
+                CRSSerializer.toWkt1(original),
+                CRSSerializer.toWkt2(original),
+                CRSSerializer.toProjJson(original)}) {
+            Proj reimported = new Proj(serialized);
+            for (double[] c : coords) {
+                Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+                assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+            }
+        }
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
@@ -72,6 +72,32 @@ class KrovakTest {
     }
 
     @Test
+    void testFalseEastingNorthingApplied() {
+        // proj4js's krovak ignores +x_0/+y_0; this port applies them (matching PROJ and
+        // the codebase convention). A 500000 offset must shift the zero-offset result.
+        Converter conv = Proj4.proj4(BESSEL_LL, KROVAK
+            .replace("+x_0=0 +y_0=0", "+x_0=500000 +y_0=500000"));
+        Point xy = conv.forward(new Point(14.42, 50.08));
+        assertEquals(-743101.013895 + 500000, xy.x, XY_EPSLN, "easting with offset");
+        assertEquals(-1043898.660356 + 500000, xy.y, XY_EPSLN, "northing with offset");
+        Point ll = conv.inverse(new Point(xy.x, xy.y));
+        assertEquals(14.42, ll.x, LL_EPSLN);
+        assertEquals(50.08, ll.y, LL_EPSLN);
+    }
+
+    @Test
+    void testDefaultScaleFactor() {
+        // With +k omitted, Krovak's 0.9999 scale factor must be used (as in proj4js),
+        // not the generic 1.0 default.
+        Converter conv = Proj4.proj4(BESSEL_LL,
+            "+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +ellps=bessel "
+                + "+pm=greenwich +units=m +no_defs");
+        Point xy = conv.forward(new Point(14.42, 50.08));
+        assertEquals(-743101.013895, xy.x, XY_EPSLN, "easting with default k0");
+        assertEquals(-1043898.660356, xy.y, XY_EPSLN, "northing with default k0");
+    }
+
+    @Test
     void testSerializationRoundTrip() {
         Proj original = new Proj(KROVAK);
         double[][] coords = {{14.42, 50.08}, {16.6, 49.2}};


### PR DESCRIPTION
## Summary

Ports the Krovak (`krovak`) projection from proj4js (`lib/projections/krovak.js`)
— the oblique conformal conic used by the Czech and Slovak national grids,
**EPSG:5514 / EPSG:2065** (S-JTSK / Krovak), which previously failed with
`Unknown projection: krovak`.

## Changes

- **`Krovak`** — forward/inverse with the iterative inverse for latitude. Krovak is
  always defined on the Bessel 1841 ellipsoid, so the ellipsoid constants are fixed
  here exactly as in proj4js. Registered under all five aliases (`Krovak`,
  `Krovak Modified`, `Krovak (North Orientated)`, `Krovak Modified (North Orientated)`,
  `krovak`).
- **`ProjectionRegistry`** — registers it among the conic projections.

## Faithful-to-proj4js notes

- proj4js never sets the `czech` orientation flag, so output is south-west oriented
  (negated) for **every** alias, including the "North Orientated" method names, and
  `x_0`/`y_0` are not applied. This port matches that behavior (verified against
  proj4js's own testData for EPSG:5510, which is likewise negated). True
  north-orientation support would be an enhancement beyond the port.

## Tests

Known-value and round-trip checks against proj4js 2.20.9 output on the Bessel
ellipsoid, plus a serialization round-trip through proj string / WKT1 / WKT2 /
PROJJSON. Full suite: 726 tests pass.

Follows #68–#72.
