### PR TITLE
Verify every projection against pyproj in the benchmark pipeline

### DIFF
--- a/scripts/pyproj-reference/generate_transform_reference.py
+++ b/scripts/pyproj-reference/generate_transform_reference.py
@@ -68,9 +68,214 @@ def get_test_coordinates() -> List[Dict[str, Any]]:
     ]
 
 
+def _pts(*lonlats: Any) -> List[Dict[str, Any]]:
+    """Compact helper: build a test_points list from (lon, lat) tuples."""
+    return [
+        {"name": f"pt_{i}", "lon": lon, "lat": lat, "desc": f"({lon}, {lat})"}
+        for i, (lon, lat) in enumerate(lonlats)
+    ]
+
+
+def get_projection_coverage_pairs() -> List[Dict[str, Any]]:
+    """One case per supported projection, verifying projection math against pyproj.
+
+    Definitions use +datum=WGS84 (ellipsoidal) or an explicit sphere (+a=+b) so no
+    datum shift is involved and the comparison exercises the projection math alone.
+    Regional projections carry in-domain test_points; world projections use the
+    shared global list. Keep this list in sync with ProjectionRegistry: every new
+    projection port should add a case here so CI verifies it against pyproj.
+    """
+    return [
+        # --- Cylindrical / transverse ---
+        {
+            "name": "proj_tmerc",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=500000 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Transverse Mercator (etmerc)",
+            "test_points": _pts((13.4, 52.5), (12.5, 41.9), (10.7, 59.9), (5.0, 45.0)),
+        },
+        {
+            "name": "proj_somerc",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 +k_0=1 +x_0=2600000 +y_0=1200000 +datum=WGS84 +units=m +no_defs",
+            "desc": "Swiss Oblique Mercator",
+            "test_points": _pts((7.44, 46.95), (8.55, 47.37), (6.14, 46.2), (9.5, 47.5)),
+        },
+        {
+            "name": "proj_omerc",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=omerc +lat_0=4 +lonc=102.25 +alpha=323.0257964666666 +k=0.99984 +x_0=804671 +y_0=0 +no_uoff +gamma=323.1301023611111 +datum=WGS84 +units=m +no_defs",
+            "desc": "Hotine Oblique Mercator (variant A)",
+            "test_points": _pts((102.25, 4.0), (102.5, 4.2), (101.7, 3.06), (103.5, 5.5)),
+        },
+        {
+            "name": "proj_cass",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=cass +lat_0=11.25217861111111 +lon_0=-60.68600888888889 +x_0=187500 +y_0=180000 +datum=WGS84 +units=m +no_defs",
+            "desc": "Cassini-Soldner",
+            "test_points": _pts((-60.7, 11.25), (-60.5, 11.4), (-60.9, 11.1)),
+        },
+        {
+            "name": "proj_mill",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=mill +lon_0=0 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +units=m +no_defs",
+            "desc": "Miller Cylindrical (sphere)",
+        },
+        {
+            "name": "proj_eqc",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=eqc +lat_ts=30 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Equidistant Cylindrical",
+        },
+        {
+            "name": "proj_cea",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=cea +lat_ts=30 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Cylindrical Equal Area",
+        },
+        # --- Conic ---
+        {
+            "name": "proj_aea",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Albers Equal Area (US)",
+            "test_points": _pts((-105.0, 39.7), (-87.6, 41.9), (-96.8, 32.8), (-74.0, 40.7)),
+        },
+        {
+            "name": "proj_eqdc",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=eqdc +lat_1=33 +lat_2=45 +lat_0=39 +lon_0=-96 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Equidistant Conic (US)",
+            "test_points": _pts((-105.0, 39.7), (-87.6, 41.9), (-96.8, 32.8), (-74.0, 40.7)),
+        },
+        {
+            "name": "proj_poly",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=poly +lat_0=0 +lon_0=-54 +x_0=5000000 +y_0=10000000 +datum=WGS84 +units=m +no_defs",
+            "desc": "American Polyconic (Brazil)",
+            "test_points": _pts((-54.0, -15.0), (-47.9, -15.8), (-60.0, -2.0), (-43.2, -22.9)),
+        },
+        {
+            # Krovak is always on the Bessel ellipsoid; use a Bessel geographic source
+            # so the comparison is pure projection math (a WGS84 source would add a
+            # datum leg whose towgs84 handling differs between implementations).
+            "name": "proj_krovak",
+            "from_crs": "+proj=longlat +ellps=bessel +no_defs",
+            "to_crs": "+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 +k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +units=m +no_defs",
+            "desc": "Krovak (S-JTSK, Bessel geographic source)",
+            "test_points": _pts((14.42, 50.08), (16.6, 49.2), (17.1, 48.15)),
+        },
+        {
+            "name": "proj_bonne",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=bonne +lat_1=40 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Bonne (ellipsoidal)",
+            "test_points": _pts((5.0, 45.0), (10.0, 50.0), (-3.0, 38.0), (18.4, -33.9)),
+        },
+        # --- Azimuthal ---
+        {
+            "name": "proj_stere_oblique",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=stere +lat_0=52 +lon_0=5 +k=0.9999 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Oblique Stereographic (Snyder)",
+            "test_points": _pts((5.0, 52.0), (7.0, 53.0), (3.5, 50.5)),
+        },
+        {
+            "name": "proj_sterea",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 +datum=WGS84 +units=m +no_defs",
+            "desc": "Oblique Stereographic Alternative (RD-style)",
+            "test_points": _pts((5.2, 52.25), (4.9, 52.37), (6.5, 53.2)),
+        },
+        {
+            "name": "proj_laea",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=laea +lat_0=52 +lon_0=10 +x_0=4321000 +y_0=3210000 +datum=WGS84 +units=m +no_defs",
+            "desc": "Lambert Azimuthal Equal Area (Europe)",
+            "test_points": _pts((10.0, 52.0), (5.0, 45.0), (20.0, 60.0), (-3.0, 40.0)),
+        },
+        {
+            "name": "proj_aeqd",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=aeqd +lat_0=40 +lon_0=-100 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Azimuthal Equidistant (ellipsoidal)",
+            "test_points": _pts((-100.0, 40.0), (-105.0, 39.7), (-87.6, 41.9), (-96.8, 32.8)),
+        },
+        {
+            "name": "proj_gnom",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=gnom +lat_0=45 +lon_0=0 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +units=m +no_defs",
+            "desc": "Gnomonic (sphere)",
+            "test_points": _pts((5.0, 50.0), (-3.0, 44.0), (2.0, 47.0), (10.0, 52.0)),
+        },
+        {
+            "name": "proj_ortho",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=ortho +lat_0=45 +lon_0=0 +x_0=0 +y_0=0 +a=6378137 +b=6378137 +units=m +no_defs",
+            "desc": "Orthographic (sphere)",
+            "test_points": _pts((5.0, 50.0), (-3.0, 44.0), (2.0, 47.0), (10.0, 40.0)),
+        },
+        # --- Pseudocylindrical / world ---
+        {
+            "name": "proj_sinu",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Sinusoidal (ellipsoidal)",
+        },
+        {
+            "name": "proj_moll",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=moll +lon_0=0 +x_0=0 +y_0=0 +a=6371000 +b=6371000 +units=m +no_defs",
+            "desc": "Mollweide (sphere)",
+        },
+        {
+            # Known difference vs PROJ: proj4js's Robinson table interpolation differs
+            # from PROJ's by up to ~0.4 m (relative ~3e-8) — an upstream proj4js-vs-PROJ
+            # difference, faithfully ported. Expect a sub-meter max error here.
+            "name": "proj_robin",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=robin +lon_0=0 +x_0=0 +y_0=0 +a=6371000 +b=6371000 +units=m +no_defs",
+            "desc": "Robinson (sphere; ~0.4 m known proj4js-vs-PROJ difference)",
+        },
+        {
+            "name": "proj_vandg",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=vandg +lon_0=0 +x_0=0 +y_0=0 +a=6371007 +b=6371007 +units=m +no_defs",
+            "desc": "Van der Grinten (sphere)",
+        },
+        {
+            "name": "proj_eqearth",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=eqearth +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Equal Earth (ellipsoidal)",
+        },
+        {
+            "name": "proj_eck6",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=eck6 +lon_0=0 +x_0=0 +y_0=0 +a=6371007 +b=6371007 +units=m +no_defs",
+            "desc": "Eckert VI (sphere)",
+        },
+        # --- Miscellaneous ---
+        {
+            "name": "proj_geos_y",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=geos +h=35785831 +sweep=y +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Geostationary (y sweep, ellipsoidal)",
+            "test_points": _pts((0.0, 0.0), (10.0, -5.0), (-8.0, 12.0), (30.0, 40.0)),
+        },
+        {
+            "name": "proj_geos_x",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=geos +h=35786023 +sweep=x +lon_0=-75 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Geostationary (x sweep, ellipsoidal)",
+            "test_points": _pts((-75.0, 0.0), (-95.0, 25.0), (-60.0, 10.0)),
+        },
+    ]
+
+
 def get_crs_pairs() -> List[Dict[str, Any]]:
     """Define CRS pairs for transformation tests."""
-    return [
+    return get_projection_coverage_pairs() + [
         # Common transformations
         {
             "name": "wgs84_to_webmerc",
@@ -149,6 +354,16 @@ def transform_point(transformer: Transformer, lon: float, lat: float) -> Dict[st
     """Transform a single point and return results."""
     try:
         x, y = transformer.transform(lon, lat)
+        # Non-finite output (e.g. a point outside the projection's domain, such as
+        # the far side of a Geostationary or Orthographic view) is recorded as an
+        # error so consumers skip it; json.dump would otherwise emit non-standard
+        # `Infinity` tokens.
+        if not (np.isfinite(x) and np.isfinite(y)):
+            return {
+                "input": {"x": lon, "y": lat},
+                "output": None,
+                "error": "non-finite result (outside projection domain)",
+            }
         return {
             "input": {"x": lon, "y": lat},
             "output": {"x": float(x), "y": float(y)},
@@ -197,8 +412,12 @@ def generate_transform_reference(output_file: str, verbose: bool = False) -> Non
                     wgs84, from_crs, always_xy=True
                 )
 
+            # Regional projections define their own in-domain test points; world
+            # projections use the shared global list.
+            case_coords = crs_pair.get("test_points", test_coords)
+
             transformations = []
-            for coord in test_coords:
+            for coord in case_coords:
                 # Get input coordinates in from_crs coordinate system
                 if need_input_transform:
                     try:

--- a/src/test/java/org/datasyslab/proj4sedona/benchmark/SpeedBenchmark.java
+++ b/src/test/java/org/datasyslab/proj4sedona/benchmark/SpeedBenchmark.java
@@ -52,6 +52,9 @@ public class SpeedBenchmark {
     
     // Error statistics by category
     private final Map<String, ErrorStats> errorStatsByCategory = new LinkedHashMap<>();
+    // Per-projection correctness vs pyproj (reference cases named proj_*), rendered
+    // as a dedicated report table so each projection's agreement is visible.
+    private final Map<String, ErrorStats> perProjectionStats = new LinkedHashMap<>();
     private final List<String> skippedTests = new ArrayList<>();
 
     public static void main(String[] args) throws Exception {
@@ -286,7 +289,18 @@ public class SpeedBenchmark {
             
             JsonArray transforms = tc.getAsJsonArray("transformations");
             boolean isProjected = isProjectedCrs(toCrs);
-            ErrorStats stats = isProjected ? projectedErrors : geographicErrors;
+
+            // Per-projection coverage cases (proj_*) get their own stats bucket and
+            // report table; they are kept out of the generic category aggregates so a
+            // documented per-projection difference does not distort those rows.
+            ErrorStats stats;
+            if (name.startsWith("proj_")) {
+                String desc = tc.get("description") != null && !tc.get("description").isJsonNull()
+                    ? tc.get("description").getAsString() : name;
+                stats = perProjectionStats.computeIfAbsent(name, k -> new ErrorStats(desc, "m"));
+            } else {
+                stats = isProjected ? projectedErrors : geographicErrors;
+            }
             
             for (JsonElement tElem : transforms) {
                 JsonObject t = tElem.getAsJsonObject();
@@ -322,8 +336,11 @@ public class SpeedBenchmark {
             errorStatsByCategory.put("Projected transforms", projectedErrors);
         }
         
-        System.out.println("   Transform correctness: " + 
-            (geographicErrors.count + projectedErrors.count) + " comparisons");
+        int perProjectionCount = perProjectionStats.values().stream().mapToInt(s -> s.count).sum();
+        System.out.println("   Transform correctness: "
+            + (geographicErrors.count + projectedErrors.count) + " comparisons, "
+            + perProjectionCount + " per-projection comparisons across "
+            + perProjectionStats.size() + " projections");
     }
 
     private void runGridCorrectness() throws IOException {
@@ -584,6 +601,24 @@ public class SpeedBenchmark {
                 tolerance));
         }
         
+        // Per-projection correctness table
+        if (!perProjectionStats.isEmpty()) {
+            sb.append("\n### Per-projection correctness (vs pyproj)\n\n");
+            sb.append("| Projection | Points | Max Error | Avg Error |\n");
+            sb.append("|------------|-------:|----------:|----------:|\n");
+            for (Map.Entry<String, ErrorStats> e : perProjectionStats.entrySet()) {
+                ErrorStats stats = e.getValue();
+                if (stats.count == 0) {
+                    continue;
+                }
+                sb.append(String.format("| %s | %d | %s | %s |\n",
+                    stats.name,
+                    stats.count,
+                    formatError(stats.max, stats.unit),
+                    formatError(stats.sum / stats.count, stats.unit)));
+            }
+        }
+
         // Skipped tests
         if (!skippedTests.isEmpty()) {
             sb.append("\n### Skipped Tests\n\n");


### PR DESCRIPTION
## Summary

Extends the pyproj correctness benchmark to verify **every projection in the
registry** against pyproj/PROJ. Previously the reference covered only Web
Mercator, UTM, one LCC, and UPS — none of the projections added in #68–#82.

## Changes

- **`generate_transform_reference.py`** — new `get_projection_coverage_pairs()`
  with 26 per-projection cases (tmerc/etmerc, somerc, omerc, cass, mill, eqc, cea,
  aea, eqdc, poly, krovak, bonne, oblique stere, sterea, laea, aeqd, gnom, ortho,
  sinu, moll, robin, vandg, eqearth, eck6, geos ×2 sweeps):
  - Definitions use `+datum=WGS84` or an explicit sphere so no datum shift is
    involved — the comparison exercises **projection math alone**. Krovak uses a
    Bessel geographic source (a WGS84 source adds a datum leg whose `towgs84`
    handling differs between implementations).
  - Regional projections carry in-domain `test_points`; world projections use the
    shared global list.
  - `transform_point` records non-finite pyproj output (e.g. the far side of a
    geos/ortho view) as an error instead of emitting non-standard `Infinity` JSON.
- **`SpeedBenchmark`** — `proj_*` cases render in a dedicated **“Per-projection
  correctness (vs pyproj)”** report table, kept out of the generic category
  aggregates so a documented per-projection difference can’t distort those rows.

## Verification (local, pyproj 3.7.2 / PROJ 9.5.1)

**25 of 26 projections agree with pyproj to sub-millimeter** (most at 1e-9–1e-10 m).
The one exception is **Robinson: max ~0.375 m** — a known proj4js-vs-PROJ
table-interpolation difference (confirmed byte-identical deltas in proj4js
itself), documented in the case description and visible in the report.

| Sample rows | Max Error |
|---|---|
| Transverse Mercator (etmerc) | 1.16e-10 m |
| Krovak (Bessel source) | 8.15e-09 m |
| Geostationary (x/y sweep) | ≤1.9e-09 m |
| Robinson (known upstream diff) | 0.3751 m |

## Convention going forward

Every new projection port should add a case to `get_projection_coverage_pairs()`
so CI's benchmark run verifies it against pyproj automatically.
