### PR TITLE
Add New Zealand Map Grid projection (nzmg)

### DIFF
--- a/scripts/pyproj-reference/generate_transform_reference.py
+++ b/scripts/pyproj-reference/generate_transform_reference.py
@@ -271,6 +271,14 @@ def get_projection_coverage_pairs() -> List[Dict[str, Any]]:
             "to_crs": "+proj=eck6 +lon_0=0 +x_0=0 +y_0=0 +a=6371007 +b=6371007 +units=m +no_defs",
             "desc": "Eckert VI (sphere)",
         },
+        {
+            # International-ellipsoid source keeps the comparison pure projection math.
+            "name": "proj_nzmg",
+            "from_crs": "+proj=longlat +ellps=intl +no_defs",
+            "to_crs": "+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 +ellps=intl +units=m +no_defs",
+            "desc": "New Zealand Map Grid",
+            "test_points": _pts((173.0, -41.0), (174.7645, -36.8509), (170.5036, -45.8742), (172.6362, -43.5321)),
+        },
         # --- Miscellaneous ---
         {
             "name": "proj_geos_y",

--- a/src/main/java/org/datasyslab/proj4sedona/projection/NewZealandMapGrid.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/NewZealandMapGrid.java
@@ -1,0 +1,166 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+
+/**
+ * New Zealand Map Grid projection (nzmg).
+ * Mirrors: lib/projections/nzmg.js
+ *
+ * <p>The conformal projection defined by complex-polynomial series fitted to New
+ * Zealand (Department of Land and Survey Technical Circular 1973/32; EPSG:27200).
+ * The series coefficients are fixed constants of the projection definition.</p>
+ *
+ * <p>The inverse refines a series first-approximation with Newton iterations:
+ * 0 iterations gives km accuracy, 1 gives meter accuracy, 2 gives mm accuracy.
+ * proj4js uses 1 (incl. upstream 8c632d0, which fixed the count not being applied);
+ * this port matches.</p>
+ */
+public class NewZealandMapGrid implements Projection {
+
+    private static final String[] NAMES = {"New_Zealand_Map_Grid", "nzmg"};
+
+    /** Inverse refinement iterations (1 = meter accuracy, matching proj4js). */
+    private static final int ITERATIONS = 1;
+
+    // Series coefficients (1-based indexing preserved from the definition).
+    private static final double[] A = {
+        0, 0.6399175073, -0.1358797613, 0.063294409, -0.02526853, 0.0117879,
+        -0.0055161, 0.0026906, -0.001333, 0.00067, -0.00034
+    };
+    private static final double[] B_RE = {
+        0, 0.7557853228, 0.249204646, -0.001541739, -0.10162907, -0.26623489, -0.6870983
+    };
+    private static final double[] B_IM = {
+        0, 0, 0.003371507, 0.041058560, 0.01727609, -0.36249218, -1.1651967
+    };
+    private static final double[] C_RE = {
+        0, 1.3231270439, -0.577245789, 0.508307513, -0.15094762, 1.01418179, 1.9660549
+    };
+    private static final double[] C_IM = {
+        0, 0, -0.007809598, -0.112208952, 0.18200602, 1.64497696, 2.5127645
+    };
+    private static final double[] D = {
+        0, 1.5627014243, 0.5185406398, -0.03333098, -0.1052906, -0.0368594,
+        0.007317, 0.01220, 0.00394, -0.0013
+    };
+
+    private double a, lat0, long0, x0, y0;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.lat0 = params.getLat0();
+        this.long0 = params.getLong0();
+        this.x0 = params.x0;
+        this.y0 = params.y0;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double deltaLat = p.y - lat0;
+        double deltaLon = p.x - long0;
+
+        // 1. d_phi in seconds of arc * 1e-5; d_lambda in radians.
+        double dPhi = deltaLat / Values.SEC_TO_RAD * 1E-5;
+        double dLambda = deltaLon;
+        double dPhiN = 1; // d_phi^0
+
+        double dPsi = 0;
+        for (int n = 1; n <= 10; n++) {
+            dPhiN = dPhiN * dPhi;
+            dPsi = dPsi + A[n] * dPhiN;
+        }
+
+        // 2. theta
+        double thRe = dPsi;
+        double thIm = dLambda;
+
+        // 3. z = sum B[n] * theta^n (complex)
+        double thNRe = 1, thNIm = 0;
+        double zRe = 0, zIm = 0;
+        for (int n = 1; n <= 6; n++) {
+            double thNRe1 = thNRe * thRe - thNIm * thIm;
+            double thNIm1 = thNIm * thRe + thNRe * thIm;
+            thNRe = thNRe1;
+            thNIm = thNIm1;
+            zRe = zRe + B_RE[n] * thNRe - B_IM[n] * thNIm;
+            zIm = zIm + B_IM[n] * thNRe + B_RE[n] * thNIm;
+        }
+
+        // 4. easting/northing
+        return new Point(zIm * a + x0, zRe * a + y0, p.z);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double deltaX = p.x - x0;
+        double deltaY = p.y - y0;
+
+        // 1. z
+        double zRe = deltaY / a;
+        double zIm = deltaX / a;
+
+        // 2a. theta first approximation (km accuracy)
+        double zNRe = 1, zNIm = 0;
+        double thRe = 0, thIm = 0;
+        for (int n = 1; n <= 6; n++) {
+            double zNRe1 = zNRe * zRe - zNIm * zIm;
+            double zNIm1 = zNIm * zRe + zNRe * zIm;
+            zNRe = zNRe1;
+            zNIm = zNIm1;
+            thRe = thRe + C_RE[n] * zNRe - C_IM[n] * zNIm;
+            thIm = thIm + C_IM[n] * zNRe + C_RE[n] * zNIm;
+        }
+
+        // 2b. Newton refinement
+        for (int i = 0; i < ITERATIONS; i++) {
+            double thNRe = thRe, thNIm = thIm;
+            double numRe = zRe, numIm = zIm;
+            for (int n = 2; n <= 6; n++) {
+                double thNRe1 = thNRe * thRe - thNIm * thIm;
+                double thNIm1 = thNIm * thRe + thNRe * thIm;
+                thNRe = thNRe1;
+                thNIm = thNIm1;
+                numRe = numRe + (n - 1) * (B_RE[n] * thNRe - B_IM[n] * thNIm);
+                numIm = numIm + (n - 1) * (B_IM[n] * thNRe + B_RE[n] * thNIm);
+            }
+
+            thNRe = 1;
+            thNIm = 0;
+            double denRe = B_RE[1], denIm = B_IM[1];
+            for (int n = 2; n <= 6; n++) {
+                double thNRe1 = thNRe * thRe - thNIm * thIm;
+                double thNIm1 = thNIm * thRe + thNRe * thIm;
+                thNRe = thNRe1;
+                thNIm = thNIm1;
+                denRe = denRe + n * (B_RE[n] * thNRe - B_IM[n] * thNIm);
+                denIm = denIm + n * (B_IM[n] * thNRe + B_RE[n] * thNIm);
+            }
+
+            // Complex division num/den
+            double den2 = denRe * denRe + denIm * denIm;
+            thRe = (numRe * denRe + numIm * denIm) / den2;
+            thIm = (numIm * denRe - numRe * denIm) / den2;
+        }
+
+        // 3. d_phi (seconds of arc * 1e-5) and d_lambda
+        double dPsi = thRe;
+        double dLambda = thIm;
+        double dPsiN = 1;
+
+        double dPhi = 0;
+        for (int n = 1; n <= 9; n++) {
+            dPsiN = dPsiN * dPsi;
+            dPhi = dPhi + D[n] * dPsiN;
+        }
+
+        // 4. latitude/longitude
+        double lat = lat0 + dPhi * Values.SEC_TO_RAD * 1E5;
+        double lon = long0 + dLambda;
+        return new Point(lon, lat, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -185,6 +185,7 @@ public final class ProjectionRegistry {
 
         // Miscellaneous projections
         add(Geostationary::new);
+        add(NewZealandMapGrid::new);
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/projection/NewZealandMapGridTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/NewZealandMapGridTest.java
@@ -1,0 +1,92 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the New Zealand Map Grid projection (nzmg).
+ *
+ * <p>Reference eastings/northings are from pyproj/PROJ 9.5.1 and cross-checked
+ * identical in proj4js 2.20.9 (international-ellipsoid source, pure projection
+ * math). Forward tolerance 0.01 m; the inverse uses 1 refinement iteration
+ * (meter accuracy, matching proj4js incl. upstream 8c632d0), so round-trips are
+ * asserted at 1e-4&deg; (~10 m).</p>
+ */
+class NewZealandMapGridTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double RT_EPSLN = 1e-4; // inverse is meter-accurate by design
+
+    // EPSG:27200 (NZGD49 / New Zealand Map Grid), projection parameters only
+    private static final String NZMG =
+        "+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 "
+            + "+ellps=intl +units=m +no_defs";
+    private static final String INTL_LL = "+proj=longlat +ellps=intl +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("nzmg"));
+        assertNotNull(ProjectionRegistry.get("New_Zealand_Map_Grid"));
+    }
+
+    @Test
+    void testKnownValues() {
+        // ll (deg) -> easting, northing (m), per pyproj/PROJ 9.5.1 (== proj4js)
+        double[][] cases = {
+            {173, -41, 2510000.000000, 6023150.000000},           // origin -> false origin
+            {174.7645, -36.8509, 2667767.479835, 6482111.835745}, // Auckland
+            {170.5036, -45.8742, 2316055.320203, 5478727.745716}, // Dunedin
+            {172.6362, -43.5321, 2480614.526882, 5741827.025505}, // Christchurch
+        };
+        Converter conv = Proj4.proj4(INTL_LL, NZMG);
+        for (double[] c : cases) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            assertEquals(c[2], xy.x, XY_EPSLN, "easting for " + c[0] + "," + c[1]);
+            assertEquals(c[3], xy.y, XY_EPSLN, "northing for " + c[0] + "," + c[1]);
+        }
+    }
+
+    @Test
+    void testRoundTrip() {
+        Converter conv = Proj4.proj4(INTL_LL, NZMG);
+        double[][] coords = {
+            {173, -41}, {174.7645, -36.8509}, {170.5036, -45.8742}, {172.6362, -43.5321},
+        };
+        for (double[] c : coords) {
+            Point xy = conv.forward(new Point(c[0], c[1]));
+            Point ll = conv.inverse(new Point(xy.x, xy.y));
+            assertEquals(c[0], ll.x, RT_EPSLN, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, RT_EPSLN, "lat for " + c[1]);
+        }
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        Proj original = new Proj(NZMG);
+        double[] c = {174.7645, -36.8509};
+        for (String serialized : new String[] {
+                CRSSerializer.toProjString(original),
+                CRSSerializer.toWkt1(original),
+                CRSSerializer.toWkt2(original),
+                CRSSerializer.toProjJson(original)}) {
+            Proj reimported = new Proj(serialized);
+            Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+            assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Ports the New Zealand Map Grid (`nzmg`) projection from proj4js
(`lib/projections/nzmg.js`) — the conformal complex-polynomial-series projection
of **EPSG:27200** (NZGD49 / NZMG). Third of the final six (gstmerc ✓ → tpers ✓ →
**nzmg** → geocent → qsc → ob_tran).

## Changes

- **`NewZealandMapGrid`** — the fixed series coefficients (A/B/C/D), complex
  arithmetic inlined as upstream; inverse refines a first approximation with
  **1 Newton iteration** (meter accuracy), matching proj4js **including upstream
  `8c632d0`**, which fixed the iteration count not being applied ("inverse drift").
- **pyproj benchmark case** added per the #84 convention (`proj_nzmg`).
- No serializer change needed: the `nzmg` → `New Zealand Map Grid` method mapping
  already existed, and the registry alias covers re-import.

## Verification

- References from **pyproj/PROJ 9.5.1**, cross-checked **identical in proj4js
  2.20.9** — origin/Auckland/Dunedin/Christchurch (international-ellipsoid
  source, pure projection math). Forward matches to <1 cm.
- Round-trips asserted at 1e-4° (~10 m): the inverse is meter-accurate **by
  design** at 1 iteration (0 → km, 1 → m, 2 → mm, per the LINZ circular).
- Serialization round-trips across all four formats.

Full suite: 788 tests pass.
