### PR TITLE
Add Gauss-Schreiber Transverse Mercator projection (gstmerc)

### DIFF
--- a/scripts/pyproj-reference/generate_transform_reference.py
+++ b/scripts/pyproj-reference/generate_transform_reference.py
@@ -109,6 +109,15 @@ def get_projection_coverage_pairs() -> List[Dict[str, Any]]:
             "test_points": _pts((102.25, 4.0), (102.5, 4.2), (101.7, 3.06), (103.5, 5.5)),
         },
         {
+            # Gauss Laborde Reunion; international ellipsoid source keeps the
+            # comparison pure projection math (no datum leg).
+            "name": "proj_gstmerc",
+            "from_crs": "+proj=longlat +ellps=intl +no_defs",
+            "to_crs": "+proj=gstmerc +lat_0=-21.116666667 +lon_0=55.53333333 +k_0=1 +x_0=160000 +y_0=50000 +ellps=intl +units=m +no_defs",
+            "desc": "Gauss-Schreiber Transverse Mercator (Reunion)",
+            "test_points": _pts((55.53333333, -21.116666667), (55.5, -21.1), (55.7, -21.3), (55.3, -20.9)),
+        },
+        {
             "name": "proj_cass",
             "from_crs": "EPSG:4326",
             "to_crs": "+proj=cass +lat_0=11.25217861111111 +lon_0=-60.68600888888889 +x_0=187500 +y_0=180000 +datum=WGS84 +units=m +no_defs",

--- a/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
+++ b/src/main/java/org/datasyslab/proj4sedona/common/ProjMath.java
@@ -127,6 +127,63 @@ public final class ProjMath {
     }
 
     /**
+     * Compute the isometric latitude.
+     * Mirrors: lib/common/latiso.js
+     *
+     * @param eccent Eccentricity of the ellipsoid (0 for the sphere form)
+     * @param phi Latitude in radians
+     * @param sinphi Sine of the latitude
+     * @return Isometric latitude (NaN beyond ±90°, ±Infinity at the poles)
+     */
+    public static double latiso(double eccent, double phi, double sinphi) {
+        if (Math.abs(phi) > Values.HALF_PI) {
+            return Double.NaN;
+        }
+        if (phi == Values.HALF_PI) {
+            return Double.POSITIVE_INFINITY;
+        }
+        if (phi == -Values.HALF_PI) {
+            return Double.NEGATIVE_INFINITY;
+        }
+
+        double con = eccent * sinphi;
+        return Math.log(Math.tan((Values.HALF_PI + phi) / 2))
+            + eccent * Math.log((1 - con) / (1 + con)) / 2;
+    }
+
+    /**
+     * Latitude from isometric latitude, single step.
+     * Mirrors: lib/common/fL.js
+     *
+     * @param x Multiplier
+     * @param L Isometric latitude
+     * @return Latitude in radians
+     */
+    public static double fL(double x, double L) {
+        return 2 * Math.atan(x * Math.exp(L)) - Values.HALF_PI;
+    }
+
+    /**
+     * Invert the isometric latitude iteratively.
+     * Mirrors: lib/common/invlatiso.js
+     *
+     * @param eccent Eccentricity of the ellipsoid
+     * @param ts Isometric latitude
+     * @return Latitude in radians
+     */
+    public static double invlatiso(double eccent, double ts) {
+        double phi = fL(1, ts);
+        double iPhi;
+        double con;
+        do {
+            iPhi = phi;
+            con = eccent * Math.sin(iPhi);
+            phi = fL(Math.exp(eccent * Math.log((1 + con) / (1 - con)) / 2), ts);
+        } while (Math.abs(phi - iPhi) > 1.0e-12);
+        return phi;
+    }
+
+    /**
      * Compute the latitude angle, phi2, for the inverse of various projections.
      * Mirrors: lib/common/phi2z.js
      *

--- a/src/main/java/org/datasyslab/proj4sedona/projection/GaussSchreiberTransverseMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/GaussSchreiberTransverseMercator.java
@@ -1,0 +1,73 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Gauss-Schreiber Transverse Mercator projection (gstmerc).
+ * Mirrors: lib/projections/gstmerc.js
+ *
+ * <p>The double-projection transverse Mercator used by IGN for some French
+ * territories, e.g. Gauss Laborde Réunion. Ellipsoid latitude is mapped to a
+ * conformal sphere via the isometric latitude, then the spherical transverse
+ * Mercator is applied.</p>
+ *
+ * <p>The "gstmerg" alias is a historical typo kept by proj4js; the
+ * "Gauss_Schreiber_Transverse_Mercator" alias matches the serializer's WKT
+ * method name so serialized CRSs re-import.</p>
+ */
+public class GaussSchreiberTransverseMercator implements Projection {
+
+    private static final String[] NAMES = {
+        "gstmerg", "gstmerc", "Gauss_Schreiber_Transverse_Mercator"
+    };
+
+    private double e, lc, rs, cp, n2, xs, ys;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        // array of: a, b, lon0, lat0, k0, x0, y0
+        double temp = params.b / params.a;
+        this.e = Math.sqrt(1 - temp * temp);
+        this.lc = params.getLong0();
+        double lat0 = params.getLat0();
+        this.rs = Math.sqrt(1 + e * e * Math.pow(Math.cos(lat0), 4) / (1 - e * e));
+        double sinz = Math.sin(lat0);
+        double pc = Math.asin(sinz / rs);
+        double sinzpc = Math.sin(pc);
+        this.cp = ProjMath.latiso(0, pc, sinzpc) - rs * ProjMath.latiso(e, lat0, sinz);
+        this.n2 = params.k0 * params.a * Math.sqrt(1 - e * e) / (1 - e * e * sinz * sinz);
+        this.xs = params.x0;
+        this.ys = params.y0 - n2 * pc;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lon = p.x;
+        double lat = p.y;
+
+        double L = rs * (lon - lc);
+        double Ls = cp + rs * ProjMath.latiso(e, lat, Math.sin(lat));
+        double lat1 = Math.asin(Math.sin(L) / Math.cosh(Ls));
+        double Ls1 = ProjMath.latiso(0, lat1, Math.sin(lat1));
+        double x = xs + n2 * Ls1;
+        double y = ys + n2 * Math.atan(Math.sinh(Ls) / Math.cos(L));
+        return new Point(x, y, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double x = p.x;
+        double y = p.y;
+
+        double L = Math.atan(Math.sinh((x - xs) / n2) / Math.cos((y - ys) / n2));
+        double lat1 = Math.asin(Math.sin((y - ys) / n2) / Math.cosh((x - xs) / n2));
+        double LC = ProjMath.latiso(0, lat1, Math.sin(lat1));
+        double lon = lc + L / rs;
+        double lat = ProjMath.invlatiso(e, (LC - cp) / rs);
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -156,6 +156,7 @@ public final class ProjectionRegistry {
         add(ObliqueMercator::new);
         add(CassiniSoldner::new);
         add(MillerCylindrical::new);
+        add(GaussSchreiberTransverseMercator::new);
 
         // Conic projections
         add(LambertConformalConic::new);

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GaussSchreiberTransverseMercatorTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GaussSchreiberTransverseMercatorTest.java
@@ -1,0 +1,92 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Gauss-Schreiber Transverse Mercator projection (gstmerc).
+ *
+ * <p>proj4js has no gstmerc case in {@code test/testData.js} and its published dist
+ * does not bundle the projection, so the reference eastings/northings are from
+ * pyproj/PROJ 9.5.1 (international-ellipsoid source on both sides, so the numbers
+ * exercise the projection math alone). Tolerance 0.01 m / 1e-7&deg;.</p>
+ */
+class GaussSchreiberTransverseMercatorTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-7;
+
+    // Gauss Laborde Réunion
+    private static final String GSTMERC =
+        "+proj=gstmerc +lat_0=-21.116666667 +lon_0=55.53333333 +k_0=1 "
+            + "+x_0=160000 +y_0=50000 +ellps=intl +units=m +no_defs";
+    private static final String INTL_LL = "+proj=longlat +ellps=intl +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("gstmerc"));
+        assertNotNull(ProjectionRegistry.get("gstmerg"), "historical proj4js alias");
+        assertNotNull(ProjectionRegistry.get("Gauss_Schreiber_Transverse_Mercator"));
+    }
+
+    @Test
+    void testKnownValues() {
+        // ll (deg) -> easting, northing (m), per pyproj/PROJ 9.5.1
+        double[][] cases = {
+            {55.53333333, -21.116666667, 160000.000000, 50000.000000},
+            {55.5, -21.1, 156536.491110, 51844.974871},
+            {55.7, -21.3, 177294.269791, 29691.909304},
+            {55.3, -20.9, 135723.069080, 73971.469994},
+        };
+        Converter conv = Proj4.proj4(INTL_LL, GSTMERC);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    @Test
+    void testRoundTrip() {
+        Converter conv = Proj4.proj4(INTL_LL, GSTMERC);
+        double[][] coords = {
+            {55.53333333, -21.116666667}, {55.5, -21.1}, {55.7, -21.3}, {55.3, -20.9},
+        };
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        Proj original = new Proj(GSTMERC);
+        double[] c = {55.5, -21.1};
+        for (String serialized : new String[] {
+                CRSSerializer.toProjString(original),
+                CRSSerializer.toWkt1(original),
+                CRSSerializer.toWkt2(original),
+                CRSSerializer.toProjJson(original)}) {
+            Proj reimported = new Proj(serialized);
+            Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+            assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Gauss-Schreiber Transverse Mercator (`gstmerc`) projection from proj4js
(`lib/projections/gstmerc.js`) — the double-projection TM used by IGN for French
territories (e.g. **Gauss Laborde Réunion**). First of the final six remaining
projections (gstmerc → tpers → nzmg → geocent → qsc → ob_tran).

## Changes

- **`GaussSchreiberTransverseMercator`** — ellipsoid → conformal sphere via the
  isometric latitude, then spherical TM. Registered as `gstmerc`, `gstmerg` (the
  historical proj4js typo alias), and `Gauss_Schreiber_Transverse_Mercator` (the
  serializer's WKT method name, for re-import).
- **`ProjMath`** — adds `latiso`, `fL`, `invlatiso` (mirroring `lib/common/`).
- **pyproj benchmark case** added per the #84 convention (`proj_gstmerc`).

## Verification

proj4js has no gstmerc `testData` case and its dist doesn't bundle the projection,
so the oracle is **pyproj/PROJ 9.5.1** (international-ellipsoid source on both
sides — pure projection math):

- Known values match to <1 cm (origin → false origin exactly).
- Benchmark-pipeline agreement: **max 2.5e-9 m** across the coverage points.
- Round-trips + serialization round-trips (proj string / WKT1 / WKT2 / PROJJSON).

Full suite: 776 tests pass.
