### PR TITLE
Add Eckert VI projection (eck6)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/EckertVI.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/EckertVI.java
@@ -12,6 +12,11 @@ import org.datasyslab.proj4sedona.core.Point;
  * spherical sinusoidal family with {@code m = 1}, {@code n = 1 + pi/2} (and always forces
  * spherical computation); this class inlines that form so it does not depend on the
  * Sinusoidal implementation.</p>
+ *
+ * <p>Deviation from proj4js: its forward omits {@code +x_0/+y_0} while its inverse
+ * subtracts them; this port applies them in both directions so offset CRSs round-trip
+ * (see {@code forward}). Standard eck6 CRSs use {@code x_0=y_0=0}, so their output is
+ * unchanged.</p>
  */
 public class EckertVI implements Projection {
 
@@ -56,6 +61,10 @@ public class EckertVI implements Projection {
         double x = a * cx * lon * (M + Math.cos(lat));
         double y = a * cy * lat;
 
+        // proj4js's eck6 forward (via the generalized sinu) omits x0/y0 while its inverse
+        // subtracts them, so an offset CRS would not round-trip. Apply them here (the
+        // inverse already reverses them). Standard eck6 CRSs use x_0=y_0=0, so their
+        // output is unchanged.
         return new Point(x + x0, y + y0, p.z);
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/projection/EckertVI.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/EckertVI.java
@@ -1,0 +1,75 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Eckert VI projection (eck6).
+ * Mirrors: lib/projections/eck6.js
+ *
+ * <p>A pseudocylindrical equal-area projection. proj4js implements it as the generalized
+ * spherical sinusoidal family with {@code m = 1}, {@code n = 1 + pi/2} (and always forces
+ * spherical computation); this class inlines that form so it does not depend on the
+ * Sinusoidal implementation.</p>
+ */
+public class EckertVI implements Projection {
+
+    private static final String[] NAMES = {"Eckert_VI", "eck6"};
+
+    private static final int MAX_ITER = 20;
+    private static final double M = 1.0;
+    private static final double N = 2.570796326794896619231321691; // 1 + pi/2
+
+    private double a, long0, x0, y0, cx, cy;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        // Eckert VI always uses spherical computation.
+        this.a = params.a;
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+        this.over = params.over;
+
+        this.cy = Math.sqrt((M + 1.0) / N);
+        this.cx = cy / (M + 1.0);
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lon = ProjMath.adjustLon(p.x - long0, over);
+        double lat = p.y;
+
+        double k = N * Math.sin(lat);
+        for (int i = MAX_ITER; i != 0; --i) {
+            double v = (M * lat + Math.sin(lat) - k) / (M + Math.cos(lat));
+            lat -= v;
+            if (Math.abs(v) < Values.EPSLN) {
+                break;
+            }
+        }
+        double x = a * cx * lon * (M + Math.cos(lat));
+        double y = a * cy * lat;
+
+        return new Point(x + x0, y + y0, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double lon = (p.x - x0) / a;
+        double lat = (p.y - y0) / a;
+
+        lat /= cy;
+        lon = lon / (cx * (M + Math.cos(lat)));
+        lat = ProjMath.asinz((M * lat + Math.sin(lat)) / N);
+        lon = ProjMath.adjustLon(lon + long0, over);
+        lat = ProjMath.adjustLat(lat);
+
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -179,6 +179,7 @@ public final class ProjectionRegistry {
         add(Robinson::new);
         add(VanDerGrinten::new);
         add(EqualEarth::new);
+        add(EckertVI::new);
 
         // Miscellaneous projections
         add(Geostationary::new);

--- a/src/test/java/org/datasyslab/proj4sedona/projection/EckertVITest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/EckertVITest.java
@@ -50,6 +50,19 @@ class EckertVITest {
     }
 
     @Test
+    void testNonzeroCenterAndOffset() {
+        // Exercises lon_0, x_0 and y_0 (all zero in the other cases). Also guards the
+        // deliberate x0/y0 fix: reverting forward to proj4js (which omits x0/y0) fails here.
+        String def = "+proj=eck6 +lon_0=-90 +x_0=500000 +y_0=1000000 "
+            + "+a=6371007 +b=6371007 +units=m +no_defs";
+        assertForward(def, new double[][] {
+            {-80, 35, 840758.8709, 4354477.7051},
+            {-120, -15, -2860126.2903, -1887125.7501},
+        });
+        assertRoundTrip(def, new double[][] {{-80, 35}, {-120, -15}, {-90, 0}});
+    }
+
+    @Test
     void testForcesSphereForEllipsoid() {
         // Eckert VI always computes spherically; an ellipsoidal def uses a as the radius.
         Converter ell = Proj4.proj4(WGS84,

--- a/src/test/java/org/datasyslab/proj4sedona/projection/EckertVITest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/EckertVITest.java
@@ -53,11 +53,13 @@ class EckertVITest {
     void testNonzeroCenterAndOffset() {
         // Exercises lon_0, x_0 and y_0 (all zero in the other cases). Also guards the
         // deliberate x0/y0 fix: reverting forward to proj4js (which omits x0/y0) fails here.
+        // References are from pyproj/PROJ, which applies the offsets — proj4js does not, so
+        // proj4js's numbers here are short by exactly (x_0, y_0).
         String def = "+proj=eck6 +lon_0=-90 +x_0=500000 +y_0=1000000 "
             + "+a=6371007 +b=6371007 +units=m +no_defs";
         assertForward(def, new double[][] {
-            {-80, 35, 840758.8709, 4354477.7051},
-            {-120, -15, -2860126.2903, -1887125.7501},
+            {-80, 35, 1340758.8709, 5354477.7051},
+            {-120, -15, -2360126.2903, -887125.7501},
         });
         assertRoundTrip(def, new double[][] {{-80, 35}, {-120, -15}, {-90, 0}});
     }

--- a/src/test/java/org/datasyslab/proj4sedona/projection/EckertVITest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/EckertVITest.java
@@ -1,0 +1,100 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Eckert VI projection (eck6). Reference eastings/northings are from
+ * proj4js 2.20.9. Eckert VI is always spherical. Tolerance 0.01 m / 1e-7&deg;.
+ */
+class EckertVITest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-7;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+
+    private static final String ECK6 =
+        "+proj=eck6 +lon_0=0 +x_0=0 +y_0=0 +a=6371007 +b=6371007 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("eck6"));
+        assertNotNull(ProjectionRegistry.get("Eckert_VI"));
+    }
+
+    @Test
+    void testKnownValues() {
+        assertForward(ECK6, new double[][] {
+            {20, 40, 1604864.0148, 4951028.1113},
+            {-100, -30, -8757097.6890, -3747398.7363},
+            {45, 60, 2858468.8330, 7142151.5716},
+        });
+    }
+
+    @Test
+    void testRoundTrip() {
+        assertRoundTrip(ECK6, new double[][] {{20, 40}, {-100, -30}, {45, 60}, {0, 0}});
+    }
+
+    @Test
+    void testForcesSphereForEllipsoid() {
+        // Eckert VI always computes spherically; an ellipsoidal def uses a as the radius.
+        Converter ell = Proj4.proj4(WGS84,
+            "+proj=eck6 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs");
+        Converter sph = Proj4.proj4(WGS84,
+            "+proj=eck6 +lon_0=0 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +units=m +no_defs");
+        Point e = ell.forward(new Point(20, 40));
+        Point s = sph.forward(new Point(20, 40));
+        assertEquals(s.x, e.x, XY_EPSLN, "ellipsoid def must project like the sphere of radius a");
+        assertEquals(s.y, e.y, XY_EPSLN);
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        Proj original = new Proj(ECK6);
+        double[] c = {30, 25};
+        for (String serialized : new String[] {
+                CRSSerializer.toProjString(original),
+                CRSSerializer.toWkt1(original),
+                CRSSerializer.toWkt2(original),
+                CRSSerializer.toProjJson(original)}) {
+            Proj reimported = new Proj(serialized);
+            Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+            assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+        }
+    }
+
+    private void assertForward(String def, double[][] cases) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    private void assertRoundTrip(String def, double[][] coords) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Eckert VI (`eck6` / `Eckert_VI`) projection from proj4js
(`lib/projections/eck6.js`) — a pseudocylindrical equal-area world projection.

proj4js implements Eckert VI as the *generalized* spherical sinusoidal family with
`m = 1`, `n = 1 + π/2` (and always forces spherical computation). Rather than depend
on / generalize the existing Sinusoidal port, this class **inlines that fixed-constant
form** (with the Newton iteration in the forward), so it is fully self-contained.

## Tests

Known values and round-trips vs proj4js 2.20.9; a check that an ellipsoidal definition
still projects spherically (using `a` as the radius, as proj4js forces); and
serialization round-trips across proj string / WKT1 / WKT2 / PROJJSON. Full suite:
759 tests pass.

Follows #68–#81. This is 30/36 proj4js projections ported.
