### PR TITLE
Emit +b for spheres so spherical CRSs round-trip through toProjString (#78)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -347,12 +347,10 @@ public final class CRSSerializer {
         } else if (params.a > 0) {
             // Use explicit a/b or a/rf
             sb.append(" +a=").append(params.a);
-            if (params.b > 0 && params.b != params.a) {
-                sb.append(" +b=").append(params.b);
-            } else if (params.b > 0 && params.b == params.a) {
-                // Sphere: emit +b so the sphere is preserved on re-import. Without it,
-                // "+a" alone is not recognized as a sphere and sphere-branching
-                // projections (sinu, bonne, ortho, ...) take the ellipsoidal path.
+            // Emit +b whenever it is known (including the sphere case a==b): "+a" alone
+            // is not recognized as a sphere on re-import, so sphere-branching projections
+            // (sinu, bonne, ortho, ...) would otherwise take the ellipsoidal path.
+            if (params.b > 0) {
                 sb.append(" +b=").append(params.b);
             } else if (params.rf > 0) {
                 sb.append(" +rf=").append(params.rf);

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -349,6 +349,11 @@ public final class CRSSerializer {
             sb.append(" +a=").append(params.a);
             if (params.b > 0 && params.b != params.a) {
                 sb.append(" +b=").append(params.b);
+            } else if (params.b > 0 && params.b == params.a) {
+                // Sphere: emit +b so the sphere is preserved on re-import. Without it,
+                // "+a" alone is not recognized as a sphere and sphere-branching
+                // projections (sinu, bonne, ortho, ...) take the ellipsoidal path.
+                sb.append(" +b=").append(params.b);
             } else if (params.rf > 0) {
                 sb.append(" +rf=").append(params.rf);
             }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -3,6 +3,7 @@ package org.datasyslab.proj4sedona.parser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+import org.datasyslab.proj4sedona.core.Point;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
 
@@ -52,6 +53,23 @@ class CRSSerializerTest {
         assertNotNull(result);
         assertTrue(result.contains("+proj=merc"));
         assertTrue(result.contains("+a=6378137"));
+    }
+
+    @Test
+    @DisplayName("toProjString: sphere (a==b) round-trips with sphere preserved (#78)")
+    void testToProjStringSphereRoundTrip() {
+        // Sinusoidal branches on sphere vs ellipsoid; a sphere must survive the round trip.
+        Proj sphere = new Proj("+proj=sinu +lon_0=0 +a=6371007 +b=6371007 +units=m +no_defs");
+        String projString = CRSSerializer.toProjString(sphere);
+        assertTrue(projString.contains("+b="), "sphere proj string must emit +b: " + projString);
+
+        Proj reimported = new Proj(projString);
+        assertTrue(reimported.getParams().sphere, "re-imported CRS must still be a sphere");
+
+        Point want = sphere.forward(new Point(20 * Math.PI / 180, 10 * Math.PI / 180));
+        Point got = reimported.forward(new Point(20 * Math.PI / 180, 10 * Math.PI / 180));
+        assertEquals(want.x, got.x, 0.01, "easting after round trip");
+        assertEquals(want.y, got.y, 0.01, "northing after round trip");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #78. A spherical CRS (`a == b`) serialized with `toProjString` emitted `+a`
only — `appendEllipsoidParams` guarded `+b` on `b != a`, so a sphere got neither
`+b` nor `+rf`. Re-parsing `+a=<r>` alone does not set `sphere=true`, so
sphere-branching projections (Sinusoidal, Bonne, Orthographic, Eckert VI, …) took
the ellipsoidal path on re-import and produced different coordinates.

`appendEllipsoidParams` now also emits `+b` when `a == b`, so the sphere survives.
WKT/WKT2/PROJJSON already round-tripped spheres (they emit `SPHEROID[...,0]` /
`radius`); only the proj-string path was affected.

This is a proj4sedona serializer bug — proj4js has no proj-string serializer, so it
isn't inherited. (An explicit `a==b` already parses to a sphere; the separate
`+a`-alone-as-sphere behavior matches proj4js and is out of scope.)

## Tests

Adds a regression test: a Sinusoidal sphere CRS round-trips through `toProjString`
with `sphere` preserved and identical coordinates. Full suite: 738 tests pass.
