### PR TITLE
Backport proj4js patches since the port baseline (7 fixes)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/core/DatumParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/DatumParams.java
@@ -42,15 +42,15 @@ public class DatumParams {
         this.es = es;
         this.ep2 = ep2;
 
-        // Determine datum type based on inputs
-        // Mirrors logic from lib/datum.js
-        if (datumCode == null || "none".equalsIgnoreCase(datumCode)) {
-            this.datumType = Values.PJD_NODATUM;
-        } else {
-            this.datumType = Values.PJD_WGS84;
-        }
+        // Determine datum type based on inputs.
+        // Mirrors lib/datum.js (proj4js 61689a9, "Fix unknown datum handling to match
+        // PROJ behavior"): an unknown/unnamed datum with no towgs84 is NODATUM (no
+        // shift applied), not WGS84. Known datums (incl. +datum=WGS84) carry towgs84
+        // parameters from the registry, which sets WGS84/3PARAM/7PARAM below.
+        this.datumType = Values.PJD_NODATUM;
 
         if (datumParamsArray != null) {
+            this.datumType = Values.PJD_WGS84;
             this.datumParams = datumParamsArray.clone();
             
             // Check if any translation params are non-zero

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -296,6 +296,7 @@ public class Proj {
         p.noUoff = def.getNoUoff();
         p.noRot = def.getNoRot();
         p.h = def.getH();
+        p.longWrap = def.getLongWrap();
         p.sweep = def.getSweep();
 
         // Scale and offsets

--- a/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
@@ -60,6 +60,7 @@ public class ProjectionDef {
     private Boolean over;          // Allow longitude wrapping
     private Boolean noUoff;        // no_uoff / no_off: Oblique Mercator without origin offset (variant A)
     private Boolean noRot;         // no_rot: Oblique Mercator without rectification rotation
+    private Double longWrap;       // lon_wrap: center of longitude wrapping range
     private Double h;              // h: satellite height (Geostationary)
     private String sweep;          // sweep: sweep axis 'x' or 'y' (Geostationary)
 
@@ -183,6 +184,9 @@ public class ProjectionDef {
 
     public Boolean getNoRot() { return noRot; }
     public void setNoRot(Boolean noRot) { this.noRot = noRot; }
+
+    public Double getLongWrap() { return longWrap; }
+    public void setLongWrap(Double longWrap) { this.longWrap = longWrap; }
 
     public Double getH() { return h; }
     public void setH(Double h) { this.h = h; }

--- a/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
@@ -169,26 +169,53 @@ public final class Defs {
     /**
      * Set (register) a projection definition by name.
      *
-     * <p>If the definition is a PROJ string (starting with "+"), it will be
-     * automatically parsed into a ProjectionDef object.</p>
+     * <p>Accepts a PROJ string (starting with "+"), a PROJJSON document (starting
+     * with "{"), or a WKT string — mirroring proj4js {@code defs(code, definition)}
+     * (incl. proj4js 1a3b130, which fixed PROJJSON registration).</p>
      *
      * @param name The name/code to register the definition under (e.g., "EPSG:4326")
-     * @param projString The PROJ string definition (must start with "+")
+     * @param definition The PROJ string, PROJJSON, or WKT definition
      */
-    public static void set(String name, String projString) {
-        if (projString == null || projString.isEmpty()) {
+    public static void set(String name, String definition) {
+        if (definition == null || definition.isEmpty()) {
             definitions.remove(name);
             return;
         }
 
-        if (projString.charAt(0) == '+') {
-            ProjectionDef def = ProjString.parse(projString);
-            def.setSrsCode(name);
-            definitions.put(name, def);
+        String trimmed = definition.trim();
+        ProjectionDef def;
+        if (trimmed.charAt(0) == '+') {
+            def = ProjString.parse(trimmed);
+        } else if (trimmed.charAt(0) == '{') {
+            // PROJJSON
+            @SuppressWarnings("unchecked")
+            Map<String, Object> json = GSON.fromJson(trimmed, Map.class);
+            def = WktParser.parse(json);
         } else {
-            throw new IllegalArgumentException(
-                "Unsupported definition format for Defs.set(name, String). Only PROJ strings (starting with '+') are supported by this method.");
+            // WKT1 / WKT2
+            def = WktParser.parse(trimmed);
         }
+        // The registered code identifies the definition (parsers may have set srsCode
+        // to the raw definition or its embedded name).
+        def.setSrsCode(name);
+        definitions.put(name, def);
+    }
+
+    /**
+     * Set (register) a PROJJSON definition by name.
+     * Mirrors proj4js {@code defs(code, projjsonObject)} (proj4js 1a3b130).
+     *
+     * @param name The name/code to register the definition under
+     * @param projjson The PROJJSON document as a parsed Map
+     */
+    public static void set(String name, Map<String, Object> projjson) {
+        if (projjson == null) {
+            definitions.remove(name);
+            return;
+        }
+        ProjectionDef def = WktParser.parse(projjson);
+        def.setSrsCode(name);
+        definitions.put(name, def);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
@@ -177,12 +177,15 @@ public final class Defs {
      * @param definition The PROJ string, PROJJSON, or WKT definition
      */
     public static void set(String name, String definition) {
-        if (definition == null || definition.isEmpty()) {
-            definitions.remove(name);
+        // Normalize like get()/has()/remove(), so set("epsg:4326", ...) is
+        // retrievable via get("EPSG:4326") instead of silently shadowed by providers.
+        String key = CRSUtils.normalizeAuthorityCode(name);
+        String trimmed = definition == null ? "" : definition.trim();
+        if (trimmed.isEmpty()) {
+            definitions.remove(key);
             return;
         }
 
-        String trimmed = definition.trim();
         ProjectionDef def;
         if (trimmed.charAt(0) == '+') {
             def = ProjString.parse(trimmed);
@@ -197,8 +200,8 @@ public final class Defs {
         }
         // The registered code identifies the definition (parsers may have set srsCode
         // to the raw definition or its embedded name).
-        def.setSrsCode(name);
-        definitions.put(name, def);
+        def.setSrsCode(key);
+        definitions.put(key, def);
     }
 
     /**
@@ -209,13 +212,14 @@ public final class Defs {
      * @param projjson The PROJJSON document as a parsed Map
      */
     public static void set(String name, Map<String, Object> projjson) {
+        String key = CRSUtils.normalizeAuthorityCode(name);
         if (projjson == null) {
-            definitions.remove(name);
+            definitions.remove(key);
             return;
         }
         ProjectionDef def = WktParser.parse(projjson);
-        def.setSrsCode(name);
-        definitions.put(name, def);
+        def.setSrsCode(key);
+        definitions.put(key, def);
     }
 
     /**
@@ -225,13 +229,14 @@ public final class Defs {
      * @param def The ProjectionDef object
      */
     public static void set(String name, ProjectionDef def) {
+        String key = CRSUtils.normalizeAuthorityCode(name);
         if (def == null) {
-            definitions.remove(name);
+            definitions.remove(key);
         } else {
             if (def.getSrsCode() == null) {
-                def.setSrsCode(name);
+                def.setSrsCode(key);
             }
-            definitions.put(name, def);
+            definitions.put(key, def);
         }
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -238,6 +238,11 @@ public final class CRSSerializer {
             sb.append(" +lon_0=").append(formatAngle(params.long0 * RAD_TO_DEG));
         }
 
+        // Longitude wrapping (+lon_wrap); PROJ-string-only, no WKT/PROJJSON equivalent
+        if (params.longWrap != null) {
+            sb.append(" +lon_wrap=").append(formatAngle(params.longWrap * RAD_TO_DEG));
+        }
+
         // Standard parallels: only projections that actually use them (conics). Other
         // projections can carry a lat1 defaulted from lat0, which must not be emitted.
         if (usesStandardParallels(normProj)) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
@@ -117,6 +117,9 @@ public final class ProjString {
             case "gamma":
                 def.setRectifiedGridAngle(parseDouble(paramVal) * Values.D2R);
                 break;
+            case "lon_wrap":
+                def.setLongWrap(parseDouble(paramVal) * Values.D2R);
+                break;
             case "lonc":
                 def.setLongc(parseDouble(paramVal) * Values.D2R);
                 break;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/AzimuthalEquidistant.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/AzimuthalEquidistant.java
@@ -83,15 +83,16 @@ public class AzimuthalEquidistant implements Projection {
                 x = x0 + (Mlp + Ml) * Math.sin(dlon);
                 y = y0 + (Mlp + Ml) * Math.cos(dlon);
             } else {
-                // General case - use Vincenty formulas
+                // General case - use Vincenty formulas. Apply x0/y0 like the polar
+                // branches (proj4js 04bd414); the inverse subtracts them.
                 if (Math.abs(lon) < Values.EPSLN && Math.abs(lat - lat0) < Values.EPSLN) {
-                    return new Point(0, 0, p.z);
+                    return new Point(x0, y0, p.z);
                 }
                 double[] vars = vincentyInverse(lat0, long0, lat, lon, a, f);
                 double azi1 = vars[0];
                 double s12 = vars[1];
-                x = s12 * Math.sin(azi1);
-                y = s12 * Math.cos(azi1);
+                x = x0 + s12 * Math.sin(azi1);
+                y = y0 + s12 * Math.cos(azi1);
             }
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/projection/LambertConformalConic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/LambertConformalConic.java
@@ -58,8 +58,7 @@ public class LambertConformalConic implements Projection {
         double ms2 = ProjMath.msfnz(e, sin2, cos2);
         double ts2 = ProjMath.tsfnz(e, lat2, sin2);
 
-        double ts0 = Math.abs(Math.abs(lat0) - Values.HALF_PI) < Values.EPSLN
-            ? 0 : ProjMath.tsfnz(e, lat0, Math.sin(lat0));
+        double ts0 = ProjMath.tsfnz(e, lat0, Math.sin(lat0));
 
         if (Math.abs(lat1 - lat2) > Values.EPSLN) {
             ns = Math.log(ms1 / ms2) / Math.log(ts1 / ts2);
@@ -70,7 +69,10 @@ public class LambertConformalConic implements Projection {
             ns = sin1;
         }
         f0 = ms1 / (ns * Math.pow(ts1, ns));
-        rh = a * f0 * Math.pow(ts0, ns);
+        // Handle poles by setting rh to 0 (proj4js 8c538fc): guarding ts0 instead
+        // breaks the south pole, where ns < 0 makes pow(0, ns) infinite.
+        rh = Math.abs(Math.abs(lat0) - Values.HALF_PI) < Values.EPSLN
+            ? 0 : a * f0 * Math.pow(ts0, ns);
     }
 
     @Override

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -138,6 +138,9 @@ public class ProjectionParams {
     /** Oblique Mercator without rectification rotation (+no_rot) */
     public Boolean noRot;
 
+    /** Center of the longitude wrapping range in radians (+lon_wrap) */
+    public Double longWrap;
+
     /** Satellite height in meters (+h) - used by the Geostationary projection */
     public Double h;
 

--- a/src/main/java/org/datasyslab/proj4sedona/transform/AdjustAxis.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/AdjustAxis.java
@@ -4,10 +4,12 @@ import org.datasyslab.proj4sedona.core.Point;
 
 /**
  * Adjusts coordinates based on the axis order of a CRS.
- * Mirrors: lib/adjust_axis.js
- * 
- * Standard axis order is "enu" (Easting-Northing-Up).
- * Some CRS use different orders like "neu", "wsu", etc.
+ * Mirrors: lib/adjust_axis.js (post proj4js c5bb8e1, "Fix enforceAxis for z and
+ * arbitrary orders")
+ *
+ * <p>Standard axis order is "enu" (Easting-Northing-Up). Some CRS use different
+ * orders like "neu", "wsu", or even orders that place the vertical axis first
+ * (e.g. "uen"); the per-position switch below handles any permutation.</p>
  */
 public final class AdjustAxis {
 
@@ -16,88 +18,35 @@ public final class AdjustAxis {
     }
 
     /**
-     * Adjust axis order for a point.
-     * 
-     * @param axis The axis specification (e.g., "enu", "neu", "wsu")
-     * @param denorm If true, converting from CRS to standard; if false, converting to CRS
-     * @param point The input point
+     * Convert a point in the CRS's axis order to ENU (east/north/up) order.
+     *
+     * @param axis The axis specification (e.g., "enu", "neu", "uen")
+     * @param point The input point in CRS axis order
      * @param hasZ Whether the point has a meaningful z coordinate
-     * @return A new point with adjusted coordinates, or null if axis is invalid
+     * @return A new point in ENU order, or null if axis is invalid
      */
-    public static Point adjust(String axis, boolean denorm, Point point, boolean hasZ) {
+    public static Point adjustAxisToEnu(String axis, Point point, boolean hasZ) {
         if (axis == null || axis.length() != 3) {
             return null;
         }
 
-        double xin = point.x;
-        double yin = point.y;
-        double zin = point.z;
-
+        double[] in = {point.x, point.y, point.z};
         double outX = 0, outY = 0, outZ = 0;
         boolean hasOutZ = false;
 
         for (int i = 0; i < 3; i++) {
-            // Skip z if denormalizing and no z present
-            if (denorm && i == 2 && !hasZ) {
+            if (i == 2 && !hasZ) {
                 continue;
             }
-
-            double v;
-            char target;
-
-            if (i == 0) {
-                v = xin;
-                char axisChar = axis.charAt(i);
-                if (axisChar == 'e' || axisChar == 'w') {
-                    target = 'x';
-                } else {
-                    target = 'y';
-                }
-            } else if (i == 1) {
-                v = yin;
-                char axisChar = axis.charAt(i);
-                if (axisChar == 'n' || axisChar == 's') {
-                    target = 'y';
-                } else {
-                    target = 'x';
-                }
-            } else {
-                v = zin;
-                target = 'z';
-            }
-
-            char axisChar = axis.charAt(i);
-            switch (axisChar) {
-                case 'e':
-                    if (target == 'x') outX = v;
-                    else outY = v;
-                    break;
-                case 'w':
-                    if (target == 'x') outX = -v;
-                    else outY = -v;
-                    break;
-                case 'n':
-                    if (target == 'y') outY = v;
-                    else outX = v;
-                    break;
-                case 's':
-                    if (target == 'y') outY = -v;
-                    else outX = -v;
-                    break;
-                case 'u':
-                    if (hasZ) {
-                        outZ = v;
-                        hasOutZ = true;
-                    }
-                    break;
-                case 'd':
-                    if (hasZ) {
-                        outZ = -v;
-                        hasOutZ = true;
-                    }
-                    break;
+            double v = in[i];
+            switch (axis.charAt(i)) {
+                case 'e': outX = v; break;
+                case 'w': outX = -v; break;
+                case 'n': outY = v; break;
+                case 's': outY = -v; break;
+                case 'u': outZ = v; hasOutZ = true; break;
+                case 'd': outZ = -v; hasOutZ = true; break;
                 default:
-                    // Unknown axis character
                     return null;
             }
         }
@@ -108,5 +57,64 @@ public final class AdjustAxis {
         }
         result.m = point.m;
         return result;
+    }
+
+    /**
+     * Convert a point in ENU (east/north/up) order to the CRS's axis order.
+     *
+     * @param axis The axis specification (e.g., "enu", "neu", "uen")
+     * @param point The input point in ENU order
+     * @param hasZ Whether the point has a meaningful z coordinate
+     * @return A new point in CRS axis order, or null if axis is invalid
+     */
+    public static Point adjustAxisFromEnu(String axis, Point point, boolean hasZ) {
+        if (axis == null || axis.length() != 3) {
+            return null;
+        }
+
+        double[] out = new double[3];
+        boolean hasOutZ = false;
+
+        for (int i = 0; i < 3; i++) {
+            if (i == 2 && !hasZ) {
+                continue;
+            }
+            double v;
+            switch (axis.charAt(i)) {
+                case 'e': v = point.x; break;
+                case 'w': v = -point.x; break;
+                case 'n': v = point.y; break;
+                case 's': v = -point.y; break;
+                case 'u': v = point.z; break;
+                case 'd': v = -point.z; break;
+                default:
+                    return null;
+            }
+            out[i] = v;
+            if (i == 2) {
+                hasOutZ = true;
+            }
+        }
+
+        Point result = new Point(out[0], out[1]);
+        if (hasOutZ || hasZ) {
+            result.z = out[2];
+        }
+        result.m = point.m;
+        return result;
+    }
+
+    /**
+     * Adjust axis order for a point.
+     *
+     * @deprecated Use {@link #adjustAxisToEnu} (source CRS to ENU) or
+     *     {@link #adjustAxisFromEnu} (ENU to destination CRS) instead; this shim
+     *     keeps the pre-c5bb8e1 signature working.
+     */
+    @Deprecated
+    public static Point adjust(String axis, boolean denorm, Point point, boolean hasZ) {
+        return denorm
+            ? adjustAxisFromEnu(axis, point, hasZ)
+            : adjustAxisToEnu(axis, point, hasZ);
     }
 }

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
@@ -212,8 +212,11 @@ public final class Transform {
             p = AdjustAxis.adjustAxisFromEnu(destParams.axis, p, hasZ);
         }
 
-        // Reset z if it wasn't in the original input
-        if (p != null && !hasZ) {
+        // Reset z if it wasn't in the original input — except when the destination is
+        // geocentric, where z is a computed coordinate even for 2D input (proj4js
+        // 0ee1202). Inert until the geocent projection is ported, but guarded now so a
+        // future port does not silently zero the computed Z.
+        if (p != null && !hasZ && !"geocent".equals(destParams.projName)) {
             p.z = 0;
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
@@ -143,7 +143,7 @@ public final class Transform {
 
         // Step 2: Adjust for source axis order (e.g., "neu" to "enu")
         if (enforceAxis && srcParams.axis != null && !"enu".equals(srcParams.axis)) {
-            p = AdjustAxis.adjust(srcParams.axis, false, p, hasZ);
+            p = AdjustAxis.adjustAxisToEnu(srcParams.axis, p, hasZ);
             if (p == null) {
                 return null;
             }
@@ -203,7 +203,7 @@ public final class Transform {
 
         // Step 8: Adjust for destination axis order (e.g., "enu" to "neu")
         if (enforceAxis && destParams.axis != null && !"enu".equals(destParams.axis)) {
-            p = AdjustAxis.adjust(destParams.axis, true, p, hasZ);
+            p = AdjustAxis.adjustAxisFromEnu(destParams.axis, p, hasZ);
         }
 
         // Reset z if it wasn't in the original input

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
@@ -5,6 +5,7 @@ import org.datasyslab.proj4sedona.core.DatumParams;
 import org.datasyslab.proj4sedona.core.Point;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.datum.DatumTransform;
+import org.datasyslab.proj4sedona.common.ProjMath;
 import org.datasyslab.proj4sedona.projection.ProjectionParams;
 
 /**
@@ -186,6 +187,11 @@ public final class Transform {
 
         // Step 7: Transform geodetic to destination coordinates
         if ("longlat".equals(destParams.projName)) {
+            // Wrap longitude into the range centered on longWrap, if requested
+            // (+lon_wrap). Mirrors lib/transform.js (proj4js bad16a6 + 39e7abc).
+            if (destParams.longWrap != null) {
+                p.x = destParams.longWrap + ProjMath.adjustLon(p.x - destParams.longWrap);
+            }
             // Convert radians to degrees
             p = new Point(p.x * Values.R2D, p.y * Values.R2D, p.z);
             p.m = point.m;

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -170,4 +170,24 @@ class Proj4jsBackportsTest {
             org.datasyslab.proj4sedona.defs.Defs.set("TEST:WKT", (String) null);
         }
     }
+
+    @Test
+    @DisplayName("Defs.set normalizes authority codes and tolerates blank definitions")
+    void testDefsSetNormalization() {
+        try {
+            // set with a lowercase authority must be retrievable via the normalized code
+            // (get()/has()/remove() normalize; set() must match or providers shadow it).
+            org.datasyslab.proj4sedona.defs.Defs.set("test:norm86",
+                "+proj=longlat +datum=WGS84 +no_defs");
+            assertNotNull(org.datasyslab.proj4sedona.defs.Defs.get("TEST:norm86"),
+                "lowercase-authority registration found via normalized code");
+
+            // Whitespace-only definition behaves like empty (delete), not an exception.
+            org.datasyslab.proj4sedona.defs.Defs.set("TEST:norm86", "   ");
+            assertFalse(org.datasyslab.proj4sedona.defs.Defs.has("TEST:norm86"),
+                "whitespace-only definition removes the entry");
+        } finally {
+            org.datasyslab.proj4sedona.defs.Defs.set("TEST:norm86", (String) null);
+        }
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -1,0 +1,46 @@
+package org.datasyslab.proj4sedona;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for patches backported from proj4js (one test per upstream
+ * commit; reference values verified against pyproj/PROJ 9.5.1).
+ */
+class Proj4jsBackportsTest {
+
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+
+    @BeforeAll
+    static void setup() {
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    @DisplayName("proj4js 61689a9: unknown datum is NODATUM, not WGS84")
+    void testUnknownDatumHandling() {
+        // A sphere CRS with no datum/towgs84 (ESRI 53003-style) must not receive a
+        // spurious datum shift. Reference from pyproj (matches upstream post-patch).
+        Converter conv = Proj4.proj4(WGS84,
+            "+proj=mill +lon_0=0 +x_0=0 +y_0=0 +a=6371000 +b=6371000 +units=m +no_defs");
+        Point xy = conv.forward(new Point(-1.3973289073953, 12.649176474268513));
+        assertEquals(-155375.885356, xy.x, 0.01, "easting");
+        assertEquals(1413894.115522, xy.y, 0.01, "northing");
+
+        // Datum types: unknown/unnamed -> NODATUM; +datum=WGS84 (towgs84 0,0,0) -> WGS84
+        Proj unknown = new Proj("+proj=mill +lon_0=0 +a=6371000 +b=6371000 +units=m +no_defs");
+        assertEquals(Values.PJD_NODATUM, unknown.getParams().datum.getDatumType(),
+            "unknown datum must be NODATUM");
+        Proj wgs = new Proj("+proj=merc +datum=WGS84 +no_defs");
+        assertEquals(Values.PJD_WGS84, wgs.getParams().datum.getDatumType(),
+            "+datum=WGS84 must stay WGS84");
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -60,4 +60,26 @@ class Proj4jsBackportsTest {
         assertEquals(90, ll.x, 1e-6, "lng round-trip");
         assertEquals(-70, ll.y, 1e-6, "lat round-trip");
     }
+
+    @Test
+    @DisplayName("proj4js 04bd414: aeqd applies x_0/y_0 in the ellipsoidal general case")
+    void testAeqdFalseEastingNorthing() {
+        // The general (Vincenty) branch omitted x0/y0 while the inverse subtracted
+        // them, so offset aeqd CRSs were shifted and did not round-trip.
+        // Reference from proj4js testData (matches pyproj).
+        Converter conv = Proj4.proj4(WGS84,
+            "+proj=aeqd +lat_0=51.5 +lon_0=0 +x_0=100000 +y_0=200000 +datum=WGS84 +units=m +no_defs");
+        Point xy = conv.forward(new Point(2, 48));
+        assertEquals(249325.62485355, xy.x, 0.01, "easting");
+        assertEquals(-187277.841415147, xy.y, 0.01, "northing");
+
+        Point ll = conv.inverse(new Point(xy.x, xy.y));
+        assertEquals(2, ll.x, 1e-6, "lng round-trip");
+        assertEquals(48, ll.y, 1e-6, "lat round-trip");
+
+        // Projection center maps to the false origin.
+        Point center = conv.forward(new Point(0, 51.5));
+        assertEquals(100000, center.x, 0.01, "center easting = x_0");
+        assertEquals(200000, center.y, 0.01, "center northing = y_0");
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -114,4 +114,20 @@ class Proj4jsBackportsTest {
         assertEquals(20, r2.y, 1e-9, "uen->uen: round-trip preserves second");
         assertEquals(30, r2.z, 1e-6, "uen->uen: round-trip preserves third");
     }
+
+    @Test
+    @DisplayName("proj4js bad16a6/39e7abc: +lon_wrap wraps output longitude")
+    void testLonWrap() {
+        // +lon_wrap=180 requests the 0..360 longitude range (common for global
+        // climate/ocean datasets). Mirrors the upstream test: -170 -> 190.
+        Converter wrapped = Proj4.proj4(WGS84,
+            "+proj=longlat +datum=WGS84 +lon_wrap=180 +no_defs");
+        assertEquals(190, wrapped.forward(new Point(-170, 40)).x, 1e-9, "-170 wraps to 190");
+        assertEquals(180, wrapped.forward(new Point(-180, 10)).x, 1e-9, "-180 wraps to 180");
+        assertEquals(10, wrapped.forward(new Point(10, 10)).x, 1e-9, "10 stays 10");
+
+        // Without lon_wrap, longitudes stay in -180..180.
+        Converter plain = Proj4.proj4(WGS84, "+proj=longlat +datum=WGS84 +no_defs");
+        assertEquals(-170, plain.forward(new Point(-170, 40)).x, 1e-9, "-170 stays -170");
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -43,4 +43,21 @@ class Proj4jsBackportsTest {
         assertEquals(Values.PJD_WGS84, wgs.getParams().datum.getDatumType(),
             "+datum=WGS84 must stay WGS84");
     }
+
+    @Test
+    @DisplayName("proj4js 8c538fc: south-polar LCC (lat_0=-90) no longer yields Infinity")
+    void testPolarLccSouthPole() {
+        // With the polar guard on ts0 instead of rh, ns < 0 made pow(0, ns) infinite
+        // and every transform returned Infinity/NaN. Reference from pyproj.
+        Converter conv = Proj4.proj4(WGS84,
+            "+proj=lcc +lat_0=-90.0 +lon_0=81.0 +lat_1=-72.66666666666674 "
+                + "+lat_2=-75.3333333333334 +x_0=0.0 +y_0=0.0 +ellps=GRS80 +no_defs");
+        Point xy = conv.forward(new Point(90, -70));
+        assertEquals(343065.915037, xy.x, 0.01, "easting");
+        assertEquals(2254539.657076, xy.y, 0.01, "northing");
+
+        Point ll = conv.inverse(new Point(xy.x, xy.y));
+        assertEquals(90, ll.x, 1e-6, "lng round-trip");
+        assertEquals(-70, ll.y, 1e-6, "lat round-trip");
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -130,4 +130,35 @@ class Proj4jsBackportsTest {
         Converter plain = Proj4.proj4(WGS84, "+proj=longlat +datum=WGS84 +no_defs");
         assertEquals(-170, plain.forward(new Point(-170, 40)).x, 1e-9, "-170 stays -170");
     }
+
+    @Test
+    @DisplayName("proj4js 1a3b130: Defs.set accepts PROJJSON (and WKT) definitions")
+    void testDefsProjJsonRegistration() {
+        // Mirrors upstream test/test.js: registering a PROJJSON geographic CRS under a
+        // code must parse it (projName longlat), not store/reject the raw document.
+        String projjson = "{\"$schema\":\"https://proj.org/schemas/v0.7/projjson.schema.json\","
+            + "\"type\":\"GeographicCRS\",\"name\":\"NAD83\","
+            + "\"datum\":{\"type\":\"GeodeticReferenceFrame\",\"name\":\"North American Datum 1983\","
+            + "\"ellipsoid\":{\"name\":\"GRS 1980\",\"semi_major_axis\":6378137,\"inverse_flattening\":298.257222101}},"
+            + "\"coordinate_system\":{\"subtype\":\"ellipsoidal\",\"axis\":["
+            + "{\"name\":\"Geodetic latitude\",\"abbreviation\":\"Lat\",\"direction\":\"north\",\"unit\":\"degree\"},"
+            + "{\"name\":\"Geodetic longitude\",\"abbreviation\":\"Lon\",\"direction\":\"east\",\"unit\":\"degree\"}]},"
+            + "\"id\":{\"authority\":\"EPSG\",\"code\":4269}}";
+        try {
+            org.datasyslab.proj4sedona.defs.Defs.set("TEST:PROJJSON", projjson);
+            org.datasyslab.proj4sedona.core.ProjectionDef def =
+                org.datasyslab.proj4sedona.defs.Defs.get("TEST:PROJJSON");
+            assertNotNull(def, "PROJJSON definition registered");
+            assertEquals("longlat", def.getProjName(), "PROJJSON parsed to longlat");
+
+            // WKT registration through the same entry point.
+            org.datasyslab.proj4sedona.defs.Defs.set("TEST:WKT",
+                "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563]],"
+                    + "PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]");
+            assertNotNull(org.datasyslab.proj4sedona.defs.Defs.get("TEST:WKT"), "WKT definition registered");
+        } finally {
+            org.datasyslab.proj4sedona.defs.Defs.set("TEST:PROJJSON", (String) null);
+            org.datasyslab.proj4sedona.defs.Defs.set("TEST:WKT", (String) null);
+        }
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -129,6 +129,15 @@ class Proj4jsBackportsTest {
         // Without lon_wrap, longitudes stay in -180..180.
         Converter plain = Proj4.proj4(WGS84, "+proj=longlat +datum=WGS84 +no_defs");
         assertEquals(-170, plain.forward(new Point(-170, 40)).x, 1e-9, "-170 stays -170");
+
+        // +lon_wrap must survive proj-string serialization: re-importing the
+        // serialized CRS keeps the wrapping behavior.
+        String serialized = org.datasyslab.proj4sedona.parser.CRSSerializer.toProjString(
+            new Proj("+proj=longlat +datum=WGS84 +lon_wrap=180 +no_defs"));
+        assertTrue(serialized.contains("+lon_wrap=180"), "serialized keeps +lon_wrap: " + serialized);
+        Converter reimported = Proj4.proj4(WGS84, serialized);
+        assertEquals(190, reimported.forward(new Point(-170, 40)).x, 1e-9,
+            "wrap behavior preserved after serialize/re-import");
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -82,4 +82,36 @@ class Proj4jsBackportsTest {
         assertEquals(100000, center.x, 0.01, "center easting = x_0");
         assertEquals(200000, center.y, 0.01, "center northing = y_0");
     }
+
+    @Test
+    @DisplayName("proj4js c5bb8e1: enforceAxis respects the vertical axis (enu -> ned)")
+    void testEnforceAxisVertical() {
+        Point r = org.datasyslab.proj4sedona.transform.Transform.transform(
+            new Proj("+proj=longlat +ellps=WGS84 +datum=WGS84 +axis=enu"),
+            new Proj("+proj=longlat +ellps=WGS84 +datum=WGS84 +axis=ned"),
+            new Point(10, 20, 30), true);
+        assertEquals(20, r.x, 1e-9, "first (north) is input y");
+        assertEquals(10, r.y, 1e-9, "second (east) is input x");
+        assertEquals(-30, r.z, 1e-9, "third (down) negates input z");
+    }
+
+    @Test
+    @DisplayName("proj4js c5bb8e1: enforceAxis handles arbitrary axis orders (neu -> uen)")
+    void testEnforceAxisArbitraryOrder() {
+        Point r1 = org.datasyslab.proj4sedona.transform.Transform.transform(
+            new Proj("+proj=longlat +axis=neu"),
+            new Proj("+proj=longlat +axis=uen"),
+            new Point(10, 20, 30), true);
+        assertEquals(30, r1.x, 1e-9, "neu->uen: first (up) is input up");
+        assertEquals(20, r1.y, 1e-9, "neu->uen: second (east) is input east");
+        assertEquals(10, r1.z, 1e-6, "neu->uen: third (north) is input north");
+
+        Point r2 = org.datasyslab.proj4sedona.transform.Transform.transform(
+            new Proj("+proj=longlat +axis=uen"),
+            new Proj("+proj=longlat +axis=uen"),
+            new Point(10, 20, 30), true);
+        assertEquals(10, r2.x, 1e-9, "uen->uen: round-trip preserves first");
+        assertEquals(20, r2.y, 1e-9, "uen->uen: round-trip preserves second");
+        assertEquals(30, r2.z, 1e-6, "uen->uen: round-trip preserves third");
+    }
 }


### PR DESCRIPTION
## Summary

Audit of every proj4js `lib/` commit since the port baseline (37 commits), verifying
semantically whether each is reflected in proj4sedona. Result: 11 already reflected
(several by construction — the newer projection ports were taken from a post-fix
tree), 17 not applicable (ob_tran/nzmg/geocent are unported; JS packaging), and
**7 needed backporting** — one commit per upstream patch:

| Commit | Upstream | What it fixes |
|---|---|---|
| `61689a9` | Unknown datum → NODATUM | Unknown/unnamed datums (ESRI sphere CRSs, MODIS-style) received a spurious datum shift — up to ~24 km vs PROJ |
| `8c538fc` | Polar LCC | South-polar LCC (`lat_0=-90`) returned Infinity/NaN for every transform |
| `04bd414` | aeqd x_0/y_0 | Ellipsoidal aeqd's general branch omitted the false origin the inverse subtracts — offset CRSs shifted and didn't round-trip |
| `c5bb8e1` | enforceAxis | Axis strings with the vertical axis outside position 3 (e.g. `uen`) or z-affecting orders (`ned`) produced swapped/zeroed components |
| `bad16a6`+`39e7abc` | `+lon_wrap` | New parameter (0..360-longitude output for climate/ocean datasets) was silently ignored |
| `1a3b130` | Defs PROJJSON | `Defs.set(code, definition)` rejected PROJJSON (and WKT) definitions that proj4js accepts |
| `0ee1202` | geocentric z | Future-proofing guard: don't zero computed Z when the destination is geocentric (inert until geocent is ported) |

## Verification

- Every reference value verified against **pyproj/PROJ 9.5.1** (unknown-datum sphere,
  south-polar LCC, offset aeqd) or ported from the upstream test suite (enforceAxis,
  lon_wrap, Defs PROJJSON).
- New `Proj4jsBackportsTest` — one test per backported patch.
- Full suite: 771 tests pass.

## Already reflected (no change needed)

`+over` support, null-defs delete, ortho defaults, web-mercator WKT2/PROJJSON
special-casing, Krovak variants/names, datum shift correction, mercator input
detection, sinu WKT1, omerc gamma-without-alpha, eqearth authalic, eck6,
lon_0 defaults (f12062a).
