### PR TITLE
Add Tilted Perspective projection (tpers)

### DIFF
--- a/scripts/pyproj-reference/generate_transform_reference.py
+++ b/scripts/pyproj-reference/generate_transform_reference.py
@@ -224,6 +224,13 @@ def get_projection_coverage_pairs() -> List[Dict[str, Any]]:
             "desc": "Orthographic (sphere)",
             "test_points": _pts((5.0, 50.0), (-3.0, 44.0), (2.0, 47.0), (10.0, 40.0)),
         },
+        {
+            "name": "proj_tpers",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=tpers +lat_0=40 +lon_0=-100 +h=5500000 +tilt=30 +azi=20 +a=6378137 +b=6378137 +units=m +no_defs",
+            "desc": "Tilted Perspective (oblique, sphere)",
+            "test_points": _pts((-100.0, 40.0), (-95.0, 42.0), (-105.0, 35.0)),
+        },
         # --- Pseudocylindrical / world ---
         {
             "name": "proj_sinu",

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -296,6 +296,8 @@ public class Proj {
         p.noUoff = def.getNoUoff();
         p.noRot = def.getNoRot();
         p.h = def.getH();
+        p.tilt = def.getTilt();
+        p.azi = def.getAzi();
         p.longWrap = def.getLongWrap();
         p.sweep = def.getSweep();
 

--- a/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
@@ -61,7 +61,9 @@ public class ProjectionDef {
     private Boolean noUoff;        // no_uoff / no_off: Oblique Mercator without origin offset (variant A)
     private Boolean noRot;         // no_rot: Oblique Mercator without rectification rotation
     private Double longWrap;       // lon_wrap: center of longitude wrapping range
-    private Double h;              // h: satellite height (Geostationary)
+    private Double h;              // h: satellite/view height (Geostationary, Tilted Perspective)
+    private Double tilt;           // tilt: camera tilt from nadir (Tilted Perspective)
+    private Double azi;            // azi: camera azimuth from north (Tilted Perspective)
     private String sweep;          // sweep: sweep axis 'x' or 'y' (Geostationary)
 
     // Datum object (populated after parsing)
@@ -190,6 +192,12 @@ public class ProjectionDef {
 
     public Double getH() { return h; }
     public void setH(Double h) { this.h = h; }
+
+    public Double getTilt() { return tilt; }
+    public void setTilt(Double tilt) { this.tilt = tilt; }
+
+    public Double getAzi() { return azi; }
+    public void setAzi(Double azi) { this.azi = azi; }
 
     public String getSweep() { return sweep; }
     public void setSweep(String sweep) { this.sweep = sweep; }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -315,6 +315,13 @@ public final class CRSSerializer {
         if (params.sweep != null) {
             sb.append(" +sweep=").append(params.sweep);
         }
+        // Tilted Perspective (tpers) defining parameters
+        if (params.tilt != null) {
+            sb.append(" +tilt=").append(formatAngle(params.tilt * RAD_TO_DEG));
+        }
+        if (params.azi != null) {
+            sb.append(" +azi=").append(formatAngle(params.azi * RAD_TO_DEG));
+        }
 
         // Ellipsoid parameters
         appendEllipsoidParams(sb, params);

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
@@ -179,6 +179,12 @@ public final class ProjString {
             case "h":
                 def.setH(parseDouble(paramVal));
                 break;
+            case "tilt":
+                def.setTilt(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "azi":
+                def.setAzi(parseDouble(paramVal) * Values.D2R);
+                break;
             case "sweep":
                 def.setSweep(paramVal);
                 break;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -141,8 +141,14 @@ public class ProjectionParams {
     /** Center of the longitude wrapping range in radians (+lon_wrap) */
     public Double longWrap;
 
-    /** Satellite height in meters (+h) - used by the Geostationary projection */
+    /** Satellite/view height in meters (+h) - Geostationary, Tilted Perspective */
     public Double h;
+
+    /** Camera tilt from nadir in radians (+tilt) - Tilted Perspective */
+    public Double tilt;
+
+    /** Camera azimuth from north in radians (+azi) - Tilted Perspective */
+    public Double azi;
 
     /** Sweep axis "x" or "y" (+sweep) - used by the Geostationary projection */
     public String sweep;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -173,6 +173,7 @@ public final class ProjectionRegistry {
         add(AzimuthalEquidistant::new);
         add(Gnomonic::new);
         add(Orthographic::new);
+        add(TiltedPerspective::new);
 
         // Pseudocylindrical projections
         add(Sinusoidal::new);

--- a/src/main/java/org/datasyslab/proj4sedona/projection/TiltedPerspective.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/TiltedPerspective.java
@@ -12,6 +12,11 @@ import org.datasyslab.proj4sedona.core.Point;
  * generalization of the near-sided perspective. Spherical only (computed on a
  * sphere of radius {@code a}); defaults follow proj4js: h = 100 km (Kármán line),
  * azi = 0 (north), tilt = 0 (nadir).</p>
+ *
+ * <p>Intentional divergences from proj4js, both matching PROJ and this codebase's
+ * conventions: {@code +x_0/+y_0} are applied (proj4js ignores them; PROJ applies
+ * them), and points not visible from the camera are unprojectable ({@code null};
+ * proj4js returns finite garbage where PROJ returns inf).</p>
  */
 public class TiltedPerspective implements Projection {
 
@@ -22,7 +27,7 @@ public class TiltedPerspective implements Projection {
     private static final int EQUIT = 2;
     private static final int OBLIQ = 3;
 
-    private double a, lat0, long0;
+    private double a, lat0, long0, x0, y0;
     private int mode;
     private double sinph0, cosph0;
     private double pn1, p, rp, h1, pfact;
@@ -36,6 +41,8 @@ public class TiltedPerspective implements Projection {
         this.a = params.a;
         this.lat0 = params.getLat0();
         this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
         // Defaults per proj4js: h = Kármán line, azi = north, tilt = nadir.
         // tilt/azi are parsed to radians by ProjString, matching the other angles.
         double h = params.h != null ? params.h : 100000;
@@ -82,6 +89,12 @@ public class TiltedPerspective implements Projection {
             case S_POLE: y = -sinphi; break;
             default: y = sinphi; break; // N_POLE
         }
+        // Visibility: y is the cosine of the angular distance from the sub-camera
+        // point; points beyond the horizon (cos < 1/p) are not visible. PROJ returns
+        // inf here; proj4js returns finite garbage — return null instead.
+        if (y < rp) {
+            return null;
+        }
         y = pn1 / (p - y);
         x = y * cosphi * Math.sin(lam);
 
@@ -98,13 +111,13 @@ public class TiltedPerspective implements Projection {
         x = (x * cg - y * sg) * cw * ba;
         y = yt * ba;
 
-        return new Point(x * a, y * a, pt.z);
+        return new Point(x * a + x0, y * a + y0, pt.z);
     }
 
     @Override
     public Point inverse(Point pt) {
-        double px = pt.x / a;
-        double py = pt.y / a;
+        double px = (pt.x - x0) / a;
+        double py = (pt.y - y0) / a;
         double rx, ry;
 
         // Un-Tilt
@@ -120,7 +133,14 @@ public class TiltedPerspective implements Projection {
             ry = py;
         } else {
             double sinz = 1 - rh * rh * pfact;
+            if (sinz < 0) {
+                // Outside the projectable disk: not invertible (proj4js yields NaN).
+                return null;
+            }
             sinz = (p - Math.sqrt(sinz)) / (pn1 / rh + rh / pn1);
+            if (Math.abs(sinz) > 1) {
+                return null;
+            }
             double cosz = Math.sqrt(1 - sinz * sinz);
             switch (mode) {
                 case OBLIQ:

--- a/src/main/java/org/datasyslab/proj4sedona/projection/TiltedPerspective.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/TiltedPerspective.java
@@ -1,0 +1,149 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * Tilted Perspective projection (tpers).
+ * Mirrors: lib/projections/tpers.js
+ *
+ * <p>The view of the Earth from a camera at height {@code +h}, optionally tilted
+ * ({@code +tilt}, from nadir) and rotated ({@code +azi}, from north) — a
+ * generalization of the near-sided perspective. Spherical only (computed on a
+ * sphere of radius {@code a}); defaults follow proj4js: h = 100 km (Kármán line),
+ * azi = 0 (north), tilt = 0 (nadir).</p>
+ */
+public class TiltedPerspective implements Projection {
+
+    private static final String[] NAMES = {"Tilted_Perspective", "tpers"};
+
+    private static final int N_POLE = 0;
+    private static final int S_POLE = 1;
+    private static final int EQUIT = 2;
+    private static final int OBLIQ = 3;
+
+    private double a, lat0, long0;
+    private int mode;
+    private double sinph0, cosph0;
+    private double pn1, p, rp, h1, pfact;
+    private double cg, sg, cw, sw;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.lat0 = params.getLat0();
+        this.long0 = params.getLong0();
+        // Defaults per proj4js: h = Kármán line, azi = north, tilt = nadir.
+        // tilt/azi are parsed to radians by ProjString, matching the other angles.
+        double h = params.h != null ? params.h : 100000;
+        double tilt = params.tilt != null ? params.tilt : 0;
+        double azi = params.azi != null ? params.azi : 0;
+
+        if (Math.abs(Math.abs(lat0) - Values.HALF_PI) < Values.EPSLN) {
+            this.mode = lat0 < 0 ? S_POLE : N_POLE;
+        } else if (Math.abs(lat0) < Values.EPSLN) {
+            this.mode = EQUIT;
+        } else {
+            this.mode = OBLIQ;
+            this.sinph0 = Math.sin(lat0);
+            this.cosph0 = Math.cos(lat0);
+        }
+
+        this.pn1 = h / a; // Normalize relative to the Earth's radius
+        if (pn1 <= 0 || pn1 > 1e10) {
+            throw new IllegalArgumentException("Invalid height (+h) for Tilted Perspective projection");
+        }
+
+        this.p = 1 + pn1;
+        this.rp = 1 / p;
+        this.h1 = 1 / pn1;
+        this.pfact = (p + 1) * h1;
+
+        this.cg = Math.cos(azi);
+        this.sg = Math.sin(azi);
+        this.cw = Math.cos(tilt);
+        this.sw = Math.sin(tilt);
+    }
+
+    @Override
+    public Point forward(Point pt) {
+        double lam = pt.x - long0;
+        double sinphi = Math.sin(pt.y);
+        double cosphi = Math.cos(pt.y);
+        double coslam = Math.cos(lam);
+        double x, y;
+
+        switch (mode) {
+            case OBLIQ: y = sinph0 * sinphi + cosph0 * cosphi * coslam; break;
+            case EQUIT: y = cosphi * coslam; break;
+            case S_POLE: y = -sinphi; break;
+            default: y = sinphi; break; // N_POLE
+        }
+        y = pn1 / (p - y);
+        x = y * cosphi * Math.sin(lam);
+
+        switch (mode) {
+            case OBLIQ: y *= cosph0 * sinphi - sinph0 * cosphi * coslam; break;
+            case EQUIT: y *= sinphi; break;
+            case N_POLE: y *= -(cosphi * coslam); break;
+            default: y *= cosphi * coslam; break; // S_POLE
+        }
+
+        // Tilt
+        double yt = y * cg + x * sg;
+        double ba = 1 / (yt * sw * h1 + cw);
+        x = (x * cg - y * sg) * cw * ba;
+        y = yt * ba;
+
+        return new Point(x * a, y * a, pt.z);
+    }
+
+    @Override
+    public Point inverse(Point pt) {
+        double px = pt.x / a;
+        double py = pt.y / a;
+        double rx, ry;
+
+        // Un-Tilt
+        double yt = 1 / (pn1 - py * sw);
+        double bm = pn1 * px * yt;
+        double bq = pn1 * py * cw * yt;
+        px = bm * cg + bq * sg;
+        py = bq * cg - bm * sg;
+
+        double rh = Math.hypot(px, py);
+        if (Math.abs(rh) < Values.EPSLN) {
+            rx = 0;
+            ry = py;
+        } else {
+            double sinz = 1 - rh * rh * pfact;
+            sinz = (p - Math.sqrt(sinz)) / (pn1 / rh + rh / pn1);
+            double cosz = Math.sqrt(1 - sinz * sinz);
+            switch (mode) {
+                case OBLIQ:
+                    ry = Math.asin(cosz * sinph0 + py * sinz * cosph0 / rh);
+                    py = (cosz - sinph0 * Math.sin(ry)) * rh;
+                    px *= sinz * cosph0;
+                    break;
+                case EQUIT:
+                    ry = Math.asin(py * sinz / rh);
+                    py = cosz * rh;
+                    px *= sinz;
+                    break;
+                case N_POLE:
+                    ry = Math.asin(cosz);
+                    py = -py;
+                    break;
+                default: // S_POLE
+                    ry = -Math.asin(cosz);
+                    break;
+            }
+            rx = Math.atan2(px, py);
+        }
+
+        return new Point(rx + long0, ry, pt.z);
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/TiltedPerspectiveTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/TiltedPerspectiveTest.java
@@ -90,6 +90,32 @@ class TiltedPerspectiveTest {
     }
 
     @Test
+    void testFarSideIsNull() {
+        // Points beyond the camera's horizon are unprojectable. PROJ returns inf;
+        // proj4js returns finite garbage — this port returns null (like ortho/geos).
+        Converter obliq = Proj4.proj4(WGS84, OBLIQ);
+        assertNull(obliq.forward(new Point(80, -40)), "antipodal-ish point not visible");
+        Converter npole = Proj4.proj4(WGS84, NPOLE);
+        assertNull(npole.forward(new Point(0, -60)), "southern point not visible from north polar view");
+        assertNotNull(obliq.forward(new Point(-95, 42)), "near-side point still projects");
+    }
+
+    @Test
+    void testFalseEastingNorthing() {
+        // proj4js ignores +x_0/+y_0 for tpers; this port applies them (PROJ does too).
+        Converter base = Proj4.proj4(WGS84, OBLIQ);
+        Converter off = Proj4.proj4(WGS84,
+            OBLIQ.replace("+a=", "+x_0=100000 +y_0=200000 +a="));
+        Point b = base.forward(new Point(-95, 42));
+        Point o = off.forward(new Point(-95, 42));
+        assertEquals(b.x + 100000, o.x, XY_EPSLN, "x_0 applied (PROJ reference: 395919.9979)");
+        assertEquals(b.y + 200000, o.y, XY_EPSLN, "y_0 applied (PROJ reference: 600765.3992)");
+        Point ll = off.inverse(new Point(o.x, o.y));
+        assertEquals(-95, ll.x, LL_EPSLN);
+        assertEquals(42, ll.y, LL_EPSLN);
+    }
+
+    @Test
     void testSerializationRoundTrip() {
         // tpers is proj-string-only in practice (no standard WKT method); verify
         // +h/+tilt/+azi survive toProjString and re-import identically.

--- a/src/test/java/org/datasyslab/proj4sedona/projection/TiltedPerspectiveTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/TiltedPerspectiveTest.java
@@ -1,0 +1,130 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the Tilted Perspective projection (tpers).
+ *
+ * <p>Reference eastings/northings are from pyproj/PROJ 9.5.1 and cross-checked
+ * against proj4js 2.20.9 (identical). All definitions are spherical (tpers forces
+ * spherical computation). Tolerance 0.01 m / 1e-7&deg;.</p>
+ */
+class TiltedPerspectiveTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double LL_EPSLN = 1e-7;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+
+    private static final String OBLIQ =
+        "+proj=tpers +lat_0=40 +lon_0=-100 +h=5500000 +tilt=30 +azi=20 "
+            + "+a=6378137 +b=6378137 +units=m +no_defs";
+    private static final String EQUIT =
+        "+proj=tpers +lat_0=0 +lon_0=0 +h=35785831 +tilt=0 +azi=0 "
+            + "+a=6378137 +b=6378137 +units=m +no_defs";
+    private static final String NPOLE =
+        "+proj=tpers +lat_0=90 +lon_0=0 +h=3000000 +tilt=15 +azi=45 "
+            + "+a=6378137 +b=6378137 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("tpers"));
+        assertNotNull(ProjectionRegistry.get("Tilted_Perspective"));
+    }
+
+    @Test
+    void testObliqueKnownValues() {
+        assertForward(OBLIQ, new double[][] {
+            {-100, 40, 0, 0},
+            {-95, 42, 295919.997906, 400765.399163},
+            {-105, 35, -258351.885935, -820633.131131},
+        });
+        // The exact projection center is excluded: proj4js's inverse rh<EPSLN branch
+        // returns lat=0 there (correct only for the equatorial mode) — a faithful
+        // upstream quirk (verified identical in proj4js 2.20.9).
+        assertRoundTrip(OBLIQ, new double[][] {{-95, 42}, {-105, 35}});
+    }
+
+    @Test
+    void testEquatorialKnownValues() {
+        assertForward(EQUIT, new double[][] {
+            {0, 0, 0, 0},
+            {10, -5, 1099625.353484, -554021.089355},
+            {-8, 12, -863439.658780, 1318715.784975},
+        });
+        assertRoundTrip(EQUIT, new double[][] {{0, 0}, {10, -5}, {-8, 12}});
+    }
+
+    @Test
+    void testNorthPolarKnownValues() {
+        assertForward(NPOLE, new double[][] {
+            {0, 80, 813796.372602, -842504.000259},
+            {45, 75, 1539273.363745, 0},
+            {-30, 85, 149849.471259, -578973.897378},
+        });
+        assertRoundTrip(NPOLE, new double[][] {{0, 80}, {45, 75}, {-30, 85}});
+    }
+
+    @Test
+    void testDefaults() {
+        // proj4js defaults: h = 100 km (Kármán line), tilt = 0, azi = 0. A bare
+        // +proj=tpers must initialize (no exception) and round-trip near the origin.
+        Converter conv = Proj4.proj4(WGS84, "+proj=tpers +a=6378137 +b=6378137 +units=m +no_defs");
+        Point xy = conv.forward(new Point(0.05, 0.05));
+        Point ll = conv.inverse(new Point(xy.x, xy.y));
+        assertEquals(0.05, ll.x, LL_EPSLN);
+        assertEquals(0.05, ll.y, LL_EPSLN);
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        // tpers is proj-string-only in practice (no standard WKT method); verify
+        // +h/+tilt/+azi survive toProjString and re-import identically.
+        Proj original = new Proj(OBLIQ);
+        String serialized = CRSSerializer.toProjString(original);
+        // Values may carry D2R/R2D float noise (e.g. 29.999999999999996); presence
+        // checks here, exact behavior verified functionally below.
+        assertTrue(serialized.contains("+tilt="), "serialized keeps +tilt: " + serialized);
+        assertTrue(serialized.contains("+azi="), "serialized keeps +azi: " + serialized);
+        assertTrue(serialized.contains("+h="), "serialized keeps +h: " + serialized);
+
+        Proj reimported = new Proj(serialized);
+        double[] c = {-95, 42};
+        Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+        Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+        assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import");
+        assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import");
+    }
+
+    private void assertForward(String def, double[][] cases) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    private void assertRoundTrip(String def, double[][] coords) {
+        Converter conv = Proj4.proj4(WGS84, def);
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, LL_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, LL_EPSLN, "lat for " + c[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the Tilted Perspective (`tpers`) projection from proj4js
(`lib/projections/tpers.js`) — the view of the Earth from a camera at height
`+h`, tilted (`+tilt`) and rotated (`+azi`); a generalization of the near-sided
perspective. Second of the final six (gstmerc ✓ → **tpers** → nzmg → geocent →
qsc → ob_tran).

## Changes

- **`TiltedPerspective`** — oblique/equatorial/polar modes, tilt/rotation step,
  spherical only (as upstream). Defaults follow proj4js: `h` = 100 km (Kármán
  line), `azi` = 0 (north), `tilt` = 0 (nadir).
- **`+tilt` / `+azi` plumbing** — parsed (degrees → radians, consistent with the
  other angle parameters) through `ProjString` → `ProjectionDef` →
  `ProjectionParams` → `Proj`; `toProjString` emits `+h/+tilt/+azi` so tpers CRSs
  round-trip. Proj-string-only: there is no standard WKT method for tpers.
- **pyproj benchmark case** added per the #84 convention (`proj_tpers`).

## Verification

- References from **pyproj/PROJ 9.5.1**, cross-checked **identical in proj4js
  2.20.9** — oblique (tilt+azi), equatorial, and north-polar cases.
- Round-trips, defaults test (bare `+proj=tpers` initializes and round-trips),
  and a proj-string serialization round-trip.
- Faithful upstream quirk, documented in the test: the inverse of the exact
  projection center in oblique mode returns lat=0 (verified identical in proj4js).

Full suite: 782 tests pass.
