### PR TITLE
Add Geocentric coordinates (geocent)

### DIFF
--- a/scripts/pyproj-reference/generate_transform_reference.py
+++ b/scripts/pyproj-reference/generate_transform_reference.py
@@ -281,6 +281,15 @@ def get_projection_coverage_pairs() -> List[Dict[str, Any]]:
         },
         # --- Miscellaneous ---
         {
+            # ECEF X/Y compared (the shared reference format is 2D; Z is covered by
+            # unit tests). 2D input -> geocentric requires keeping the computed Z.
+            "name": "proj_geocent",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=geocent +datum=WGS84 +units=m +no_defs",
+            "desc": "Geocentric (ECEF)",
+            "test_points": _pts((-7.56, 55.95), (2.35, 48.85), (139.69, 35.69)),
+        },
+        {
             "name": "proj_geos_y",
             "from_crs": "EPSG:4326",
             "to_crs": "+proj=geos +h=35785831 +sweep=y +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Geocentric.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Geocentric.java
@@ -1,0 +1,41 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.datum.DatumUtils;
+
+/**
+ * Geocentric coordinates (geocent).
+ * Mirrors: lib/projections/geocent.js
+ *
+ * <p>Not a map projection in the usual sense: converts geodetic longitude/latitude/
+ * height to Earth-centered, Earth-fixed (ECEF) X/Y/Z in meters (e.g. EPSG:4978).
+ * Delegates to the geodetic&harr;geocentric conversions shared with the datum
+ * pipeline. The transform pipeline keeps the computed Z even for 2D input
+ * (proj4js 0ee1202, backported ahead of this port).</p>
+ */
+public class Geocentric implements Projection {
+
+    private static final String[] NAMES = {"Geocentric", "geocentric", "geocent", "Geocent"};
+
+    private double a, b, es;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.a = params.a;
+        this.b = params.b;
+        this.es = params.es;
+    }
+
+    @Override
+    public Point forward(Point p) {
+        return DatumUtils.geodeticToGeocentric(p, es, a);
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        return DatumUtils.geocentricToGeodetic(p, es, a, b);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -186,6 +186,7 @@ public final class ProjectionRegistry {
         // Miscellaneous projections
         add(Geostationary::new);
         add(NewZealandMapGrid::new);
+        add(Geocentric::new);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Converter.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Converter.java
@@ -32,7 +32,7 @@ public class Converter {
      * @return Output coordinates in destination CRS
      */
     public Point forward(Point point) {
-        return Transform.transform(from, to, point, false);
+        return forward(point, false);
     }
 
     /**
@@ -43,7 +43,13 @@ public class Converter {
      * @return Output coordinates in destination CRS
      */
     public Point forward(Point point, boolean enforceAxis) {
-        return Transform.transform(from, to, point, enforceAxis);
+        Point result = Transform.transform(from, to, point, enforceAxis);
+        // Preserve the input measure, like proj4js's transformer adapter copies
+        // extra keys (m) back onto the output.
+        if (result != null && !Double.isNaN(point.m)) {
+            result.m = point.m;
+        }
+        return result;
     }
 
     /**
@@ -55,10 +61,7 @@ public class Converter {
     public double[] forward(double[] coords) {
         Point p = new Point(coords);
         Point result = forward(p);
-        if (result == null) {
-            return new double[]{Double.NaN, Double.NaN};
-        }
-        return result.toArray();
+        return adaptArray(coords, result);
     }
 
     /**
@@ -68,7 +71,7 @@ public class Converter {
      * @return Output coordinates in source CRS
      */
     public Point inverse(Point point) {
-        return Transform.transform(to, from, point, false);
+        return inverse(point, false);
     }
 
     /**
@@ -79,7 +82,11 @@ public class Converter {
      * @return Output coordinates in source CRS
      */
     public Point inverse(Point point, boolean enforceAxis) {
-        return Transform.transform(to, from, point, enforceAxis);
+        Point result = Transform.transform(to, from, point, enforceAxis);
+        if (result != null && !Double.isNaN(point.m)) {
+            result.m = point.m;
+        }
+        return result;
     }
 
     /**
@@ -91,10 +98,35 @@ public class Converter {
     public double[] inverse(double[] coords) {
         Point p = new Point(coords);
         Point result = inverse(p);
+        return adaptArray(coords, result);
+    }
+
+    /**
+     * Shape the array result like proj4js's transformer adapter (lib/core.js):
+     * when either CRS is geocentric, a 3-component input keeps its third component
+     * (the computed z), instead of Point.toArray() collapsing z == 0 to two
+     * components. Also preserves the input measure (m) for 4-component input.
+     */
+    private double[] adaptArray(double[] coords, Point result) {
         if (result == null) {
             return new double[]{Double.NaN, Double.NaN};
         }
+        if (coords.length > 2 && (isGeocent(from) || isGeocent(to))) {
+            if (coords.length > 3) {
+                return new double[]{result.x, result.y, result.z, coords[3]};
+            }
+            return new double[]{result.x, result.y, result.z};
+        }
         return result.toArray();
+    }
+
+    private static boolean isGeocent(Proj proj) {
+        String n = proj.getParams().projName;
+        if (n == null) {
+            return false;
+        }
+        n = n.toLowerCase();
+        return "geocent".equals(n) || "geocentric".equals(n);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Converter.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Converter.java
@@ -125,7 +125,7 @@ public class Converter {
         if (n == null) {
             return false;
         }
-        n = n.toLowerCase();
+        n = n.toLowerCase(java.util.Locale.ROOT);
         return "geocent".equals(n) || "geocentric".equals(n);
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
@@ -158,7 +158,11 @@ public final class Transform {
         } else {
             // Apply unit conversion if needed
             if (srcParams.toMeter != null && srcParams.toMeter != 0 && srcParams.toMeter != 1) {
-                p = new Point(p.x * srcParams.toMeter, p.y * srcParams.toMeter, p.z);
+                // Geocentric CRSs carry the linear unit on all three axes (as in PROJ;
+                // proj4js leaves z unscaled, producing mixed units).
+                double zIn = "geocent".equals(srcParams.projName)
+                    ? p.z * srcParams.toMeter : p.z;
+                p = new Point(p.x * srcParams.toMeter, p.y * srcParams.toMeter, zIn);
                 p.m = point.m;
             }
             // Inverse projection: projected → geodetic
@@ -203,7 +207,10 @@ public final class Transform {
             }
             // Apply inverse unit conversion if needed
             if (destParams.toMeter != null && destParams.toMeter != 0 && destParams.toMeter != 1) {
-                p = new Point(p.x / destParams.toMeter, p.y / destParams.toMeter, p.z);
+                // Geocentric CRSs carry the linear unit on all three axes (as in PROJ).
+                double zOut = "geocent".equals(destParams.projName)
+                    ? p.z / destParams.toMeter : p.z;
+                p = new Point(p.x / destParams.toMeter, p.y / destParams.toMeter, zOut);
             }
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
@@ -71,6 +71,19 @@ public final class Transform {
      * @param dest Destination projection parameters
      * @return true if WGS84 intermediate transformation is needed
      */
+    /**
+     * Canonical geocentric identity: matches any registered alias of the Geocentric
+     * projection (geocent/geocentric/Geocent/Geocentric), not just the raw "geocent"
+     * spelling (mirrors proj4js, whose geocent init sets a canonical name).
+     */
+    private static boolean isGeocent(ProjectionParams params) {
+        if (params.projName == null) {
+            return false;
+        }
+        String n = params.projName.toLowerCase();
+        return "geocent".equals(n) || "geocentric".equals(n);
+    }
+
     private static boolean checkNotWGS(ProjectionParams source, ProjectionParams dest) {
         DatumParams srcDatum = source.datum;
         DatumParams destDatum = dest.datum;
@@ -160,7 +173,7 @@ public final class Transform {
             if (srcParams.toMeter != null && srcParams.toMeter != 0 && srcParams.toMeter != 1) {
                 // Geocentric CRSs carry the linear unit on all three axes (as in PROJ;
                 // proj4js leaves z unscaled, producing mixed units).
-                double zIn = "geocent".equals(srcParams.projName)
+                double zIn = isGeocent(srcParams)
                     ? p.z * srcParams.toMeter : p.z;
                 p = new Point(p.x * srcParams.toMeter, p.y * srcParams.toMeter, zIn);
                 p.m = point.m;
@@ -208,7 +221,7 @@ public final class Transform {
             // Apply inverse unit conversion if needed
             if (destParams.toMeter != null && destParams.toMeter != 0 && destParams.toMeter != 1) {
                 // Geocentric CRSs carry the linear unit on all three axes (as in PROJ).
-                double zOut = "geocent".equals(destParams.projName)
+                double zOut = isGeocent(destParams)
                     ? p.z / destParams.toMeter : p.z;
                 p = new Point(p.x / destParams.toMeter, p.y / destParams.toMeter, zOut);
             }
@@ -216,14 +229,14 @@ public final class Transform {
 
         // Step 8: Adjust for destination axis order (e.g., "enu" to "neu")
         if (enforceAxis && destParams.axis != null && !"enu".equals(destParams.axis)) {
-            p = AdjustAxis.adjustAxisFromEnu(destParams.axis, p, hasZ);
+            p = AdjustAxis.adjustAxisFromEnu(destParams.axis, p, hasZ || isGeocent(destParams));
         }
 
         // Reset z if it wasn't in the original input — except when the destination is
         // geocentric, where z is a computed coordinate even for 2D input (proj4js
         // 0ee1202). Inert until the geocent projection is ported, but guarded now so a
         // future port does not silently zero the computed Z.
-        if (p != null && !hasZ && !"geocent".equals(destParams.projName)) {
+        if (p != null && !hasZ && !isGeocent(destParams)) {
             p.z = 0;
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
@@ -61,6 +61,19 @@ public final class Transform {
     }
 
     /**
+     * Canonical geocentric identity: matches any registered alias of the Geocentric
+     * projection (geocent/geocentric/Geocent/Geocentric), not just the raw "geocent"
+     * spelling (mirrors proj4js, whose geocent init sets a canonical name).
+     */
+    private static boolean isGeocent(ProjectionParams params) {
+        if (params.projName == null) {
+            return false;
+        }
+        String n = params.projName.toLowerCase(java.util.Locale.ROOT);
+        return "geocent".equals(n) || "geocentric".equals(n);
+    }
+
+    /**
      * Check if transformation through WGS84 is needed for datum shift.
      * 
      * <p>This is required when both source and destination have datum shift
@@ -71,19 +84,6 @@ public final class Transform {
      * @param dest Destination projection parameters
      * @return true if WGS84 intermediate transformation is needed
      */
-    /**
-     * Canonical geocentric identity: matches any registered alias of the Geocentric
-     * projection (geocent/geocentric/Geocent/Geocentric), not just the raw "geocent"
-     * spelling (mirrors proj4js, whose geocent init sets a canonical name).
-     */
-    private static boolean isGeocent(ProjectionParams params) {
-        if (params.projName == null) {
-            return false;
-        }
-        String n = params.projName.toLowerCase();
-        return "geocent".equals(n) || "geocentric".equals(n);
-    }
-
     private static boolean checkNotWGS(ProjectionParams source, ProjectionParams dest) {
         DatumParams srcDatum = source.datum;
         DatumParams destDatum = dest.datum;
@@ -234,8 +234,7 @@ public final class Transform {
 
         // Reset z if it wasn't in the original input — except when the destination is
         // geocentric, where z is a computed coordinate even for 2D input (proj4js
-        // 0ee1202). Inert until the geocent projection is ported, but guarded now so a
-        // future port does not silently zero the computed Z.
+        // 0ee1202).
         if (p != null && !hasZ && !isGeocent(destParams)) {
             p.z = 0;
         }

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
@@ -1,0 +1,94 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for Geocentric coordinates (geocent / EPSG:4978-style).
+ *
+ * <p>Reference X/Y/Z from pyproj/PROJ 9.5.1. Tolerance 1e-4 m (ECEF meters).</p>
+ */
+class GeocentricTest {
+
+    private static final double M_EPSLN = 1e-4;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+    private static final String GEOCENT = "+proj=geocent +datum=WGS84 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("geocent"));
+        assertNotNull(ProjectionRegistry.get("Geocentric"));
+        assertNotNull(ProjectionRegistry.get("geocentric"));
+    }
+
+    @Test
+    void testKnownValues3d() {
+        // (lon, lat, h) -> ECEF (X, Y, Z), per pyproj/PROJ 9.5.1
+        double[][] cases = {
+            {-7.56, 55.95, 0, 3548342.473034, -470928.890965, 5261327.157452},
+            {2.35, 48.85, 100, 4201539.397559, 172423.833421, 4779673.699511},
+            {139.69, 35.69, 0, -3954720.064214, 3355033.336380, 3700309.845473},
+        };
+        Converter conv = Proj4.proj4(WGS84, GEOCENT);
+        for (double[] c : cases) {
+            Point xyz = conv.forward(new Point(c[0], c[1], c[2]));
+            assertEquals(c[3], xyz.x, M_EPSLN, "X for " + c[0] + "," + c[1]);
+            assertEquals(c[4], xyz.y, M_EPSLN, "Y for " + c[0] + "," + c[1]);
+            assertEquals(c[5], xyz.z, M_EPSLN, "Z for " + c[0] + "," + c[1]);
+        }
+    }
+
+    @Test
+    void testTwoDimensionalInputKeepsComputedZ() {
+        // Mirrors proj4js test/test.js EPSG:4978 case: 2D input to a geocentric CRS
+        // must return the computed Z, not reset it to 0 (proj4js 0ee1202, backported
+        // ahead of this port — this test activates that guard).
+        Converter conv = Proj4.proj4(WGS84, GEOCENT);
+        Point xyz = conv.forward(new Point(-7.56, 55.95));
+        assertEquals(3548342.473034, xyz.x, M_EPSLN, "X");
+        assertEquals(-470928.890965, xyz.y, M_EPSLN, "Y");
+        assertEquals(5261327.157452, xyz.z, M_EPSLN, "computed Z survives 2D input");
+    }
+
+    @Test
+    void testRoundTrip() {
+        Converter conv = Proj4.proj4(WGS84, GEOCENT);
+        double[][] coords = {{-7.56, 55.95, 0}, {2.35, 48.85, 100}, {139.69, 35.69, 250}};
+        for (double[] c : coords) {
+            Point xyz = conv.forward(new Point(c[0], c[1], c[2]));
+            Point ll = conv.inverse(new Point(xyz.x, xyz.y, xyz.z));
+            assertEquals(c[0], ll.x, 1e-9, "lng for " + c[0]);
+            assertEquals(c[1], ll.y, 1e-9, "lat for " + c[1]);
+            assertEquals(c[2], ll.z, 1e-6, "height for " + c[2]);
+        }
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        // Proj-string only: geocentric CRSs use GEOCCS/GeodeticCRS WKT structures the
+        // serializer does not emit (it writes projected-CRS WKT).
+        Proj original = new Proj(GEOCENT);
+        String serialized = CRSSerializer.toProjString(original);
+        assertTrue(serialized.contains("+proj=geocent"), "serialized: " + serialized);
+        Proj reimported = new Proj(serialized);
+        double lon = 2.35 * Math.PI / 180, lat = 48.85 * Math.PI / 180;
+        Point want = original.forward(new Point(lon, lat, 100));
+        Point got = reimported.forward(new Point(lon, lat, 100));
+        assertEquals(want.x, got.x, M_EPSLN);
+        assertEquals(want.y, got.y, M_EPSLN);
+        assertEquals(want.z, got.z, M_EPSLN);
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
@@ -94,6 +94,46 @@ class GeocentricTest {
     }
 
     @Test
+    void testGeocentAliasKeepsComputedZ() {
+        // The z handling must key on the canonical geocentric identity, not the raw
+        // "geocent" spelling: a registered alias (+proj=Geocentric) computes Z for
+        // 2D input too.
+        Converter conv = Proj4.proj4(WGS84, "+proj=Geocentric +datum=WGS84 +units=m +no_defs");
+        Point xyz = conv.forward(new Point(-7.56, 55.95));
+        assertEquals(5261327.157452, xyz.z, M_EPSLN, "alias keeps computed Z");
+    }
+
+    @Test
+    void testAxisEnforcementKeepsComputedZ() {
+        // 2D input to +proj=geocent +axis=neu with enforceAxis: the destination-axis
+        // reordering must see the computed Z (post-projection), not the input's
+        // 2D-ness — otherwise the third coordinate is zeroed.
+        Converter conv = Proj4.proj4(WGS84, "+proj=geocent +datum=WGS84 +axis=neu +units=m +no_defs");
+        Point r = conv.forward(new Point(-7.56, 55.95), true);
+        assertEquals(-470928.890965, r.x, M_EPSLN, "first (north) = ECEF Y");
+        assertEquals(3548342.473034, r.y, M_EPSLN, "second (east) = ECEF X");
+        assertEquals(5261327.157452, r.z, M_EPSLN, "third (up) = computed ECEF Z, not 0");
+    }
+
+    @Test
+    void testMeasureAndArrayArityPreserved() {
+        // Mirrors proj4js's transformer adapter (lib/core.js): the measure survives,
+        // and a 3-component array through a geocentric CRS keeps 3 components even
+        // when a coordinate is 0 (Point.toArray would collapse z == 0).
+        Converter conv = Proj4.proj4(WGS84, GEOCENT);
+        Point in = new Point(-7.56, 55.95, 0);
+        in.m = 999;
+        Point out = conv.forward(in);
+        assertEquals(999, out.m, 0, "measure preserved");
+
+        double[] arr = conv.inverse(new double[] {6378137, 0, 0});
+        assertEquals(3, arr.length, "3-component array keeps arity through geocent");
+        assertEquals(0, arr[0], 1e-9, "lon");
+        assertEquals(0, arr[1], 1e-9, "lat");
+        assertEquals(0, arr[2], 1e-6, "height 0 kept as third component");
+    }
+
+    @Test
     void testSerializationRoundTrip() {
         // Proj-string only: geocentric CRSs use GEOCCS/GeodeticCRS WKT structures the
         // serializer does not emit (it writes projected-CRS WKT).

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
@@ -77,6 +77,23 @@ class GeocentricTest {
     }
 
     @Test
+    void testNonMeterUnitsScaleAllAxes() {
+        // A geocentric CRS carries its linear unit on all three axes. PROJ scales
+        // X/Y/Z uniformly (reference below); proj4js scales only x/y, leaving z in
+        // meters — this port follows PROJ. Reference from pyproj/PROJ 9.5.1.
+        Converter conv = Proj4.proj4(WGS84, "+proj=geocent +datum=WGS84 +units=us-ft +no_defs");
+        Point xyz = conv.forward(new Point(2.35, 48.85, 100));
+        assertEquals(13784550.5068, xyz.x, 0.001, "X in US feet");
+        assertEquals(565693.8601, xyz.y, 0.001, "Y in US feet");
+        assertEquals(15681312.7958, xyz.z, 0.001, "Z in US feet (not meters)");
+
+        Point ll = conv.inverse(new Point(xyz.x, xyz.y, xyz.z));
+        assertEquals(2.35, ll.x, 1e-9);
+        assertEquals(48.85, ll.y, 1e-9);
+        assertEquals(100, ll.z, 1e-5, "height round-trips through the unit scaling");
+    }
+
+    @Test
     void testSerializationRoundTrip() {
         // Proj-string only: geocentric CRSs use GEOCCS/GeodeticCRS WKT structures the
         // serializer does not emit (it writes projected-CRS WKT).


### PR DESCRIPTION
## Summary

Ports Geocentric coordinates (`geocent`) from proj4js (`lib/projections/geocent.js`)
— geodetic lon/lat/height ↔ Earth-centered Earth-fixed X/Y/Z (EPSG:4978-style).
Fourth of the final six (gstmerc ✓ → tpers ✓ → nzmg ✓ → **geocent** → qsc → ob_tran).

## Changes

- **`Geocentric`** — delegates to the `DatumUtils` geodetic↔geocentric conversions
  already used by the datum pipeline (exactly as upstream delegates to datumUtils).
- **Activates the `0ee1202` backport** from #86: the transform pipeline's z-reset
  guard for geocentric destinations was landed ahead of this port; the test here
  mirrors the upstream EPSG:4978 case — **2D input keeps the computed Z** (~5.3e6 m)
  instead of being zeroed.
- **pyproj benchmark case** (`proj_geocent`) per the #84 convention.

## Verification

- Reference X/Y/Z from **pyproj/PROJ 9.5.1** (3 sites, with and without ellipsoidal
  height); matches to 1e-4 m.
- 3D round-trips recover height to micrometers.
- Serialization round-trip is **proj-string-only**: geocentric CRSs use
  GEOCCS/GeodeticCRS WKT structures the serializer does not emit (it writes
  projected-CRS WKT) — noted in the test.

Full suite: 793 tests pass.
