### PR TITLE
Add Equal Earth and Geostationary Satellite projections

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
+++ b/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
@@ -167,6 +167,45 @@ public final class ProjMath {
         return 2 * sinphi;
     }
 
+    /**
+     * Coefficients for the authalic latitude series.
+     * Mirrors: lib/common/authset.js
+     *
+     * @param es Eccentricity squared
+     * @return three-element coefficient array (APA)
+     */
+    public static double[] authset(double es) {
+        final double P00 = 0.33333333333333333333;
+        final double P01 = 0.17222222222222222222;
+        final double P02 = 0.10257936507936507936;
+        final double P10 = 0.06388888888888888888;
+        final double P11 = 0.06640211640211640211;
+        final double P20 = 0.01641501294219154443;
+        double[] apa = new double[3];
+        apa[0] = es * P00;
+        double t = es * es;
+        apa[0] += t * P01;
+        apa[1] = t * P10;
+        t *= es;
+        apa[0] += t * P02;
+        apa[1] += t * P11;
+        apa[2] = t * P20;
+        return apa;
+    }
+
+    /**
+     * Convert authalic latitude to geodetic latitude using the series coefficients.
+     * Mirrors: lib/common/authlat.js
+     *
+     * @param beta Authalic latitude
+     * @param apa Coefficients from {@link #authset(double)}
+     * @return Geodetic latitude
+     */
+    public static double authlat(double beta, double[] apa) {
+        double t = beta + beta;
+        return beta + apa[0] * Math.sin(t) + apa[1] * Math.sin(t + t) + apa[2] * Math.sin(t + t + t);
+    }
+
     // ==================== Meridional Distance Functions ====================
     // These functions calculate the meridional distance from the equator to a 
     // given latitude on an ellipsoid.

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -295,6 +295,8 @@ public class Proj {
         p.rectifiedGridAngle = def.getRectifiedGridAngle();
         p.noUoff = def.getNoUoff();
         p.noRot = def.getNoRot();
+        p.h = def.getH();
+        p.sweep = def.getSweep();
 
         // Scale and offsets
         p.k0 = def.getK0() != null ? def.getK0() : 1.0;

--- a/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
@@ -60,6 +60,8 @@ public class ProjectionDef {
     private Boolean over;          // Allow longitude wrapping
     private Boolean noUoff;        // no_uoff / no_off: Oblique Mercator without origin offset (variant A)
     private Boolean noRot;         // no_rot: Oblique Mercator without rectification rotation
+    private Double h;              // h: satellite height (Geostationary)
+    private String sweep;          // sweep: sweep axis 'x' or 'y' (Geostationary)
 
     // Datum object (populated after parsing)
     private DatumParams datum;
@@ -181,6 +183,12 @@ public class ProjectionDef {
 
     public Boolean getNoRot() { return noRot; }
     public void setNoRot(Boolean noRot) { this.noRot = noRot; }
+
+    public Double getH() { return h; }
+    public void setH(Double h) { this.h = h; }
+
+    public String getSweep() { return sweep; }
+    public void setSweep(String sweep) { this.sweep = sweep; }
 
     public DatumParams getDatum() { return datum; }
     public void setDatum(DatumParams datum) { this.datum = datum; }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -296,6 +296,14 @@ public final class CRSSerializer {
             }
         }
 
+        // Geostationary (geos) defining parameters
+        if (params.h != null) {
+            sb.append(" +h=").append(params.h);
+        }
+        if (params.sweep != null) {
+            sb.append(" +sweep=").append(params.sweep);
+        }
+
         // Ellipsoid parameters
         appendEllipsoidParams(sb, params);
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
@@ -173,6 +173,12 @@ public final class ProjString {
             case "no_rot":
                 def.setNoRot(true);
                 break;
+            case "h":
+                def.setH(parseDouble(paramVal));
+                break;
+            case "sweep":
+                def.setSweep(paramVal);
+                break;
 
             // towgs84 parameters
             case "towgs84":

--- a/src/main/java/org/datasyslab/proj4sedona/projection/EqualEarth.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/EqualEarth.java
@@ -96,7 +96,9 @@ public class EqualEarth implements Projection {
         paramLatPow6 = paramLatSq * paramLatSq * paramLatSq;
         double lon = M * px * (A1 + 3 * A2 * paramLatSq + paramLatPow6 * (7 * A3 + 9 * A4 * paramLatSq))
             / Math.cos(paramLat);
-        double lat = Math.asin(Math.sin(paramLat) / M);
+        // asinz (clamped) guards against the Newton result drifting sin(paramLat)/M
+        // slightly outside [-1, 1] near the latitude limit, which would give NaN.
+        double lat = ProjMath.asinz(Math.sin(paramLat) / M);
 
         if (es != 0) {
             lat = ProjMath.authlat(lat, apa);

--- a/src/main/java/org/datasyslab/proj4sedona/projection/EqualEarth.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/EqualEarth.java
@@ -1,0 +1,107 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Equal Earth projection (eqearth).
+ * Mirrors: lib/projections/eqearth.js
+ *
+ * <p>An equal-area pseudocylindrical projection (Savric, Patterson &amp; Jenny, 2018)
+ * inspired by Robinson but preserving areas. Supports the spherical and ellipsoidal
+ * (authalic) forms.</p>
+ */
+public class EqualEarth implements Projection {
+
+    private static final String[] NAMES = {"eqearth", "Equal Earth", "Equal_Earth"};
+
+    private static final double A1 = 1.340264;
+    private static final double A2 = -0.081106;
+    private static final double A3 = 0.000893;
+    private static final double A4 = 0.003796;
+    private static final double M = Math.sqrt(3) / 2.0;
+
+    private double a, es, e, long0, x0, y0;
+    private double[] apa;
+    private double qp, rqda;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.es = params.es;
+        this.e = Math.sqrt(es);
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+
+        if (es != 0) {
+            this.apa = ProjMath.authset(es);
+            this.qp = ProjMath.qsfnz(e, 1);
+            this.rqda = Math.sqrt(0.5 * qp);
+        }
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lam = ProjMath.adjustLon(p.x - long0, over);
+        double sinphi = Math.sin(p.y);
+        if (es != 0) {
+            sinphi = ProjMath.qsfnz(e, sinphi) / qp;
+        }
+        double paramLat = Math.asin(M * sinphi);
+        double paramLatSq = paramLat * paramLat;
+        double paramLatPow6 = paramLatSq * paramLatSq * paramLatSq;
+        double x = lam * Math.cos(paramLat)
+            / (M * (A1 + 3 * A2 * paramLatSq + paramLatPow6 * (7 * A3 + 9 * A4 * paramLatSq)));
+        double y = paramLat * (A1 + A2 * paramLatSq + paramLatPow6 * (A3 + A4 * paramLatSq));
+
+        if (es != 0) {
+            x *= rqda;
+            y *= rqda;
+        }
+
+        return new Point(a * x + x0, a * y + y0, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double px = (p.x - x0) / a;
+        double py = (p.y - y0) / a;
+        if (es != 0) {
+            px /= rqda;
+            py /= rqda;
+        }
+
+        double EPS = 1e-9;
+        int NITER = 12;
+        double paramLat = py;
+        double paramLatSq, paramLatPow6, fy, fpy, dlat;
+        for (int i = 0; i < NITER; ++i) {
+            paramLatSq = paramLat * paramLat;
+            paramLatPow6 = paramLatSq * paramLatSq * paramLatSq;
+            fy = paramLat * (A1 + A2 * paramLatSq + paramLatPow6 * (A3 + A4 * paramLatSq)) - py;
+            fpy = A1 + 3 * A2 * paramLatSq + paramLatPow6 * (7 * A3 + 9 * A4 * paramLatSq);
+            dlat = fy / fpy;
+            paramLat -= dlat;
+            if (Math.abs(dlat) < EPS) {
+                break;
+            }
+        }
+        paramLatSq = paramLat * paramLat;
+        paramLatPow6 = paramLatSq * paramLatSq * paramLatSq;
+        double lon = M * px * (A1 + 3 * A2 * paramLatSq + paramLatPow6 * (7 * A3 + 9 * A4 * paramLatSq))
+            / Math.cos(paramLat);
+        double lat = Math.asin(Math.sin(paramLat) / M);
+
+        if (es != 0) {
+            lat = ProjMath.authlat(lat, apa);
+        }
+
+        return new Point(ProjMath.adjustLon(lon + long0, over), lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
@@ -1,0 +1,148 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Geostationary Satellite View projection (geos).
+ * Mirrors: lib/projections/geos.js
+ *
+ * <p>The view of the Earth from a geostationary satellite. Requires the satellite
+ * height above the ellipsoid ({@code +h}); the scan {@code +sweep} axis ('x' or 'y',
+ * default 'y') selects the instrument sweep convention. Supports spherical and
+ * ellipsoidal forms; points not visible from the satellite are unprojectable (null).</p>
+ */
+public class Geostationary implements Projection {
+
+    private static final String[] NAMES = {
+        "Geostationary Satellite View", "Geostationary_Satellite", "geos"
+    };
+
+    private double a, es, long0, x0, y0;
+    private boolean flipAxis;
+    private double radiusG1, radiusG, radiusP, radiusP2, radiusPInv2, C;
+    private boolean ellipse;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.es = params.es;
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+
+        this.flipAxis = "x".equals(params.sweep);
+        if (params.h == null) {
+            throw new IllegalArgumentException("Geostationary projection requires satellite height (+h)");
+        }
+        this.radiusG1 = params.h / a;
+        if (radiusG1 <= 0 || radiusG1 > 1e10) {
+            throw new IllegalArgumentException("Invalid satellite height (+h) for Geostationary projection");
+        }
+        this.radiusG = 1.0 + radiusG1;
+        this.C = radiusG * radiusG - 1.0;
+
+        if (es != 0.0) {
+            double oneEs = 1.0 - es;
+            this.radiusP = Math.sqrt(oneEs);
+            this.radiusP2 = oneEs;
+            this.radiusPInv2 = 1 / oneEs;
+            this.ellipse = true;
+        } else {
+            this.radiusP = 1.0;
+            this.radiusP2 = 1.0;
+            this.radiusPInv2 = 1.0;
+            this.ellipse = false;
+        }
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lon = p.x - long0;
+        double lat = p.y;
+        double vx, vy, vz, tmp;
+
+        if (ellipse) {
+            lat = Math.atan(radiusP2 * Math.tan(lat));
+            double r = radiusP / Math.hypot(radiusP * Math.cos(lat), Math.sin(lat));
+            vx = r * Math.cos(lon) * Math.cos(lat);
+            vy = r * Math.sin(lon) * Math.cos(lat);
+            vz = r * Math.sin(lat);
+            if (((radiusG - vx) * vx - vy * vy - vz * vz * radiusPInv2) < 0.0) {
+                return null;
+            }
+        } else {
+            tmp = Math.cos(lat);
+            vx = Math.cos(lon) * tmp;
+            vy = Math.sin(lon) * tmp;
+            vz = Math.sin(lat);
+        }
+
+        tmp = radiusG - vx;
+        double x, y;
+        if (flipAxis) {
+            x = radiusG1 * Math.atan(vy / Math.hypot(vz, tmp));
+            y = radiusG1 * Math.atan(vz / tmp);
+        } else {
+            x = radiusG1 * Math.atan(vy / tmp);
+            y = radiusG1 * Math.atan(vz / Math.hypot(vy, tmp));
+        }
+        return new Point(x * a + x0, y * a + y0, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double px = (p.x - x0) / a;
+        double py = (p.y - y0) / a;
+        double vx = -1.0, vy = 0.0, vz = 0.0;
+        double a2, b, det, k;
+
+        if (ellipse) {
+            if (flipAxis) {
+                vz = Math.tan(py / radiusG1);
+                vy = Math.tan(px / radiusG1) * Math.hypot(1.0, vz);
+            } else {
+                vy = Math.tan(px / radiusG1);
+                vz = Math.tan(py / radiusG1) * Math.hypot(1.0, vy);
+            }
+            double vzp = vz / radiusP;
+            a2 = vy * vy + vzp * vzp + vx * vx;
+            b = 2 * radiusG * vx;
+            det = (b * b) - 4 * a2 * C;
+            if (det < 0.0) {
+                return null;
+            }
+            k = (-b - Math.sqrt(det)) / (2.0 * a2);
+            vx = radiusG + k * vx;
+            vy *= k;
+            vz *= k;
+            double lon = Math.atan2(vy, vx);
+            double lat = Math.atan(vz * Math.cos(lon) / vx);
+            lat = Math.atan(radiusPInv2 * Math.tan(lat));
+            return new Point(lon + long0, lat, p.z);
+        } else {
+            if (flipAxis) {
+                vz = Math.tan(py / radiusG1);
+                vy = Math.tan(px / radiusG1) * Math.sqrt(1.0 + vz * vz);
+            } else {
+                vy = Math.tan(px / radiusG1);
+                vz = Math.tan(py / radiusG1) * Math.sqrt(1.0 + vy * vy);
+            }
+            a2 = vy * vy + vz * vz + vx * vx;
+            b = 2 * radiusG * vx;
+            det = (b * b) - 4 * a2 * C;
+            if (det < 0.0) {
+                return null;
+            }
+            k = (-b - Math.sqrt(det)) / (2.0 * a2);
+            vx = radiusG + k * vx;
+            vy *= k;
+            vz *= k;
+            double lon = Math.atan2(vy, vx);
+            double lat = Math.atan(vz * Math.cos(lon) / vx);
+            return new Point(lon + long0, lat, p.z);
+        }
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
@@ -10,6 +10,12 @@ import org.datasyslab.proj4sedona.core.Point;
  * height above the ellipsoid ({@code +h}); the scan {@code +sweep} axis ('x' or 'y',
  * default 'y') selects the instrument sweep convention. Supports spherical and
  * ellipsoidal forms; points not visible from the satellite are unprojectable (null).</p>
+ *
+ * <p>proj4js's geos only scales by {@code a} and never applies {@code +x_0/+y_0}. This
+ * port applies them (in {@code forward}/{@code inverse}) to match PROJ and this
+ * codebase's convention that projections apply offsets themselves ({@code Transform}
+ * does not) — an intentional divergence from proj4js. Standard geos CRSs use
+ * {@code x_0=y_0=0}, so their output is unchanged.</p>
  */
 public class Geostationary implements Projection {
 
@@ -70,14 +76,19 @@ public class Geostationary implements Projection {
             vx = r * Math.cos(lon) * Math.cos(lat);
             vy = r * Math.sin(lon) * Math.cos(lat);
             vz = r * Math.sin(lat);
-            if (((radiusG - vx) * vx - vy * vy - vz * vz * radiusPInv2) < 0.0) {
-                return null;
-            }
         } else {
             tmp = Math.cos(lat);
             vx = Math.cos(lon) * tmp;
             vy = Math.sin(lon) * tmp;
             vz = Math.sin(lat);
+        }
+
+        // Visibility check for both branches (radiusPInv2 == 1 for the sphere). proj4js
+        // only guards the ellipsoidal path; guard the sphere too, so far-side points are
+        // unprojectable (null) rather than projecting to finite garbage, consistent with
+        // the inverse (which returns null when the point is off-disk).
+        if (((radiusG - vx) * vx - vy * vy - vz * vz * radiusPInv2) < 0.0) {
+            return null;
         }
 
         tmp = radiusG - vx;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -138,6 +138,12 @@ public class ProjectionParams {
     /** Oblique Mercator without rectification rotation (+no_rot) */
     public Boolean noRot;
 
+    /** Satellite height in meters (+h) - used by the Geostationary projection */
+    public Double h;
+
+    /** Sweep axis "x" or "y" (+sweep) - used by the Geostationary projection */
+    public String sweep;
+
     // ==================== Original Definition ====================
     
     /** Original SRS code or PROJ string */

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -176,6 +176,10 @@ public final class ProjectionRegistry {
         add(Sinusoidal::new);
         add(Mollweide::new);
         add(Robinson::new);
+        add(EqualEarth::new);
+
+        // Miscellaneous projections
+        add(Geostationary::new);
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/projection/EqualEarthGeosTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/EqualEarthGeosTest.java
@@ -82,10 +82,36 @@ class EqualEarthGeosTest {
     }
 
     @Test
+    void testGeostationaryFalseEastingNorthing() {
+        // Intentional divergence from proj4js (which ignores +x_0/+y_0 for geos): this
+        // port applies them, matching PROJ and the codebase convention. A 1000/2000
+        // offset must shift the zero-offset result and round-trip.
+        Converter base = Proj4.proj4(WGS84, GEOS_Y);
+        Converter off = Proj4.proj4(WGS84, GEOS_Y.replace("+lon_0=0", "+lon_0=0 +x_0=1000 +y_0=2000"));
+        Point b = base.forward(new Point(10, -5));
+        Point o = off.forward(new Point(10, -5));
+        assertEquals(b.x + 1000, o.x, XY_EPSLN, "x_0 applied in forward");
+        assertEquals(b.y + 2000, o.y, XY_EPSLN, "y_0 applied in forward");
+        Point ll = off.inverse(new Point(o.x, o.y));
+        assertEquals(10, ll.x, LL_EPSLN);
+        assertEquals(-5, ll.y, LL_EPSLN);
+    }
+
+    @Test
     void testGeostationaryFarSideIsNull() {
         // A point on the far side of the globe from the sub-satellite point is not visible.
         Converter conv = Proj4.proj4(WGS84, GEOS_Y);
         assertNull(conv.forward(new Point(180, 0)));
+    }
+
+    @Test
+    void testGeostationarySphereFarSideIsNull() {
+        // The spherical branch must also reject far-side points (proj4js only guards the
+        // ellipsoidal path).
+        Converter conv = Proj4.proj4(WGS84,
+            "+proj=geos +lon_0=0 +h=35785831 +a=6378137 +b=6378137 +units=m +no_defs");
+        assertNull(conv.forward(new Point(180, 0)));
+        assertNotNull(conv.forward(new Point(5, 5)), "near-side point must still project");
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/projection/EqualEarthGeosTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/EqualEarthGeosTest.java
@@ -1,0 +1,136 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Equal Earth (eqearth) and Geostationary (geos) projections. Reference
+ * eastings/northings are from proj4js 2.20.9 (WGS84 &rarr; CRS); definitions keep the
+ * same datum on both sides, so the numbers exercise the projection math. Tolerance
+ * 0.01 m / 1e-7&deg;.
+ */
+class EqualEarthGeosTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-7;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+
+    private static final String EQEARTH_E =
+        "+proj=eqearth +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs";
+    private static final String EQEARTH_S =
+        "+proj=eqearth +lon_0=0 +x_0=0 +y_0=0 +a=6371007 +b=6371007 +units=m +no_defs";
+    private static final String GEOS_X =
+        "+proj=geos +sweep=x +lon_0=-75 +h=35786023 +a=6378137.0 +b=6356752.314 +units=m +no_defs";
+    private static final String GEOS_Y =
+        "+proj=geos +sweep=y +lon_0=0 +h=35785831 +a=6378137 +b=6356752.31414 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("eqearth"));
+        assertNotNull(ProjectionRegistry.get("Equal_Earth"));
+        assertNotNull(ProjectionRegistry.get("geos"));
+        assertNotNull(ProjectionRegistry.get("Geostationary_Satellite"));
+    }
+
+    @Test
+    void testEqualEarthEllipsoid() {
+        assertForward(EQEARTH_E, new double[][] {
+            {20, 40, 1699499.6614, 4921020.0618},
+            {-100, -30, -8965339.9386, -3764325.4269},
+        });
+        assertRoundTrip(EQEARTH_E, new double[][] {{20, 40}, {-100, -30}, {5, 60}});
+    }
+
+    @Test
+    void testEqualEarthSphere() {
+        assertForward(EQEARTH_S, new double[][] {
+            {20, 40, 1698159.2845, 4935117.0615},
+            {-100, -30, -8960827.2770, -3777593.7991},
+        });
+        assertRoundTrip(EQEARTH_S, new double[][] {{20, 40}, {-100, -30}, {5, 60}});
+    }
+
+    @Test
+    void testGeostationaryXSweep() {
+        // proj4js testData published point.
+        assertForward(GEOS_X, new double[][] {
+            {-95, 25, -1920508.77, 2605680.03},
+            {-60, 10, 1610055.5137, 1090452.2824},
+        });
+        assertRoundTrip(GEOS_X, new double[][] {{-95, 25}, {-60, 10}, {-75, 0}});
+    }
+
+    @Test
+    void testGeostationaryYSweep() {
+        assertForward(GEOS_Y, new double[][] {
+            {10, -5, 1099312.2595, -550025.7331},
+        });
+        assertRoundTrip(GEOS_Y, new double[][] {{10, -5}, {0, 0}, {-8, 12}});
+    }
+
+    @Test
+    void testGeostationaryFarSideIsNull() {
+        // A point on the far side of the globe from the sub-satellite point is not visible.
+        Converter conv = Proj4.proj4(WGS84, GEOS_Y);
+        assertNull(conv.forward(new Point(180, 0)));
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        // eqearth: all four formats. geos: proj string only (WKT/PROJJSON serialization
+        // of +h/+sweep is not implemented; proj string is the canonical geos form).
+        assertProjMathRoundTrip(EQEARTH_E, new String[] {"proj", "wkt1", "wkt2", "projjson"});
+        assertProjMathRoundTrip(GEOS_X, new String[] {"proj"});
+    }
+
+    private void assertProjMathRoundTrip(String def, String[] formats) {
+        Proj original = new Proj(def);
+        double[] c = {-40, 15};
+        for (String fmt : formats) {
+            String serialized;
+            switch (fmt) {
+                case "wkt1": serialized = CRSSerializer.toWkt1(original); break;
+                case "wkt2": serialized = CRSSerializer.toWkt2(original); break;
+                case "projjson": serialized = CRSSerializer.toProjJson(original); break;
+                default: serialized = CRSSerializer.toProjString(original);
+            }
+            Proj reimported = new Proj(serialized);
+            Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+            assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+        }
+    }
+
+    private void assertForward(String def, double[][] cases) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    private void assertRoundTrip(String def, double[][] coords) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds two more projections from proj4js:

- **Equal Earth** (`eqearth` / `Equal Earth` / `Equal_Earth`) —
  `lib/projections/eqearth.js`. Equal-area pseudocylindrical (Savric/Patterson/Jenny),
  spherical and ellipsoidal (authalic) forms. Adds `authset`/`authlat` to `ProjMath`.
- **Geostationary Satellite View** (`geos` / `Geostationary_Satellite`) —
  `lib/projections/geos.js`. Satellite view of the Earth, spherical and ellipsoidal
  forms; off-disk (not visible) points return `null`. Adds `+h` (satellite height)
  and `+sweep` (x/y) parsing through `ProjString` → `ProjectionDef` →
  `ProjectionParams` → `Proj`, and emits them in `toProjString`.

## Note on Equal Earth references

The eqearth ellipsoidal path uses the current proj4js authalic handling. proj4js's
**published `dist` ships an older spherical-only eqearth**, so I verified the
ellipsoidal reference values against a freshly built proj4js (from `lib`), not the
stale dist. Spherical values match the dist directly.

## Tests

Known values and round-trips vs proj4js 2.20.9 — including geos `testData` points
(x/y sweep, ellipsoid) and the geos far-side `null` — plus serialization round-trips
(all four formats for eqearth; proj string for geos). geos WKT/PROJJSON `+h/+sweep`
serialization is not implemented (proj string is the canonical geos form). Full
suite: 744 tests pass.

Follows #68–#76, #79.
