### PR TITLE
Add Van der Grinten and Bonne projections

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/Bonne.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Bonne.java
@@ -1,0 +1,122 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Bonne (pseudoconic, equal-area) projection.
+ * Mirrors: lib/projections/bonne.js
+ *
+ * <p>Parallels are concentric circular arcs; true to scale along the central meridian
+ * and every parallel. Supports both the spherical and ellipsoidal forms.</p>
+ */
+public class Bonne implements Projection {
+
+    private static final String[] NAMES = {"bonne", "Bonne (Werner lat_1=90)"};
+
+    private static final double EPS10 = 1e-10;
+
+    private double a, es, phi1, long0, x0, y0;
+    private double[] en;
+    private double m1, am1, cphi1;
+    private boolean sphere;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.es = params.es;
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+
+        this.phi1 = params.getLat1();
+        if (Math.abs(phi1) < EPS10) {
+            throw new IllegalArgumentException("Bonne requires a non-zero standard parallel (+lat_1)");
+        }
+
+        this.sphere = params.sphere || es == 0;
+        if (!sphere) {
+            this.en = ProjMath.pjEnfn(es);
+            double sinPhi1 = Math.sin(phi1);
+            double cosPhi1 = Math.cos(phi1);
+            this.m1 = ProjMath.pjMlfn(phi1, sinPhi1, cosPhi1, en);
+            this.am1 = cosPhi1 / (Math.sqrt(1 - es * sinPhi1 * sinPhi1) * sinPhi1);
+        } else {
+            if (Math.abs(phi1) + EPS10 >= Values.HALF_PI) {
+                this.cphi1 = 0;
+            } else {
+                this.cphi1 = 1 / Math.tan(phi1);
+            }
+        }
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lam = ProjMath.adjustLon(p.x - long0, over);
+        double phi = p.y;
+        double x, y;
+
+        if (!sphere) {
+            double sinPhi = Math.sin(phi);
+            double cosPhi = Math.cos(phi);
+            double rh = am1 + m1 - ProjMath.pjMlfn(phi, sinPhi, cosPhi, en);
+            double e = cosPhi * lam / (rh * Math.sqrt(1 - es * sinPhi * sinPhi));
+            x = rh * Math.sin(e);
+            y = am1 - rh * Math.cos(e);
+        } else {
+            double rh = cphi1 + phi1 - phi;
+            if (Math.abs(rh) > EPS10) {
+                double e = lam * Math.cos(phi) / rh;
+                x = rh * Math.sin(e);
+                y = cphi1 - rh * Math.cos(e);
+            } else {
+                x = 0;
+                y = 0;
+            }
+        }
+
+        return new Point(a * x + x0, a * y + y0, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double px = (p.x - x0) / a;
+        double py = (p.y - y0) / a;
+        double lam, phi;
+
+        if (!sphere) {
+            py = am1 - py;
+            double rh = Math.hypot(px, py);
+            phi = ProjMath.pjInvMlfn(am1 + m1 - rh, es, en);
+            double s = Math.abs(phi);
+            if (s < Values.HALF_PI) {
+                s = Math.sin(phi);
+                lam = rh * Math.atan2(px, py) * Math.sqrt(1 - es * s * s) / Math.cos(phi);
+            } else if (Math.abs(s - Values.HALF_PI) <= EPS10) {
+                lam = 0;
+            } else {
+                return null;
+            }
+        } else {
+            py = cphi1 - py;
+            double rh = Math.hypot(px, py);
+            phi = cphi1 + phi1 - rh;
+            if (Math.abs(phi) > Values.HALF_PI) {
+                return null;
+            }
+            if (Math.abs(Math.abs(phi) - Values.HALF_PI) <= EPS10) {
+                lam = 0;
+            } else {
+                lam = rh * Math.atan2(px, py) / Math.cos(phi);
+            }
+        }
+
+        return new Point(ProjMath.adjustLon(lam + long0, over), ProjMath.adjustLat(phi), p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -163,6 +163,7 @@ public final class ProjectionRegistry {
         add(EquidistantConic::new);
         add(Polyconic::new);
         add(Krovak::new);
+        add(Bonne::new);
 
         // Azimuthal projections
         add(Stereographic::new);
@@ -176,6 +177,7 @@ public final class ProjectionRegistry {
         add(Sinusoidal::new);
         add(Mollweide::new);
         add(Robinson::new);
+        add(VanDerGrinten::new);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/projection/VanDerGrinten.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/VanDerGrinten.java
@@ -81,6 +81,13 @@ public class VanDerGrinten implements Projection {
         double con = Math.PI * R;
         double xx = (p.x - x0) / con;
         double yy = (p.y - y0) / con;
+
+        // Projection center: the cubic solve below is 0/0 (NaN) at the origin, as in
+        // proj4js. Return the center (long0, 0) directly so it round-trips.
+        if (Math.abs(xx) <= Values.EPSLN && Math.abs(yy) <= Values.EPSLN) {
+            return new Point(long0, 0, p.z);
+        }
+
         double xys = xx * xx + yy * yy;
         double c1 = -Math.abs(yy) * (1 + xys);
         double c2 = c1 - 2 * yy * yy + xx * xx;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/VanDerGrinten.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/VanDerGrinten.java
@@ -1,0 +1,114 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Van der Grinten (I) projection (vandg).
+ * Mirrors: lib/projections/vandg.js
+ *
+ * <p>Projects the world into a circle. Computed on a sphere of radius {@code a}.</p>
+ *
+ * <p>proj4js's vandg forward leaves the equator/meridian/pole special cases unreturned,
+ * so the general formula overwrites them and divides by zero at the equator (it throws
+ * on the resulting non-finite value). This port returns those special cases, matching
+ * PROJ, so the equator and poles project correctly.</p>
+ */
+public class VanDerGrinten implements Projection {
+
+    private static final String[] NAMES = {
+        "Van_der_Grinten_I", "VanDerGrinten", "Van_der_Grinten", "vandg"
+    };
+
+    private double R, long0, x0, y0;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.R = params.a;
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lat = p.y;
+        double dlon = ProjMath.adjustLon(p.x - long0, over);
+
+        if (Math.abs(lat) <= Values.EPSLN) {
+            return new Point(x0 + R * dlon, y0, p.z);
+        }
+        double theta = ProjMath.asinz(2 * Math.abs(lat / Math.PI));
+        if (Math.abs(dlon) <= Values.EPSLN || Math.abs(Math.abs(lat) - Values.HALF_PI) <= Values.EPSLN) {
+            double y = (lat >= 0)
+                ? y0 + Math.PI * R * Math.tan(0.5 * theta)
+                : y0 - Math.PI * R * Math.tan(0.5 * theta);
+            return new Point(x0, y, p.z);
+        }
+
+        double al = 0.5 * Math.abs((Math.PI / dlon) - (dlon / Math.PI));
+        double asq = al * al;
+        double sinth = Math.sin(theta);
+        double costh = Math.cos(theta);
+
+        double g = costh / (sinth + costh - 1);
+        double gsq = g * g;
+        double m = g * (2 / sinth - 1);
+        double msq = m * m;
+        double con = Math.PI * R
+            * (al * (g - msq) + Math.sqrt(asq * (g - msq) * (g - msq) - (msq + asq) * (gsq - msq)))
+            / (msq + asq);
+        if (dlon < 0) {
+            con = -con;
+        }
+        double x = x0 + con;
+
+        double q = asq + g;
+        con = Math.PI * R * (m * q - al * Math.sqrt((msq + asq) * (asq + 1) - q * q)) / (msq + asq);
+        double y = (lat >= 0) ? y0 + con : y0 - con;
+
+        return new Point(x, y, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double con = Math.PI * R;
+        double xx = (p.x - x0) / con;
+        double yy = (p.y - y0) / con;
+        double xys = xx * xx + yy * yy;
+        double c1 = -Math.abs(yy) * (1 + xys);
+        double c2 = c1 - 2 * yy * yy + xx * xx;
+        double c3 = -2 * c1 + 1 + 2 * yy * yy + xys * xys;
+        double d = yy * yy / c3 + (2 * c2 * c2 * c2 / c3 / c3 / c3 - 9 * c1 * c2 / c3 / c3) / 27;
+        double a1 = (c1 - c2 * c2 / 3 / c3) / c3;
+        double m1 = 2 * Math.sqrt(-a1 / 3);
+        con = ((3 * d) / a1) / m1;
+        if (Math.abs(con) > 1) {
+            con = (con >= 0) ? 1 : -1;
+        }
+        double th1 = Math.acos(con) / 3;
+        double lat;
+        if (p.y - y0 >= 0) {
+            lat = (-m1 * Math.cos(th1 + Math.PI / 3) - c2 / 3 / c3) * Math.PI;
+        } else {
+            lat = -(-m1 * Math.cos(th1 + Math.PI / 3) - c2 / 3 / c3) * Math.PI;
+        }
+
+        double lon;
+        if (Math.abs(xx) < Values.EPSLN) {
+            lon = long0;
+        } else {
+            lon = ProjMath.adjustLon(
+                long0 + Math.PI * (xys - 1 + Math.sqrt(1 + 2 * (xx * xx - yy * yy) + xys * xys)) / 2 / xx,
+                over);
+        }
+
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/VanDerGrintenBonneTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/VanDerGrintenBonneTest.java
@@ -65,6 +65,19 @@ class VanDerGrintenBonneTest {
     }
 
     @Test
+    void testVanDerGrintenCenter() {
+        // The projection center maps to (x0,y0); its inverse would hit a 0/0 in the
+        // cubic solve (NaN) without the origin guard. Verify it round-trips to (lon_0,0).
+        Converter conv = Proj4.proj4(WGS84, VANDG);
+        Point xy = conv.forward(new Point(0, 0));
+        assertEquals(0, xy.x, XY_EPSLN, "center easting");
+        assertEquals(0, xy.y, XY_EPSLN, "center northing");
+        Point ll = conv.inverse(new Point(0, 0));
+        assertEquals(0, ll.x, 1e-6, "center lng");
+        assertEquals(0, ll.y, 1e-6, "center lat");
+    }
+
+    @Test
     void testBonneEllipsoid() {
         assertForward(BONNE_E, new double[][] {
             {5, 45, 394029.1105, 566425.3996},

--- a/src/test/java/org/datasyslab/proj4sedona/projection/VanDerGrintenBonneTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/VanDerGrintenBonneTest.java
@@ -1,0 +1,127 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Van der Grinten (vandg) and Bonne projections. Reference eastings/
+ * northings are from proj4js 2.20.9 (WGS84 &rarr; CRS); definitions keep the same datum
+ * on both sides, so the numbers exercise the projection math. Tolerance 0.01 m / 1e-7&deg;.
+ */
+class VanDerGrintenBonneTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-7;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+
+    private static final String VANDG =
+        "+proj=vandg +lon_0=0 +x_0=0 +y_0=0 +a=6371007 +units=m +no_defs";
+    private static final String BONNE_E =
+        "+proj=bonne +lat_1=40 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs";
+    private static final String BONNE_S =
+        "+proj=bonne +lat_1=40 +lon_0=0 +x_0=0 +y_0=0 +a=6371007 +b=6371007 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("vandg"));
+        assertNotNull(ProjectionRegistry.get("Van_der_Grinten"));
+        assertNotNull(ProjectionRegistry.get("bonne"));
+    }
+
+    @Test
+    void testVanDerGrinten() {
+        assertForward(VANDG, new double[][] {
+            {20, 40, 2102451.3435, 4704549.9752},
+            {-60, -30, -6487975.8526, -3496279.3225},
+            {100, 55, 9919575.7830, 7425151.0583},
+        });
+        assertRoundTrip(VANDG, new double[][] {{20, 40}, {-60, -30}, {100, 55}});
+    }
+
+    @Test
+    void testVanDerGrintenEquator() {
+        // proj4js throws (non-finite) at the equator; this port returns the correct
+        // x = R * dlon, y = 0.
+        Converter conv = Proj4.proj4(WGS84, VANDG);
+        Point xy = conv.forward(new Point(30, 0));
+        assertEquals(6371007 * 30 * Math.PI / 180, xy.x, XY_EPSLN, "equator easting");
+        assertEquals(0, xy.y, XY_EPSLN, "equator northing");
+        Point ll = conv.inverse(new Point(xy.x, xy.y));
+        assertEquals(30, ll.x, 1e-6);
+        assertEquals(0, ll.y, 1e-6);
+    }
+
+    @Test
+    void testBonneEllipsoid() {
+        assertForward(BONNE_E, new double[][] {
+            {5, 45, 394029.1105, 566425.3996},
+            {10, 50, 715504.7995, 1150816.2352},
+            {-3, 38, -263447.6992, -217599.8973},
+        });
+        assertRoundTrip(BONNE_E, new double[][] {{5, 45}, {10, 50}, {-3, 38}});
+    }
+
+    @Test
+    void testBonneSphere() {
+        assertForward(BONNE_S, new double[][] {
+            {5, 45, 392929.3787, 566954.4064},
+            {10, 50, 713299.9018, 1151324.7462},
+            {-3, 38, -262819.1175, -217969.5670},
+        });
+        assertRoundTrip(BONNE_S, new double[][] {{5, 45}, {10, 50}, {-3, 38}});
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        // BONNE_S (a sphere) is intentionally excluded: spherical CRSs don't yet
+        // round-trip through the serializer (the +b/sphere flag is dropped) — tracked
+        // separately in #78. It's not specific to these projections.
+        for (String def : new String[] {VANDG, BONNE_E}) {
+            Proj original = new Proj(def);
+            double[] c = {6, 46};
+            for (String serialized : new String[] {
+                    CRSSerializer.toProjString(original),
+                    CRSSerializer.toWkt1(original),
+                    CRSSerializer.toWkt2(original),
+                    CRSSerializer.toProjJson(original)}) {
+                Proj reimported = new Proj(serialized);
+                Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+                assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+                assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+            }
+        }
+    }
+
+    private void assertForward(String def, double[][] cases) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    private void assertRoundTrip(String def, double[][] coords) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two more projections from proj4js:

- **Van der Grinten I** (`vandg` / `Van_der_Grinten` / `VanDerGrinten`) —
  `lib/projections/vandg.js`. Projects the world into a circle.
- **Bonne** (`bonne`) — `lib/projections/bonne.js`. Pseudoconic equal-area,
  spherical and ellipsoidal branches.

All reuse existing `ProjMath` helpers (`adjustLon/Lat`, `asinz`,
`pjEnfn/pjMlfn/pjInvMlfn`); no new helpers.

## Correction vs proj4js

- **Van der Grinten**: proj4js leaves its equator/meridian/pole special cases
  unreturned, so the general formula overwrites them and yields a non-finite
  result at the equator (proj4js throws there). This port returns those special
  cases — as PROJ does — so the equator and poles project correctly.

## Tests

Known values and round-trips vs proj4js 2.20.9 (including the Van der Grinten
equator), plus serialization round-trips for vandg and ellipsoidal bonne.

The bonne-sphere serialization round-trip is excluded pending **#78**: spherical
CRSs (`a==b`) currently lose the sphere flag through `toProjString` (the `+b` is
dropped). That's a pre-existing, projection-agnostic gap surfaced by bonne's
spherical branch — the projection math itself is verified by the known-value and
round-trip tests. Full suite: 743 tests pass.

Follows #68–#76.
