### PR TITLE
Add standard WKT/PROJJSON method names for eck6/eqearth/geos/bonne (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Proj4Sedona provides coordinate system transformations, datum conversions, and p
 **Key Features:**
 - High-performance: faster than Python's pyproj
 - Format support: PROJ strings, WKT1/WKT2, PROJJSON, EPSG codes
-- 15 map projections (Mercator, UTM, Lambert, Albers, Sinusoidal, Robinson, etc.)
+- 30 map projections (Mercator, UTM, Lambert, Albers, Krovak, Oblique Mercator, Equal Earth, etc.)
 - MGRS coordinate conversion
 - GeoTIFF datum grids with PROJ CDN integration
 - JTS geometry transformation support
@@ -210,12 +210,12 @@ CompletableFuture<GridData> future = GridCdnFetcher.fetchAndLoadAsync("ca_nrc_nt
 
 ## Supported Projections
 
-21 map projections including:
-- **Cylindrical**: Mercator, Transverse Mercator, UTM, Miller, Equirectangular, Cylindrical Equal Area
-- **Pseudocylindrical**: Sinusoidal, Mollweide, Robinson, Equal Earth
-- **Conic**: Lambert Conformal Conic, Albers Equal Area, Equidistant Conic
-- **Azimuthal**: Lambert Azimuthal Equal Area, Stereographic, Azimuthal Equidistant, Orthographic, Gnomonic
-- **Other**: Van der Grinten, Hotine Oblique Mercator
+30 map projections:
+- **Cylindrical**: Mercator, Transverse Mercator, UTM, Miller, Equirectangular, Cylindrical Equal Area, Cassini-Soldner, Swiss Oblique Mercator, Hotine Oblique Mercator
+- **Pseudocylindrical**: Sinusoidal, Mollweide, Robinson, Equal Earth, Eckert VI, Van der Grinten
+- **Conic**: Lambert Conformal Conic, Albers Equal Area, Equidistant Conic, Polyconic, Krovak, Bonne
+- **Azimuthal**: Lambert Azimuthal Equal Area, Stereographic, Oblique Stereographic Alternative, Azimuthal Equidistant, Orthographic, Gnomonic
+- **Other**: Geostationary Satellite, Identity (longlat)
 
 ## Building
 

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -87,6 +87,66 @@ double[] result = Proj4.proj4(
 );
 ```
 
+### Miller Cylindrical
+
+Compromise cylindrical projection related to Mercator but showing the poles.
+
+- PROJ name: `mill`
+- Aliases: `Miller_Cylindrical`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=mill +lon_0=0 +a=6378137 +b=6378137 +units=m",
+    new double[]{-77.0, 38.9}
+);
+```
+
+### Cassini-Soldner
+
+Transverse cylindrical projection, true to scale along the central meridian. Used by older national and cadastral grids (e.g. EPSG:2066).
+
+- PROJ name: `cass`
+- Aliases: `Cassini`, `Cassini_Soldner`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=cass +lat_0=11.25 +lon_0=-60.69 +x_0=187500 +y_0=180000 +datum=WGS84 +units=m",
+    new double[]{-60.7, 11.25}
+);
+```
+
+### Swiss Oblique Mercator
+
+Oblique conformal cylindrical projection used by the Swiss national grids (EPSG:21781 LV03, EPSG:2056 LV95).
+
+- PROJ name: `somerc`
+- Aliases: `Swiss_Oblique_Mercator`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=somerc +lat_0=46.9524055555 +lon_0=7.4395833333 +k_0=1 +x_0=2600000 +y_0=1200000 +ellps=bessel +towgs84=674.374,15.056,405.346 +units=m",
+    new double[]{8.55, 47.37}
+);
+```
+
+### Hotine Oblique Mercator
+
+Oblique Mercator with an arbitrary central line (EPSG:3375 RSO Malaysia, Alaska zone 1). Supports the azimuth/rectified-grid-angle parameterization (variants A and B via `+no_uoff`) and the two-point form.
+
+- PROJ name: `omerc`
+- Aliases: `Hotine_Oblique_Mercator`, `Oblique_Mercator`, `Hotine_Oblique_Mercator_Azimuth_Center`, and variants
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=omerc +lat_0=4 +lonc=102.25 +alpha=323.0257964667 +k=0.99984 +x_0=804671 +y_0=0 +no_uoff +gamma=323.1301023611 +ellps=GRS80 +units=m",
+    new double[]{102.5, 4.2}
+);
+```
+
 ## Pseudocylindrical Projections
 
 ### Sinusoidal
@@ -130,6 +190,51 @@ Compromise pseudocylindrical projection designed for visual appeal.
 double[] result = Proj4.proj4(
     "+proj=longlat +datum=WGS84",
     "+proj=robin +lon_0=0 +datum=WGS84 +units=m",
+    new double[]{-77.0, 38.9}
+);
+```
+
+### Equal Earth
+
+Equal-area pseudocylindrical world projection (Savric, Patterson & Jenny, 2018). Spherical and ellipsoidal (authalic) forms.
+
+- PROJ name: `eqearth`
+- Aliases: `Equal Earth`, `Equal_Earth`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=eqearth +lon_0=0 +datum=WGS84 +units=m",
+    new double[]{-77.0, 38.9}
+);
+```
+
+### Eckert VI
+
+Equal-area pseudocylindrical world projection; always computed spherically.
+
+- PROJ name: `eck6`
+- Aliases: `Eckert_VI`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=eck6 +lon_0=0 +a=6371007 +b=6371007 +units=m",
+    new double[]{-77.0, 38.9}
+);
+```
+
+### Van der Grinten
+
+Projects the world into a circle; computed on a sphere of radius `a`.
+
+- PROJ name: `vandg`
+- Aliases: `Van_der_Grinten_I`, `VanDerGrinten`, `Van_der_Grinten`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=vandg +lon_0=0 +a=6371007 +b=6371007 +units=m",
     new double[]{-77.0, 38.9}
 );
 ```
@@ -182,6 +287,51 @@ double[] result = Proj4.proj4(
 );
 ```
 
+### Polyconic
+
+American Polyconic: each parallel has its own cone, true to scale along the central meridian and every parallel. Used by EPSG:5880 / EPSG:29101 (Brazil Polyconic).
+
+- PROJ name: `poly`
+- Aliases: `Polyconic`, `American_Polyconic`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=poly +lat_0=0 +lon_0=-54 +x_0=5000000 +y_0=10000000 +ellps=GRS80 +units=m",
+    new double[]{-47.9, -15.8}
+);
+```
+
+### Krovak
+
+Oblique conformal conic used by the Czech and Slovak national grids (EPSG:5514 / EPSG:2065, S-JTSK). Always on the Bessel 1841 ellipsoid; output is south-west oriented (negative), as in proj4js.
+
+- PROJ name: `krovak`
+- Aliases: `Krovak`, `Krovak Modified`, `Krovak (North Orientated)`, `Krovak Modified (North Orientated)`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +ellps=bessel",
+    "+proj=krovak +lat_0=49.5 +lon_0=24.8333333333 +alpha=30.2881397222 +k=0.9999 +ellps=bessel +units=m",
+    new double[]{14.42, 50.08}
+);
+```
+
+### Bonne
+
+Pseudoconic equal-area projection; true to scale along the central meridian and every parallel. Requires a non-zero standard parallel (`+lat_1`).
+
+- PROJ name: `bonne`
+- Aliases: `Bonne (Werner lat_1=90)`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=bonne +lat_1=40 +lon_0=0 +datum=WGS84 +units=m",
+    new double[]{10.0, 50.0}
+);
+```
+
 ## Azimuthal Projections
 
 ### Lambert Azimuthal Equal Area
@@ -230,6 +380,51 @@ double[] result = Proj4.proj4(
 );
 ```
 
+### Oblique Stereographic Alternative
+
+Double Stereographic (EPSG method 9809): maps the ellipsoid to a conformal sphere first, then applies the spherical stereographic. Used by EPSG:28992 (Amersfoort / RD New) and EPSG:2036 (New Brunswick). Distinct from the Snyder `stere`.
+
+- PROJ name: `sterea`
+- Aliases: `Oblique_Stereographic`, `Double_Stereographic`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=sterea +lat_0=52.1561605556 +lon_0=5.3876388889 +k=0.9999079 +x_0=155000 +y_0=463000 +ellps=bessel +towgs84=565.417,50.3319,465.552,-0.398957,0.343988,-1.8774,4.0725 +units=m",
+    new double[]{5.2, 52.25}
+);
+```
+
+### Gnomonic
+
+Azimuthal projection from the center of the sphere; every great circle maps to a straight line.
+
+- PROJ name: `gnom`
+- Aliases: `Gnomonic`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=gnom +lat_0=45 +lon_0=0 +a=6378137 +b=6378137 +units=m",
+    new double[]{5.0, 50.0}
+);
+```
+
+### Orthographic
+
+View of the globe from infinite distance; only the near hemisphere is projectable (far-side points return null).
+
+- PROJ name: `ortho`
+- Aliases: `Orthographic`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=ortho +lat_0=45 +lon_0=0 +a=6378137 +b=6378137 +units=m",
+    new double[]{5.0, 50.0}
+);
+```
+
 ## Other Projections
 
 ### Identity (Longitude/Latitude)
@@ -243,6 +438,21 @@ Passes coordinates through without projection. Used to represent geographic (unp
 Proj wgs84 = new Proj("+proj=longlat +datum=WGS84");
 ```
 
+### Geostationary Satellite
+
+The view of the Earth from a geostationary satellite. Requires the satellite height (`+h`); the `+sweep` axis (x/y) selects the instrument sweep convention. Far-side points return null.
+
+- PROJ name: `geos`
+- Aliases: `Geostationary_Satellite`, `Geostationary Satellite (Sweep X)`, `Geostationary Satellite (Sweep Y)`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=geos +h=35785831 +sweep=y +lon_0=0 +datum=WGS84 +units=m",
+    new double[]{10.0, -5.0}
+);
+```
+
 ## Projection Summary Table
 
 | Category | Projection | PROJ Name | Properties |
@@ -252,15 +462,29 @@ Proj wgs84 = new Proj("+proj=longlat +datum=WGS84");
 | Cylindrical | UTM | `utm` | Conformal |
 | Cylindrical | Equidistant Cylindrical | `eqc` | Equidistant |
 | Cylindrical | Cylindrical Equal Area | `cea` | Equal-area |
+| Cylindrical | Miller Cylindrical | `mill` | Compromise |
+| Cylindrical | Cassini-Soldner | `cass` | Equidistant (central meridian) |
+| Cylindrical | Swiss Oblique Mercator | `somerc` | Conformal |
+| Cylindrical | Hotine Oblique Mercator | `omerc` | Conformal |
 | Pseudocylindrical | Sinusoidal | `sinu` | Equal-area |
 | Pseudocylindrical | Mollweide | `moll` | Equal-area |
 | Pseudocylindrical | Robinson | `robin` | Compromise |
+| Pseudocylindrical | Equal Earth | `eqearth` | Equal-area |
+| Pseudocylindrical | Eckert VI | `eck6` | Equal-area |
+| Pseudocylindrical | Van der Grinten | `vandg` | Compromise |
 | Conic | Lambert Conformal Conic | `lcc` | Conformal |
 | Conic | Albers Equal Area | `aea` | Equal-area |
 | Conic | Equidistant Conic | `eqdc` | Equidistant |
+| Conic | Polyconic | `poly` | Compromise |
+| Conic | Krovak | `krovak` | Conformal |
+| Conic | Bonne | `bonne` | Equal-area |
 | Azimuthal | Lambert Azimuthal Equal Area | `laea` | Equal-area |
 | Azimuthal | Stereographic | `stere` | Conformal |
 | Azimuthal | Azimuthal Equidistant | `aeqd` | Equidistant |
+| Azimuthal | Oblique Stereographic Alternative | `sterea` | Conformal |
+| Azimuthal | Gnomonic | `gnom` | Gnomonic |
+| Azimuthal | Orthographic | `ortho` | Perspective |
+| Other | Geostationary Satellite | `geos` | Perspective |
 | Other | Identity | `longlat` | None |
 
 ## See Also

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -71,6 +71,11 @@ public final class CRSSerializer {
         PROJ_TO_WKT_METHOD.put("robin", "Robinson");
         PROJ_TO_WKT_METHOD.put("etmerc", "Transverse Mercator");
         PROJ_TO_WKT_METHOD.put("gstmerc", "Gauss Schreiber Transverse Mercator");
+        PROJ_TO_WKT_METHOD.put("eck6", "Eckert VI");
+        PROJ_TO_WKT_METHOD.put("eqearth", "Equal Earth");
+        PROJ_TO_WKT_METHOD.put("bonne", "Bonne");
+        // Base geos name; getWktMethodName(proj, params) selects the sweep variant.
+        PROJ_TO_WKT_METHOD.put("geos", "Geostationary Satellite (Sweep Y)");
     }
 
     // Reverse mapping: WKT/PROJJSON method name -> PROJ short name
@@ -112,6 +117,8 @@ public final class CRSSerializer {
         WKT_TO_PROJ_METHOD.put("krovak (north orientated)", "krovak");
         WKT_TO_PROJ_METHOD.put("krovak modified", "krovak");
         WKT_TO_PROJ_METHOD.put("krovak modified (north orientated)", "krovak");
+        WKT_TO_PROJ_METHOD.put("geostationary satellite (sweep x)", "geos");
+        WKT_TO_PROJ_METHOD.put("geostationary satellite", "geos");  // ESRI WKT1 name
         WKT_TO_PROJ_METHOD.put("american polyconic", "poly");
         WKT_TO_PROJ_METHOD.put("equidistant cylindrical", "eqc");
         WKT_TO_PROJ_METHOD.put("equirectangular", "eqc");
@@ -509,6 +516,11 @@ public final class CRSSerializer {
             }
         }
 
+        // Geostationary satellite height
+        if ("geos".equals(proj) && params.h != null) {
+            sb.append(",PARAMETER[\"satellite_height\",").append(params.h).append("]");
+        }
+
         // Scale factor
         if (params.k0 != 1.0) {
             sb.append(",PARAMETER[\"scale_factor\",").append(params.k0).append("]");
@@ -721,6 +733,13 @@ public final class CRSSerializer {
                 sb.append(formatAngle(params.lat2 * RAD_TO_DEG));
                 sb.append(",ANGLEUNIT[\"degree\",").append(DEG_TO_RAD_STR).append("]]");
             }
+        }
+
+        // Geostationary satellite height (name matches PROJ's WKT2 output)
+        if ("geos".equals(proj) && params.h != null) {
+            sb.append(",PARAMETER[\"Satellite Height\",");
+            sb.append(params.h);
+            sb.append(",LENGTHUNIT[\"metre\",1]]");
         }
 
         // Scale factor
@@ -959,9 +978,12 @@ public final class CRSSerializer {
                     params.lat1 * RAD_TO_DEG, "degree"));
             }
             if (params.lat2 != null) {
-                parameters.add(buildProjJsonParam("Latitude of 2nd standard parallel", 
+                parameters.add(buildProjJsonParam("Latitude of 2nd standard parallel",
                     params.lat2 * RAD_TO_DEG, "degree"));
             }
+        }
+        if ("geos".equals(proj) && params.h != null) {
+            parameters.add(buildProjJsonParam("Satellite Height", params.h, "metre"));
         }
         if (params.k0 != 1.0) {
             parameters.add(buildProjJsonParam("Scale factor at natural origin", params.k0, null));
@@ -1497,6 +1519,12 @@ public final class CRSSerializer {
             return omercIsTypeA(params)
                 ? "Hotine Oblique Mercator (variant A)"
                 : "Hotine Oblique Mercator (variant B)";
+        }
+        if ("geos".equals(proj)) {
+            // PROJ encodes the sweep axis in the method name.
+            return "x".equals(params.sweep)
+                ? "Geostationary Satellite (Sweep X)"
+                : "Geostationary Satellite (Sweep Y)";
         }
         return getWktMethodName(proj);
     }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -489,6 +489,9 @@ public final class ProjJsonTransformer {
             case "angle_from_rectified_to_skew_grid":
                 def.setRectifiedGridAngle(value);
                 break;
+            case "satellite_height":
+                def.setH(value);
+                break;
             default:
                 // Unknown parameters are ignored
                 break;

--- a/src/main/java/org/datasyslab/proj4sedona/parser/WktUtils.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/WktUtils.java
@@ -401,6 +401,8 @@ public final class WktUtils {
             {"lat2", "standard_parallel_2", (Function<Double, Double>) WktUtils::d2r},
             {"azimuth", "Azimuth", null},
             {"alpha", "azimuth", (Function<Double, Double>) WktUtils::d2r},
+            {"h", "satellite_height", null},
+            {"h", "Satellite_Height", null},
             {"srsCode", "name", null}
         };
 
@@ -477,6 +479,7 @@ public final class WktUtils {
         setDoubleIfPresent(wkt, "alpha", def::setAlpha);
         setDoubleIfPresent(wkt, "longc", def::setLongc);
         setDoubleIfPresent(wkt, "rectified_grid_angle", def::setRectifiedGridAngle);
+        setDoubleIfPresent(wkt, "h", def::setH);
 
         // Scale and offsets
         setDoubleIfPresent(wkt, "k0", def::setK0);

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
@@ -19,8 +19,11 @@ import org.datasyslab.proj4sedona.core.Point;
  */
 public class Geostationary implements Projection {
 
+    // The sweep-variant names are PROJ's WKT2/PROJJSON method names (PROJ encodes the
+    // sweep axis in the method name); registered so serialized CRSs re-import.
     private static final String[] NAMES = {
-        "Geostationary Satellite View", "Geostationary_Satellite", "geos"
+        "Geostationary Satellite View", "Geostationary_Satellite",
+        "Geostationary Satellite (Sweep X)", "Geostationary Satellite (Sweep Y)", "geos"
     };
 
     private double a, es, long0, x0, y0;
@@ -39,7 +42,11 @@ public class Geostationary implements Projection {
         this.x0 = params.x0;
         this.y0 = params.y0;
 
-        this.flipAxis = "x".equals(params.sweep);
+        // Sweep comes from +sweep, or — for CRSs parsed from WKT2/PROJJSON, where PROJ
+        // encodes it in the method name — from the projection name.
+        this.flipAxis = "x".equals(params.sweep)
+            || (params.sweep == null && params.projName != null
+                && params.projName.toLowerCase().contains("sweep x"));
         if (params.h == null) {
             throw new IllegalArgumentException("Geostationary projection requires satellite height (+h)");
         }

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Geostationary.java
@@ -47,6 +47,9 @@ public class Geostationary implements Projection {
         this.flipAxis = "x".equals(params.sweep)
             || (params.sweep == null && params.projName != null
                 && params.projName.toLowerCase().contains("sweep x"));
+        // Persist the resolved sweep so re-serialization keeps it (otherwise a CRS
+        // parsed from a Sweep X method name would re-export as the default Sweep Y).
+        params.sweep = flipAxis ? "x" : "y";
         if (params.h == null) {
             throw new IllegalArgumentException("Geostationary projection requires satellite height (+h)");
         }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1102,6 +1102,28 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("Issue #83: geos Sweep X survives a serialize -> parse -> re-serialize chain")
+    void testGeosSweepXSurvivesReserialization() {
+        // The sweep axis lives only in the method name in WKT2/PROJJSON; the resolved
+        // sweep must be persisted on parse so the second serialization keeps Sweep X.
+        Proj original = new Proj("+proj=geos +h=35785831 +sweep=x +lon_0=0 +ellps=WGS84 +units=m +no_defs");
+        Proj hop1 = new Proj(CRSSerializer.toWkt2(original));
+        assertTrue(CRSSerializer.toWkt2(hop1).contains("(Sweep X)"),
+            "second WKT2 serialization keeps Sweep X");
+        assertTrue(CRSSerializer.toProjString(hop1).contains("+sweep=x"),
+            "proj string re-export keeps +sweep=x");
+
+        double lon = 10 * Math.PI / 180, lat = -5 * Math.PI / 180;
+        org.datasyslab.proj4sedona.core.Point want =
+            original.forward(new org.datasyslab.proj4sedona.core.Point(lon, lat));
+        Proj hop2 = new Proj(CRSSerializer.toWkt2(hop1));
+        org.datasyslab.proj4sedona.core.Point got =
+            hop2.forward(new org.datasyslab.proj4sedona.core.Point(lon, lat));
+        assertEquals(want.x, got.x, 0.01, "easting after two hops");
+        assertEquals(want.y, got.y, 0.01, "northing after two hops");
+    }
+
+    @Test
     @DisplayName("Issue #83: external WKT2 method name re-exports to a valid proj string")
     void testExternalWkt2MethodNameReExport() {
         // A CRS whose projName is the WKT2 method name must re-export with the PROJ

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1056,4 +1056,59 @@ class CRSSerializerTest {
         assertEquals(-71 * Math.PI / 180, reimported.getParams().latTs, 1e-10,
                 "latTs should be preserved through WKT2 round-trip");
     }
+
+    // ==================== Issue #83: standard WKT method names ====================
+
+    @Test
+    @DisplayName("Issue #83: eck6/eqearth/bonne/geos serialize with standard method names")
+    void testStandardWktMethodNames() {
+        assertTrue(CRSSerializer.toWkt2(new Proj(
+            "+proj=eck6 +lon_0=0 +a=6371007 +b=6371007 +units=m +no_defs"))
+            .contains("METHOD[\"Eckert VI\"]"), "eck6 method name");
+        assertTrue(CRSSerializer.toWkt2(new Proj(
+            "+proj=eqearth +lon_0=0 +datum=WGS84 +units=m +no_defs"))
+            .contains("METHOD[\"Equal Earth\"]"), "eqearth method name");
+        assertTrue(CRSSerializer.toWkt2(new Proj(
+            "+proj=bonne +lat_1=40 +lon_0=0 +datum=WGS84 +units=m +no_defs"))
+            .contains("METHOD[\"Bonne\"]"), "bonne method name");
+        assertTrue(CRSSerializer.toWkt2(new Proj(
+            "+proj=geos +h=35785831 +sweep=y +lon_0=0 +datum=WGS84 +units=m +no_defs"))
+            .contains("METHOD[\"Geostationary Satellite (Sweep Y)\"]"), "geos sweep-y method name");
+        assertTrue(CRSSerializer.toWkt2(new Proj(
+            "+proj=geos +h=35785831 +sweep=x +lon_0=0 +datum=WGS84 +units=m +no_defs"))
+            .contains("METHOD[\"Geostationary Satellite (Sweep X)\"]"), "geos sweep-x method name");
+    }
+
+    @Test
+    @DisplayName("Issue #83: geos round-trips through WKT2/PROJJSON (Satellite Height + sweep)")
+    void testGeosWktRoundTrip() {
+        for (String sweep : new String[] {"x", "y"}) {
+            Proj original = new Proj("+proj=geos +h=35785831 +sweep=" + sweep
+                + " +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +units=m +no_defs");
+            double lon = 10 * Math.PI / 180, lat = -5 * Math.PI / 180;
+            org.datasyslab.proj4sedona.core.Point want =
+                original.forward(new org.datasyslab.proj4sedona.core.Point(lon, lat));
+            for (String serialized : new String[] {
+                    CRSSerializer.toWkt1(original),
+                    CRSSerializer.toWkt2(original),
+                    CRSSerializer.toProjJson(original)}) {
+                Proj reimported = new Proj(serialized);
+                org.datasyslab.proj4sedona.core.Point got =
+                    reimported.forward(new org.datasyslab.proj4sedona.core.Point(lon, lat));
+                assertEquals(want.x, got.x, 0.01, "easting (sweep " + sweep + ") after re-import");
+                assertEquals(want.y, got.y, 0.01, "northing (sweep " + sweep + ") after re-import");
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Issue #83: external WKT2 method name re-exports to a valid proj string")
+    void testExternalWkt2MethodNameReExport() {
+        // A CRS whose projName is the WKT2 method name must re-export with the PROJ
+        // short code, not the method name (e.g. not "+proj=Eckert VI").
+        Proj ext = new Proj(CRSSerializer.toWkt2(
+            new Proj("+proj=eck6 +lon_0=0 +a=6371007 +b=6371007 +no_defs")));
+        String projString = CRSSerializer.toProjString(ext);
+        assertTrue(projString.contains("+proj=eck6"), "re-export uses short code: " + projString);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #83. The serializer emitted raw PROJ short codes (`PROJECTION["eck6"]`,
`METHOD["eck6"]`, PROJJSON `method: "eck6"`) for the four projections missing from
`PROJ_TO_WKT_METHOD`. External tools expect the standard method names.

## Changes

- **Standard method names** (verified against pyproj/PROJ 9.5.1 output, not guessed):
  - `eck6` → `Eckert VI`
  - `eqearth` → `Equal Earth`
  - `bonne` → `Bonne`
  - `geos` → `Geostationary Satellite (Sweep X)` / `(Sweep Y)` — PROJ encodes the
    sweep axis in the method name, so `getWktMethodName` selects the variant from
    params (same pattern as the Mercator/omerc variants).
- The auto-built reverse map also fixes **external-WKT2 → proj string re-export**
  (previously produced the invalid `+proj=Eckert VI`).

## Bonus: geos now fully round-trips through WKT2/PROJJSON

This closes the limitation documented in the geos port (#81):
- Writers emit the **`Satellite Height`** parameter (PROJ's WKT2 name) in
  WKT1/WKT2/PROJJSON.
- Parsers map it back to `h` (`satellite_height` in ProjJSON/WKT paths).
- The sweep-variant method names are registered as `Geostationary` aliases, and
  `init()` resolves the sweep axis from the method name when `+sweep` is absent
  (it only exists in the method name in WKT2/PROJJSON).

Verified: geos round-trips through **all four formats** for both sweeps with
identical coordinates.

## Docs

- README: stale "15/21 projections" lists refreshed to the current 30.
- `docs/projections.md`: added the 15 missing projections (sections in the
  existing format + summary-table rows).

## Tests

Standard-method-name assertions for all four, geos WKT1/WKT2/PROJJSON round-trips
for both sweeps, and an external-WKT2 re-export check. Full suite: 763 tests pass.
