### PR TITLE
Apply false easting/northing in Sinusoidal forward

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/Sinusoidal.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Sinusoidal.java
@@ -54,7 +54,10 @@ public class Sinusoidal implements Projection {
             x = a * lon * c / Math.sqrt(1 - es * s * s);
         }
 
-        return new Point(x, y, p.z);
+        // proj4js sinu forward omits x0/y0 while its inverse subtracts them, so an
+        // offset CRS would not round-trip. Apply them here (the inverse already reverses
+        // them). Standard sinu CRSs use x_0=y_0=0, so their output is unchanged.
+        return new Point(x + x0, y + y0, p.z);
     }
 
     @Override

--- a/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
@@ -176,6 +176,25 @@ class AllProjectionsTest {
     }
 
     @Test
+    void testSinusoidalFalseEastingNorthing() {
+        // Regression: sinu forward must apply +x_0/+y_0 (it previously omitted them
+        // while the inverse subtracted them, so offset CRSs did not round-trip).
+        Converter noOff = Proj4.proj4("+proj=longlat +datum=WGS84",
+            "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs");
+        Converter withOff = Proj4.proj4("+proj=longlat +datum=WGS84",
+            "+proj=sinu +lon_0=0 +x_0=1000000 +y_0=2000000 +ellps=WGS84 +units=m +no_defs");
+
+        Point base = noOff.forward(new Point(20, 10));
+        Point off = withOff.forward(new Point(20, 10));
+        assertEquals(base.x + 1000000, off.x, 0.01, "x_0 applied in forward");
+        assertEquals(base.y + 2000000, off.y, 0.01, "y_0 applied in forward");
+
+        Point restored = withOff.inverse(new Point(off.x, off.y));
+        assertEquals(20, restored.x, DEGREE_TOLERANCE);
+        assertEquals(10, restored.y, DEGREE_TOLERANCE);
+    }
+
+    @Test
     void testMollweideRoundTrip() {
         Converter conv = Proj4.proj4(
             "+proj=longlat +datum=WGS84",


### PR DESCRIPTION
## Summary

Fixes a forward/inverse asymmetry in the Sinusoidal (`sinu`) projection:
`forward` omitted `+x_0/+y_0` while `inverse` subtracted them, so a Sinusoidal CRS
with a non-zero false origin was **misprojected and did not round-trip**.

This is inherited faithfully from proj4js `sinu.js` (its sinu forward also ignores
`x_0` — verified: a `+x_0` offset produces identical output and fails to round-trip).
The fix applies `x0/y0` in the forward to match the inverse, PROJ, and this codebase's
convention that projections apply offsets themselves (`Transform` does not).

Standard Sinusoidal CRSs use `x_0=y_0=0`, so their output is unchanged.

## Context

Found during an audit of the merged projections for the forward/inverse offset/scale
asymmetry pattern that came up in code review (the `ortho` `x_0`, `gnom` `k_0`, and
`krovak` `x_0/y_0` fixes). Sinusoidal was the only pre-existing projection with the
same pattern; all others apply offsets symmetrically.

## Tests

Adds `testSinusoidalFalseEastingNorthing`: asserts the offset is applied in the forward
and that an offset CRS round-trips. Full suite passes.
