### PR TITLE
Add Miller Cylindrical, Gnomonic, and Orthographic projections

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/Gnomonic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Gnomonic.java
@@ -1,0 +1,86 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Gnomonic projection (gnom).
+ * Mirrors: lib/projections/gnom.js
+ *
+ * <p>Azimuthal projection from the center of the sphere; every great circle maps to a
+ * straight line. Points on the far hemisphere are projected toward infinity on a bearing,
+ * as in proj4js.</p>
+ */
+public class Gnomonic implements Projection {
+
+    // "Gnomonic" alias (beyond proj4js's ["gnom"]) lets a CRS round-trip through the
+    // serializer, which emits the "Gnomonic" method name.
+    private static final String[] NAMES = {"gnom", "Gnomonic"};
+
+    private double a, k0, lat0, long0, x0, y0;
+    private double sinP14, cosP14, infinityDist, rc;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.k0 = params.k0;
+        this.lat0 = params.getLat0();
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+
+        this.sinP14 = Math.sin(lat0);
+        this.cosP14 = Math.cos(lat0);
+        this.infinityDist = 1000 * a;
+        this.rc = 1;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lat = p.y;
+        double dlon = ProjMath.adjustLon(p.x - long0, over);
+        double sinphi = Math.sin(lat);
+        double cosphi = Math.cos(lat);
+        double coslon = Math.cos(dlon);
+        double g = sinP14 * sinphi + cosP14 * cosphi * coslon;
+        double x, y;
+
+        if (g > 0 || Math.abs(g) <= Values.EPSLN) {
+            x = x0 + a * cosphi * Math.sin(dlon) / g;
+            y = y0 + a * (cosP14 * sinphi - sinP14 * cosphi * coslon) / g;
+        } else {
+            // Opposing hemisphere: project toward infinity on the equivalent bearing.
+            x = x0 + infinityDist * cosphi * Math.sin(dlon);
+            y = y0 + infinityDist * (cosP14 * sinphi - sinP14 * cosphi * coslon);
+        }
+        return new Point(x, y, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double x = (p.x - x0) / a / k0;
+        double y = (p.y - y0) / a / k0;
+        double lon, lat;
+
+        double rh = Math.sqrt(x * x + y * y);
+        if (rh != 0) {
+            double c = Math.atan2(rh, rc);
+            double sinc = Math.sin(c);
+            double cosc = Math.cos(c);
+            lat = ProjMath.asinz(cosc * sinP14 + (y * sinc * cosP14) / rh);
+            lon = Math.atan2(x * sinc, rh * cosP14 * cosc - y * sinP14 * sinc);
+            lon = ProjMath.adjustLon(long0 + lon, over);
+        } else {
+            // Projection center. proj4js reads an unset phic0 here (NaN); use lat0.
+            lat = lat0;
+            lon = long0;
+        }
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Gnomonic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Gnomonic.java
@@ -52,8 +52,10 @@ public class Gnomonic implements Projection {
         double x, y;
 
         if (g > 0 || Math.abs(g) <= Values.EPSLN) {
-            x = x0 + a * cosphi * Math.sin(dlon) / g;
-            y = y0 + a * (cosP14 * sinphi - sinP14 * cosphi * coslon) / g;
+            // proj4js uses ksp=1 (ignores k0) in forward while its inverse divides by k0,
+            // so a +k_0 CRS would not round-trip. Apply k0 here to match the inverse.
+            x = x0 + a * k0 * cosphi * Math.sin(dlon) / g;
+            y = y0 + a * k0 * (cosP14 * sinphi - sinP14 * cosphi * coslon) / g;
         } else {
             // Opposing hemisphere: project toward infinity on the equivalent bearing.
             x = x0 + infinityDist * cosphi * Math.sin(dlon);

--- a/src/main/java/org/datasyslab/proj4sedona/projection/MillerCylindrical.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/MillerCylindrical.java
@@ -1,0 +1,47 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Miller Cylindrical projection (mill).
+ * Mirrors: lib/projections/mill.js
+ *
+ * <p>A cylindrical compromise projection related to Mercator but showing the poles.</p>
+ */
+public class MillerCylindrical implements Projection {
+
+    private static final String[] NAMES = {"Miller_Cylindrical", "mill"};
+
+    private double a, long0, x0, y0;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double dlon = ProjMath.adjustLon(p.x - long0, over);
+        double x = x0 + a * dlon;
+        double y = y0 + a * Math.log(Math.tan((Math.PI / 4) + (p.y / 2.5))) * 1.25;
+        return new Point(x, y, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double x = p.x - x0;
+        double y = p.y - y0;
+        double lon = ProjMath.adjustLon(long0 + x / a, over);
+        double lat = 2.5 * (Math.atan(Math.exp(0.8 * y / a)) - Math.PI / 4);
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Orthographic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Orthographic.java
@@ -1,0 +1,86 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Orthographic projection (ortho).
+ * Mirrors: lib/projections/ortho.js
+ *
+ * <p>Azimuthal projection giving the view of the globe from infinite distance; only the
+ * near hemisphere is visible. Points on the far hemisphere are unprojectable (null).</p>
+ */
+public class Orthographic implements Projection {
+
+    // "Orthographic" alias (beyond proj4js's ["ortho"]) lets a CRS round-trip through
+    // the serializer, which emits the "Orthographic" method name.
+    private static final String[] NAMES = {"ortho", "Orthographic"};
+
+    private double a, lat0, long0, x0, y0;
+    private double sinP14, cosP14;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.lat0 = params.getLat0();
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+
+        this.sinP14 = Math.sin(lat0);
+        this.cosP14 = Math.cos(lat0);
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lat = p.y;
+        double dlon = ProjMath.adjustLon(p.x - long0, over);
+        double sinphi = Math.sin(lat);
+        double cosphi = Math.cos(lat);
+        double coslon = Math.cos(dlon);
+        double g = sinP14 * sinphi + cosP14 * cosphi * coslon;
+
+        if (g > 0 || Math.abs(g) <= Values.EPSLN) {
+            // proj4js omits x0 here (asymmetric with the inverse); apply it so the
+            // projection round-trips and matches PROJ / the codebase convention.
+            double x = x0 + a * cosphi * Math.sin(dlon);
+            double y = y0 + a * (cosP14 * sinphi - sinP14 * cosphi * coslon);
+            return new Point(x, y, p.z);
+        }
+        // Far hemisphere: unprojectable.
+        return null;
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double x = p.x - x0;
+        double y = p.y - y0;
+        double rh = Math.sqrt(x * x + y * y);
+        double z = ProjMath.asinz(rh / a);
+        double sinz = Math.sin(z);
+        double cosz = Math.cos(z);
+
+        double lon = long0;
+        if (Math.abs(rh) <= Values.EPSLN) {
+            return new Point(lon, lat0, p.z);
+        }
+        double lat = ProjMath.asinz(cosz * sinP14 + (y * sinz * cosP14) / rh);
+        double con = Math.abs(lat0) - Values.HALF_PI;
+        if (Math.abs(con) <= Values.EPSLN) {
+            if (lat0 >= 0) {
+                lon = ProjMath.adjustLon(long0 + Math.atan2(x, -y), over);
+            } else {
+                lon = ProjMath.adjustLon(long0 - Math.atan2(-x, y), over);
+            }
+            return new Point(lon, lat, p.z);
+        }
+        lon = ProjMath.adjustLon(long0 + Math.atan2(x * sinz, rh * cosP14 * cosz - y * sinP14 * sinz), over);
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -155,6 +155,7 @@ public final class ProjectionRegistry {
         add(SwissObliqueMercator::new);
         add(ObliqueMercator::new);
         add(CassiniSoldner::new);
+        add(MillerCylindrical::new);
 
         // Conic projections
         add(LambertConformalConic::new);
@@ -168,7 +169,9 @@ public final class ProjectionRegistry {
         add(StereographicAlternative::new);
         add(LambertAzimuthalEqualArea::new);
         add(AzimuthalEquidistant::new);
-        
+        add(Gnomonic::new);
+        add(Orthographic::new);
+
         // Pseudocylindrical projections
         add(Sinusoidal::new);
         add(Mollweide::new);

--- a/src/test/java/org/datasyslab/proj4sedona/projection/SimpleProjectionsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/SimpleProjectionsTest.java
@@ -1,0 +1,130 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Miller Cylindrical (mill), Gnomonic (gnom) and Orthographic (ortho)
+ * projections. Reference eastings/northings are from proj4js 2.20.9 (WGS84 &rarr; CRS);
+ * definitions keep the same datum on both sides, so the numbers exercise the projection
+ * math. Tolerance 0.01 m / 1e-7&deg;.
+ */
+class SimpleProjectionsTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-7;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+
+    private static final String MILL =
+        "+proj=mill +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +R=6378137 +units=m +no_defs";
+    private static final String GNOM =
+        "+proj=gnom +lat_0=45 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs";
+    private static final String ORTHO =
+        "+proj=ortho +lat_0=45 +lon_0=0 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("mill"));
+        assertNotNull(ProjectionRegistry.get("Miller_Cylindrical"));
+        assertNotNull(ProjectionRegistry.get("gnom"));
+        assertNotNull(ProjectionRegistry.get("ortho"));
+    }
+
+    @Test
+    void testMiller() {
+        assertForward(MILL, new double[][] {
+            {10, 40, 1113194.90793, 4704138.28393},
+            {-100, -30, -11131949.07933, -3441760.13671},
+        });
+        assertRoundTrip(MILL, new double[][] {{10, 40}, {-100, -30}, {45, 60}});
+    }
+
+    @Test
+    void testGnomonic() {
+        assertForward(GNOM, new double[][] {
+            {5, 50, 359308.75202, 570078.10743},
+            {-3, 44, -240323.99799, -106958.57123},
+        });
+        assertRoundTrip(GNOM, new double[][] {{5, 50}, {-3, 44}, {2, 47}});
+    }
+
+    @Test
+    void testOrthographic() {
+        assertForward(ORTHO, new double[][] {
+            {5, 50, 357320.01913, 566922.79024},
+            {10, 40, 848433.95315, -503403.89607},
+        });
+        assertRoundTrip(ORTHO, new double[][] {{5, 50}, {10, 40}, {-4, 48}});
+    }
+
+    @Test
+    void testOrthographicFarHemisphereIsNull() {
+        // A point on the far side of the projection center is unprojectable (proj4js
+        // likewise yields null here).
+        Converter conv = Proj4.proj4(WGS84, ORTHO);
+        assertNull(conv.forward(new Point(180, -45)));
+    }
+
+    @Test
+    void testOrthographicOffsetRoundTrip() {
+        // proj4js's ortho omits +x_0 in the forward path (asymmetric); this port applies
+        // it, so an offset ortho CRS round-trips. Verify forward->inverse identity.
+        Converter conv = Proj4.proj4(WGS84,
+            "+proj=ortho +lat_0=45 +lon_0=0 +x_0=100000 +y_0=100000 +a=6378137 +b=6378137 +units=m +no_defs");
+        Point xy = conv.forward(new Point(5, 50));
+        Point ll = conv.inverse(new Point(xy.x, xy.y));
+        assertEquals(5, ll.x, LL_EPSLN);
+        assertEquals(50, ll.y, LL_EPSLN);
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        for (String def : new String[] {MILL, GNOM, ORTHO}) {
+            Proj original = new Proj(def);
+            double[] c = {5, 48};
+            for (String serialized : new String[] {
+                    CRSSerializer.toProjString(original),
+                    CRSSerializer.toWkt1(original),
+                    CRSSerializer.toWkt2(original),
+                    CRSSerializer.toProjJson(original)}) {
+                Proj reimported = new Proj(serialized);
+                Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+                assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+            }
+        }
+    }
+
+    private void assertForward(String def, double[][] cases) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    private void assertRoundTrip(String def, double[][] coords) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/SimpleProjectionsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/SimpleProjectionsTest.java
@@ -71,6 +71,20 @@ class SimpleProjectionsTest {
     }
 
     @Test
+    void testGnomonicScaleFactorRoundTrip() {
+        // proj4js's gnom applies k0 only in the inverse; this port applies it in the
+        // forward too, so a +k_0 CRS round-trips. Verify forward->inverse identity.
+        Converter conv = Proj4.proj4(WGS84,
+            "+proj=gnom +lat_0=45 +lon_0=0 +k_0=0.9 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs");
+        for (double[] c : new double[][] {{5, 50}, {-3, 44}}) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+
+    @Test
     void testOrthographicFarHemisphereIsNull() {
         // A point on the far side of the projection center is unprojectable (proj4js
         // likewise yields null here).


### PR DESCRIPTION
## Summary

Adds three small self-contained projections from proj4js, clearing part of the
long tail:

- **Miller Cylindrical** (`mill` / `Miller_Cylindrical`) — `lib/projections/mill.js`
- **Gnomonic** (`gnom`) — `lib/projections/gnom.js`
- **Orthographic** (`ortho`) — `lib/projections/ortho.js`

All reuse existing `ProjMath` helpers (`adjustLon`, `asinz`); no new helpers.

## Faithful-to-proj4js notes / corrections

- **Gnomonic**: far-hemisphere points project toward infinity on a bearing, as in
  proj4js. Its inverse reads an unset `phic0` at the exact projection center (NaN
  in proj4js); this port returns the center latitude (`lat0`) there instead.
- **Orthographic**: far-hemisphere points are unprojectable (`null`, matching
  proj4js). proj4js's ortho *forward* omits `+x_0` (asymmetric with its inverse,
  which subtracts it) — this port applies `x0` so offset ortho CRSs round-trip and
  it matches PROJ / the codebase convention. Standard (`x_0=0`) output is unchanged.
- **Gnomonic/Orthographic** also register their WKT method names (`Gnomonic` /
  `Orthographic`) so a CRS round-trips through the serializer (proj4js names them
  only `gnom`/`ortho`).

## Tests

Known values and round-trips vs proj4js 2.20.9, ortho far-hemisphere `null` and
offset round-trip, and serialization round-trips across proj string / WKT1 / WKT2
/ PROJJSON. Full suite: 735 tests pass.

Follows #68–#73.
