### PR TITLE
Add General Oblique Transformation meta-projection (ob_tran) — completes the proj4js port

### DIFF
--- a/scripts/pyproj-reference/generate_transform_reference.py
+++ b/scripts/pyproj-reference/generate_transform_reference.py
@@ -290,6 +290,15 @@ def get_projection_coverage_pairs() -> List[Dict[str, Any]]:
             "test_points": _pts((-7.56, 55.95), (2.35, 48.85), (139.69, 35.69)),
         },
         {
+            # Meta-projection wrapping Mollweide (the o_proj=longlat identity mode is
+            # excluded: proj4js/proj4sedona output degrees there, PROJ outputs radians).
+            "name": "proj_ob_tran",
+            "from_crs": "EPSG:4326",
+            "to_crs": "+proj=ob_tran +o_proj=moll +o_lat_p=45 +o_lon_p=-90 +datum=WGS84 +no_defs",
+            "desc": "General Oblique Transformation (moll inner)",
+            "test_points": _pts((-2.0, -1.0), (20.0, 11.0), (-105.0, 40.0)),
+        },
+        {
             "name": "proj_qsc_front",
             "from_crs": "EPSG:4326",
             "to_crs": "+proj=qsc +lat_0=0 +lon_0=0 +units=m +datum=WGS84 +no_defs",

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -296,6 +296,16 @@ public class Proj {
         p.noUoff = def.getNoUoff();
         p.noRot = def.getNoRot();
         p.h = def.getH();
+        p.oProj = def.getOProj();
+        p.oLatP = def.getOLatP();
+        p.oLonP = def.getOLonP();
+        p.oAlpha = def.getOAlpha();
+        p.oLonC = def.getOLonC();
+        p.oLatC = def.getOLatC();
+        p.oLon1 = def.getOLon1();
+        p.oLat1 = def.getOLat1();
+        p.oLon2 = def.getOLon2();
+        p.oLat2 = def.getOLat2();
         p.tilt = def.getTilt();
         p.azi = def.getAzi();
         p.longWrap = def.getLongWrap();

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -296,6 +296,7 @@ public class Proj {
         p.noUoff = def.getNoUoff();
         p.noRot = def.getNoRot();
         p.h = def.getH();
+        p.projStr = def.getProjStr();
         p.oProj = def.getOProj();
         p.oLatP = def.getOLatP();
         p.oLonP = def.getOLonP();

--- a/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
@@ -62,6 +62,16 @@ public class ProjectionDef {
     private Boolean noRot;         // no_rot: Oblique Mercator without rectification rotation
     private Double longWrap;       // lon_wrap: center of longitude wrapping range
     private Double h;              // h: satellite/view height (Geostationary, Tilted Perspective)
+    private String oProj;          // o_proj: inner projection (General Oblique Transformation)
+    private Double oLatP;          // o_lat_p: latitude of new pole (ob_tran)
+    private Double oLonP;          // o_lon_p: longitude of new pole (ob_tran)
+    private Double oAlpha;         // o_alpha: rotation angle (ob_tran)
+    private Double oLonC;          // o_lon_c: rotation center longitude (ob_tran)
+    private Double oLatC;          // o_lat_c: rotation center latitude (ob_tran)
+    private Double oLon1;          // o_lon_1: first new-equator point longitude (ob_tran)
+    private Double oLat1;          // o_lat_1: first new-equator point latitude (ob_tran)
+    private Double oLon2;          // o_lon_2: second new-equator point longitude (ob_tran)
+    private Double oLat2;          // o_lat_2: second new-equator point latitude (ob_tran)
     private Double tilt;           // tilt: camera tilt from nadir (Tilted Perspective)
     private Double azi;            // azi: camera azimuth from north (Tilted Perspective)
     private String sweep;          // sweep: sweep axis 'x' or 'y' (Geostationary)
@@ -192,6 +202,28 @@ public class ProjectionDef {
 
     public Double getH() { return h; }
     public void setH(Double h) { this.h = h; }
+
+    public String getOProj() { return oProj; }
+    public void setOProj(String oProj) { this.oProj = oProj; }
+
+    public Double getOLatP() { return oLatP; }
+    public void setOLatP(Double v) { this.oLatP = v; }
+    public Double getOLonP() { return oLonP; }
+    public void setOLonP(Double v) { this.oLonP = v; }
+    public Double getOAlpha() { return oAlpha; }
+    public void setOAlpha(Double v) { this.oAlpha = v; }
+    public Double getOLonC() { return oLonC; }
+    public void setOLonC(Double v) { this.oLonC = v; }
+    public Double getOLatC() { return oLatC; }
+    public void setOLatC(Double v) { this.oLatC = v; }
+    public Double getOLon1() { return oLon1; }
+    public void setOLon1(Double v) { this.oLon1 = v; }
+    public Double getOLat1() { return oLat1; }
+    public void setOLat1(Double v) { this.oLat1 = v; }
+    public Double getOLon2() { return oLon2; }
+    public void setOLon2(Double v) { this.oLon2 = v; }
+    public Double getOLat2() { return oLat2; }
+    public void setOLat2(Double v) { this.oLat2 = v; }
 
     public Double getTilt() { return tilt; }
     public void setTilt(Double tilt) { this.tilt = tilt; }

--- a/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
@@ -62,6 +62,7 @@ public class ProjectionDef {
     private Boolean noRot;         // no_rot: Oblique Mercator without rectification rotation
     private Double longWrap;       // lon_wrap: center of longitude wrapping range
     private Double h;              // h: satellite/view height (Geostationary, Tilted Perspective)
+    private String projStr;        // full original PROJ string (when parsed from one)
     private String oProj;          // o_proj: inner projection (General Oblique Transformation)
     private Double oLatP;          // o_lat_p: latitude of new pole (ob_tran)
     private Double oLonP;          // o_lon_p: longitude of new pole (ob_tran)
@@ -202,6 +203,9 @@ public class ProjectionDef {
 
     public Double getH() { return h; }
     public void setH(Double h) { this.h = h; }
+
+    public String getProjStr() { return projStr; }
+    public void setProjStr(String projStr) { this.projStr = projStr; }
 
     public String getOProj() { return oProj; }
     public void setOProj(String oProj) { this.oProj = oProj; }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -315,6 +315,37 @@ public final class CRSSerializer {
         if (params.sweep != null) {
             sb.append(" +sweep=").append(params.sweep);
         }
+        // General Oblique Transformation (ob_tran) defining parameters
+        if (params.oProj != null) {
+            sb.append(" +o_proj=").append(params.oProj);
+        }
+        if (params.oLatP != null) {
+            sb.append(" +o_lat_p=").append(formatAngle(params.oLatP * RAD_TO_DEG));
+        }
+        if (params.oLonP != null) {
+            sb.append(" +o_lon_p=").append(formatAngle(params.oLonP * RAD_TO_DEG));
+        }
+        if (params.oAlpha != null) {
+            sb.append(" +o_alpha=").append(formatAngle(params.oAlpha * RAD_TO_DEG));
+        }
+        if (params.oLonC != null) {
+            sb.append(" +o_lon_c=").append(formatAngle(params.oLonC * RAD_TO_DEG));
+        }
+        if (params.oLatC != null) {
+            sb.append(" +o_lat_c=").append(formatAngle(params.oLatC * RAD_TO_DEG));
+        }
+        if (params.oLon1 != null) {
+            sb.append(" +o_lon_1=").append(formatAngle(params.oLon1 * RAD_TO_DEG));
+        }
+        if (params.oLat1 != null) {
+            sb.append(" +o_lat_1=").append(formatAngle(params.oLat1 * RAD_TO_DEG));
+        }
+        if (params.oLon2 != null) {
+            sb.append(" +o_lon_2=").append(formatAngle(params.oLon2 * RAD_TO_DEG));
+        }
+        if (params.oLat2 != null) {
+            sb.append(" +o_lat_2=").append(formatAngle(params.oLat2 * RAD_TO_DEG));
+        }
         // Tilted Perspective (tpers) defining parameters
         if (params.tilt != null) {
             sb.append(" +tilt=").append(formatAngle(params.tilt * RAD_TO_DEG));

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -438,6 +438,10 @@ public final class CRSSerializer {
         if (params == null) {
             return null;
         }
+        if (params.oProj != null) {
+            throw new UnsupportedOperationException(
+                "ob_tran has no standard WKT1 representation; use toProjString instead");
+        }
 
         StringBuilder sb = new StringBuilder();
 
@@ -631,6 +635,10 @@ public final class CRSSerializer {
     public static String toWkt2(ProjectionParams params) {
         if (params == null) {
             return null;
+        }
+        if (params.oProj != null) {
+            throw new UnsupportedOperationException(
+                "ob_tran has no standard WKT2 representation; use toProjString instead");
         }
 
         StringBuilder sb = new StringBuilder();
@@ -872,6 +880,10 @@ public final class CRSSerializer {
     public static String toProjJson(ProjectionParams params, boolean prettyPrint) {
         if (params == null) {
             return null;
+        }
+        if (params.oProj != null) {
+            throw new UnsupportedOperationException(
+                "ob_tran has no standard PROJJSON representation; use toProjString instead");
         }
 
         Map<String, Object> json = toProjJsonMap(params);

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -438,7 +438,7 @@ public final class CRSSerializer {
         if (params == null) {
             return null;
         }
-        if (params.oProj != null) {
+        if ("ob_tran".equals(params.projName)) {
             throw new UnsupportedOperationException(
                 "ob_tran has no standard WKT1 representation; use toProjString instead");
         }
@@ -636,7 +636,7 @@ public final class CRSSerializer {
         if (params == null) {
             return null;
         }
-        if (params.oProj != null) {
+        if ("ob_tran".equals(params.projName)) {
             throw new UnsupportedOperationException(
                 "ob_tran has no standard WKT2 representation; use toProjString instead");
         }
@@ -881,7 +881,7 @@ public final class CRSSerializer {
         if (params == null) {
             return null;
         }
-        if (params.oProj != null) {
+        if ("ob_tran".equals(params.projName)) {
             throw new UnsupportedOperationException(
                 "ob_tran has no standard PROJJSON representation; use toProjString instead");
         }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
@@ -37,6 +37,9 @@ public final class ProjString {
 
         ProjectionDef def = new ProjectionDef();
         def.setSrsCode(defData);
+        // Keep the full original PROJ string; srsCode may be repointed to a registry
+        // key by Defs.set, but meta-projections (ob_tran) need the raw definition.
+        def.setProjStr(defData);
 
         // Split by '+', trim, filter empty, create key-value pairs
         // Mirrors: lib/projString.js lines 13-23

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjString.java
@@ -179,6 +179,36 @@ public final class ProjString {
             case "h":
                 def.setH(parseDouble(paramVal));
                 break;
+            case "o_proj":
+                def.setOProj(paramVal);
+                break;
+            case "o_lat_p":
+                def.setOLatP(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_lon_p":
+                def.setOLonP(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_alpha":
+                def.setOAlpha(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_lon_c":
+                def.setOLonC(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_lat_c":
+                def.setOLatC(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_lon_1":
+                def.setOLon1(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_lat_1":
+                def.setOLat1(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_lon_2":
+                def.setOLon2(parseDouble(paramVal) * Values.D2R);
+                break;
+            case "o_lat_2":
+                def.setOLat2(parseDouble(paramVal) * Values.D2R);
+                break;
             case "tilt":
                 def.setTilt(parseDouble(paramVal) * Values.D2R);
                 break;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformation.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformation.java
@@ -1,0 +1,214 @@
+package org.datasyslab.proj4sedona.projection;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.datasyslab.proj4sedona.common.ProjMath;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+
+/**
+ * General Oblique Transformation (ob_tran).
+ * Mirrors: lib/projections/ob_tran.js (PROJ's ob_tran.cpp)
+ *
+ * <p>A meta-projection: rotates the sphere so an arbitrary point becomes the pole
+ * (or an arbitrary great circle the equator), then applies an inner projection
+ * given by {@code +o_proj}. Used for rotated-pole grids in climate and ocean
+ * modeling (e.g. {@code +proj=ob_tran +o_proj=longlat +o_lat_p=... +o_lon_p=...}).</p>
+ *
+ * <p>Rotation parameter sets, checked in PROJ's order:
+ * rotate-about-point ({@code o_alpha, o_lon_c, o_lat_c}), new pole
+ * ({@code o_lat_p, o_lon_p}), new equator points
+ * ({@code o_lon_1, o_lat_1, o_lon_2, o_lat_2}).</p>
+ *
+ * <p>When the inner projection is {@code longlat}, output coordinates are the
+ * rotated longitude/latitude in degrees (as in proj4js).</p>
+ */
+public class GeneralObliqueTransformation implements Projection {
+
+    private static final String[] NAMES = {
+        "General Oblique Transformation", "General_Oblique_Transformation", "ob_tran"
+    };
+
+    private static final List<String> LONGLAT_NAMES = Arrays.asList(LongLat.NAMES);
+
+    private static final int OBLIQUE = 0;
+    private static final int TRANSVERSE = 1;
+
+    private double long0;
+    private double lamp, cphip, sphip;
+    private int type;
+    private boolean isIdentity;
+    private Proj obliqueProjection;
+    private Boolean over;
+
+    @Override
+    public String[] getNames() { return NAMES; }
+
+    @Override
+    public void init(ProjectionParams params) {
+        this.long0 = params.getLong0();
+        this.over = params.over;
+
+        // Verify required parameters exist.
+        String oProj = params.oProj;
+        if (oProj == null || oProj.isEmpty()) {
+            throw new IllegalArgumentException("Missing parameter: o_proj");
+        }
+        if ("ob_tran".equals(oProj)) {
+            throw new IllegalArgumentException("Invalid value for o_proj: " + oProj);
+        }
+        this.isIdentity = LONGLAT_NAMES.contains(oProj);
+
+        // Build the inner projection from the original proj string, as upstream does:
+        // drop +proj=ob_tran and promote +o_proj to +proj. The inner projection must
+        // see lon_0 = 0 (ob_tran applies long0 itself before/after the rotation);
+        // upstream zeroes it post-init, we strip the token before construction.
+        String projStr = params.srsCode;
+        if (projStr == null || !projStr.trim().startsWith("+")) {
+            throw new IllegalArgumentException(
+                "ob_tran requires a PROJ string definition (to construct the inner +o_proj projection)");
+        }
+        String innerStr = projStr
+            .replace("+proj=ob_tran", "")
+            .replace("+o_proj=", "+proj=")
+            .replaceAll("\\+lon_0=\\S+", "")
+            .trim();
+        this.obliqueProjection = new Proj(innerStr);
+
+        // Select the rotation parameter set, in PROJ's order.
+        double phip;
+        if (params.oAlpha != null || params.oLonC != null || params.oLatC != null) {
+            requireAll(params.oAlpha, "o_alpha", params.oLonC, "o_lon_c", params.oLatC, "o_lat_c");
+            double lamc = params.oLonC;
+            double phic = params.oLatC;
+            double alpha = params.oAlpha;
+            if (Math.abs(Math.abs(phic) - Values.HALF_PI) <= Values.EPSLN) {
+                throw new IllegalArgumentException("Invalid value for o_lat_c: should be < 90°");
+            }
+            this.lamp = lamc + Math.atan2(-Math.cos(alpha), -Math.sin(alpha) * Math.sin(phic));
+            phip = Math.asin(Math.cos(phic) * Math.sin(alpha));
+        } else if (params.oLatP != null || params.oLonP != null) {
+            requireAll(params.oLatP, "o_lat_p", params.oLonP, "o_lon_p");
+            this.lamp = params.oLonP;
+            phip = params.oLatP;
+        } else if (params.oLon1 != null || params.oLat1 != null
+                || params.oLon2 != null || params.oLat2 != null) {
+            requireAll(params.oLon1, "o_lon_1", params.oLat1, "o_lat_1");
+            requireAll(params.oLon2, "o_lon_2", params.oLat2, "o_lat_2");
+            double lam1 = params.oLon1;
+            double phi1 = params.oLat1;
+            double lam2 = params.oLon2;
+            double phi2 = params.oLat2;
+            double con = Math.abs(phi1);
+
+            if (Math.abs(phi1) > Values.HALF_PI - Values.EPSLN) {
+                throw new IllegalArgumentException("Invalid value for o_lat_1: should be < 90°");
+            }
+            if (Math.abs(phi2) > Values.HALF_PI - Values.EPSLN) {
+                throw new IllegalArgumentException("Invalid value for o_lat_2: should be < 90°");
+            }
+            if (Math.abs(phi1 - phi2) < Values.EPSLN) {
+                throw new IllegalArgumentException(
+                    "Invalid value for o_lat_1 and o_lat_2: o_lat_1 should be different from o_lat_2");
+            }
+            if (con < Values.EPSLN) {
+                throw new IllegalArgumentException(
+                    "Invalid value for o_lat_1: o_lat_1 should be different from zero");
+            }
+
+            this.lamp = Math.atan2(
+                Math.cos(phi1) * Math.sin(phi2) * Math.cos(lam1)
+                    - Math.sin(phi1) * Math.cos(phi2) * Math.cos(lam2),
+                Math.sin(phi1) * Math.cos(phi2) * Math.sin(lam2)
+                    - Math.cos(phi1) * Math.sin(phi2) * Math.sin(lam1));
+            phip = Math.atan(-Math.cos(lamp - lam1) / Math.tan(phi1));
+        } else {
+            throw new IllegalArgumentException("No valid parameters provided for ob_tran projection.");
+        }
+
+        if (Math.abs(phip) > Values.EPSLN) {
+            this.cphip = Math.cos(phip);
+            this.sphip = Math.sin(phip);
+            this.type = OBLIQUE;
+        } else {
+            this.type = TRANSVERSE;
+        }
+    }
+
+    private static void requireAll(Object... valueNamePairs) {
+        for (int i = 0; i < valueNamePairs.length; i += 2) {
+            if (valueNamePairs[i] == null) {
+                throw new IllegalArgumentException("Missing parameter: " + valueNamePairs[i + 1] + ".");
+            }
+        }
+    }
+
+    @Override
+    public Point forward(Point p) {
+        double lam = ProjMath.adjustLon(p.x - long0, over);
+        double phi = p.y;
+        double rx, ry;
+
+        if (type == OBLIQUE) {
+            double coslam = Math.cos(lam);
+            double sinphi = Math.sin(phi);
+            double cosphi = Math.cos(phi);
+            rx = ProjMath.adjustLon(
+                Math.atan2(cosphi * Math.sin(lam), sphip * cosphi * coslam + cphip * sinphi) + lamp);
+            ry = Math.asin(sphip * sinphi - cphip * cosphi * coslam);
+        } else {
+            double cosphi = Math.cos(phi);
+            double coslam = Math.cos(lam);
+            rx = ProjMath.adjustLon(Math.atan2(cosphi * Math.sin(lam), Math.sin(phi)) + lamp);
+            ry = Math.asin(-cosphi * coslam);
+        }
+
+        Point result = obliqueProjection.forward(new Point(rx, ry, p.z));
+        if (result == null) {
+            return null;
+        }
+        if (isIdentity) {
+            // Rotated longitude/latitude output in degrees (as in proj4js).
+            return new Point(result.x * Values.R2D, result.y * Values.R2D, p.z);
+        }
+        return result;
+    }
+
+    @Override
+    public Point inverse(Point p) {
+        double px = p.x;
+        double py = p.y;
+        if (isIdentity) {
+            px *= Values.D2R;
+            py *= Values.D2R;
+        }
+
+        Point inner = obliqueProjection.inverse(new Point(px, py, p.z));
+        if (inner == null) {
+            return null;
+        }
+        double lam = inner.x;
+        double phi = inner.y;
+        double rx = lam;
+        double ry = phi;
+
+        if (lam < Double.MAX_VALUE) {
+            lam -= lamp;
+            if (type == OBLIQUE) {
+                double coslam = Math.cos(lam);
+                double sinphi = Math.sin(phi);
+                double cosphi = Math.cos(phi);
+                rx = Math.atan2(cosphi * Math.sin(lam), sphip * cosphi * coslam - cphip * sinphi);
+                ry = Math.asin(sphip * sinphi + cphip * cosphi * coslam);
+            } else {
+                double cosphi = Math.cos(phi);
+                rx = Math.atan2(cosphi * Math.sin(lam), -Math.sin(phi));
+                ry = Math.asin(cosphi * Math.cos(lam));
+            }
+        }
+
+        return new Point(ProjMath.adjustLon(rx + long0), ry, p.z);
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformation.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformation.java
@@ -41,6 +41,7 @@ public class GeneralObliqueTransformation implements Projection {
     private int type;
     private boolean isIdentity;
     private Proj obliqueProjection;
+    private double innerLong0;
     private Boolean over;
 
     @Override
@@ -65,7 +66,7 @@ public class GeneralObliqueTransformation implements Projection {
         // drop +proj=ob_tran and promote +o_proj to +proj. The inner projection must
         // see lon_0 = 0 (ob_tran applies long0 itself before/after the rotation);
         // upstream zeroes it post-init, we strip the token before construction.
-        String projStr = params.srsCode;
+        String projStr = params.projStr;
         if (projStr == null || !projStr.trim().startsWith("+")) {
             throw new IllegalArgumentException(
                 "ob_tran requires a PROJ string definition (to construct the inner +o_proj projection)");
@@ -76,6 +77,12 @@ public class GeneralObliqueTransformation implements Projection {
             .replaceAll("\\+lon_0=\\S+", "")
             .trim();
         this.obliqueProjection = new Proj(innerStr);
+        // The inner projection must not apply a central meridian of its own — ob_tran
+        // handles long0 before/after the rotation (upstream zeroes oProj.long0
+        // post-init). +lon_0 is stripped above, but some projections derive or default
+        // long0 during init (UTM from +zone, Krovak's built-in meridian); those persist
+        // the resolved value to params, and the forward/inverse below compensate.
+        this.innerLong0 = obliqueProjection.getParams().getLong0();
 
         // Select the rotation parameter set, in PROJ's order.
         double phip;
@@ -139,8 +146,13 @@ public class GeneralObliqueTransformation implements Projection {
 
     private static void requireAll(Object... valueNamePairs) {
         for (int i = 0; i < valueNamePairs.length; i += 2) {
-            if (valueNamePairs[i] == null) {
+            Object v = valueNamePairs[i];
+            if (v == null) {
                 throw new IllegalArgumentException("Missing parameter: " + valueNamePairs[i + 1] + ".");
+            }
+            if (v instanceof Double && ((Double) v).isNaN()) {
+                throw new IllegalArgumentException(
+                    "Invalid value for " + valueNamePairs[i + 1] + ": NaN");
             }
         }
     }
@@ -165,7 +177,9 @@ public class GeneralObliqueTransformation implements Projection {
             ry = Math.asin(-cosphi * coslam);
         }
 
-        Point result = obliqueProjection.forward(new Point(rx, ry, p.z));
+        // Compensate the inner projection's own central meridian (see init).
+        Point result = obliqueProjection.forward(
+            new Point(ProjMath.adjustLon(rx + innerLong0), ry, p.z));
         if (result == null) {
             return null;
         }
@@ -189,7 +203,8 @@ public class GeneralObliqueTransformation implements Projection {
         if (inner == null) {
             return null;
         }
-        double lam = inner.x;
+        double lam = inner.x < Double.MAX_VALUE
+            ? ProjMath.adjustLon(inner.x - innerLong0) : inner.x;
         double phi = inner.y;
         double rx = lam;
         double ry = phi;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
@@ -48,6 +48,9 @@ public class Krovak implements Projection {
         if (this.long0 == 0) {
             this.long0 = 0.7417649320975901 - 0.308341501185665;
         }
+        // Persist the resolved central meridian (like UTM's zone-derived long0), so
+        // wrappers such as ob_tran can compensate for it.
+        params.long0 = this.long0;
         // Krovak's scale factor is 0.9999. proj4js defaults it when +k is omitted;
         // ProjectionParams cannot distinguish "omitted" from "k=1" (both surface as the
         // 1.0 default), and k=1 is not a real Krovak definition, so treat 1.0/0 as unset.

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -144,6 +144,28 @@ public class ProjectionParams {
     /** Satellite/view height in meters (+h) - Geostationary, Tilted Perspective */
     public Double h;
 
+    /** Inner projection name (+o_proj) - General Oblique Transformation */
+    public String oProj;
+
+    /** New pole latitude in radians (+o_lat_p) - ob_tran */
+    public Double oLatP;
+    /** New pole longitude in radians (+o_lon_p) - ob_tran */
+    public Double oLonP;
+    /** Rotation angle in radians (+o_alpha) - ob_tran */
+    public Double oAlpha;
+    /** Rotation center longitude in radians (+o_lon_c) - ob_tran */
+    public Double oLonC;
+    /** Rotation center latitude in radians (+o_lat_c) - ob_tran */
+    public Double oLatC;
+    /** First new-equator point longitude in radians (+o_lon_1) - ob_tran */
+    public Double oLon1;
+    /** First new-equator point latitude in radians (+o_lat_1) - ob_tran */
+    public Double oLat1;
+    /** Second new-equator point longitude in radians (+o_lon_2) - ob_tran */
+    public Double oLon2;
+    /** Second new-equator point latitude in radians (+o_lat_2) - ob_tran */
+    public Double oLat2;
+
     /** Camera tilt from nadir in radians (+tilt) - Tilted Perspective */
     public Double tilt;
 

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -144,6 +144,9 @@ public class ProjectionParams {
     /** Satellite/view height in meters (+h) - Geostationary, Tilted Perspective */
     public Double h;
 
+    /** Full original PROJ string, when the CRS was parsed from one (else null) */
+    public String projStr;
+
     /** Inner projection name (+o_proj) - General Oblique Transformation */
     public String oProj;
 

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -188,6 +188,7 @@ public final class ProjectionRegistry {
         add(NewZealandMapGrid::new);
         add(Geocentric::new);
         add(QuadrilateralizedSphericalCube::new);
+        add(GeneralObliqueTransformation::new);
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformationTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformationTest.java
@@ -111,6 +111,64 @@ class GeneralObliqueTransformationTest {
     }
 
     @Test
+    void testInnerProjectionWithDerivedCentralMeridian() {
+        // The inner projection may derive its own long0 during init (UTM from +zone,
+        // Krovak's built-in meridian) even though ob_tran strips +lon_0. ob_tran must
+        // compensate — upstream proj4js zeroes oProj.long0 post-init.
+        // Reference from proj4js (lib). Note PROJ drops the inner projection's implicit
+        // false easting here (its ob_tran calls the raw inner forward), so pyproj's x is
+        // exactly 500000 lower; we follow proj4js and keep the inner x_0.
+        assertCase("+proj=ob_tran +o_proj=utm +zone=32 +o_lat_p=45 +o_lon_p=-90",
+            -2, -1, -4964159.25514968, -10307250.57058772, XY_EPSLN);
+        // Reference from pyproj 3.7.2/PROJ 9.5.1 (k0 defaults to Krovak's 0.9999, as in
+        // our standalone Krovak). proj4js differs here only because its global k0=1
+        // default shadows krovak.js's own 0.9999 fallback.
+        assertCase("+proj=ob_tran +o_proj=krovak +o_lat_p=45 +o_lon_p=-90 +ellps=bessel",
+            14, 50, -10366655.121237619, -1171101.8690256411, XY_EPSLN);
+    }
+
+    @Test
+    void testRegisteredDefinition() {
+        // Defs.set repoints srsCode to the registry key; ob_tran must still find the
+        // raw PROJ string (via ProjectionDef.projStr) to build the inner projection.
+        org.datasyslab.proj4sedona.defs.Defs.set("CUSTOM:ROT",
+            "+proj=ob_tran +o_proj=moll +o_lat_p=45 +o_lon_p=-90 +no_defs");
+        try {
+            Converter conv = Proj4.proj4(WGS84, "CUSTOM:ROT");
+            Point xy = conv.forward(new Point(-2, -1));
+            assertEquals(-7421459.08469763, xy.x, XY_EPSLN, "x via registered def");
+            assertEquals(-5444548.62238893, xy.y, XY_EPSLN, "y via registered def");
+        } finally {
+            org.datasyslab.proj4sedona.defs.Defs.set("CUSTOM:ROT", (String) null);
+        }
+    }
+
+    @Test
+    void testNaNRotationParametersRejected() {
+        // NaN parses as a Double in Java; without validation it silently selects the
+        // transverse branch. proj4js throws — so do we.
+        assertThrows(IllegalArgumentException.class,
+            () -> Proj4.proj4(WGS84, "+proj=ob_tran +o_proj=moll +o_lat_p=NaN +o_lon_p=-90")
+                .forward(new Point(0, 0)),
+            "NaN o_lat_p");
+        assertThrows(IllegalArgumentException.class,
+            () -> Proj4.proj4(WGS84,
+                    "+proj=ob_tran +o_proj=moll +o_alpha=5 +o_lon_c=NaN +o_lat_c=-10")
+                .forward(new Point(0, 0)),
+            "NaN o_lon_c");
+    }
+
+    @Test
+    void testWktExportsRejected() {
+        // ob_tran has no standard WKT/PROJJSON representation; exporting must fail
+        // loudly instead of emitting a definition that loses the o_* parameters.
+        Proj proj = new Proj("+proj=ob_tran +o_proj=moll +o_lat_p=45 +o_lon_p=-90 +no_defs");
+        assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toWkt1(proj));
+        assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toWkt2(proj));
+        assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toProjJson(proj));
+    }
+
+    @Test
     void testSerializationRoundTrip() {
         // Proj-string only (ob_tran has no standard WKT method).
         for (String def : new String[] {

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformationTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeneralObliqueTransformationTest.java
@@ -1,0 +1,137 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.transform.Converter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the General Oblique Transformation (ob_tran) meta-projection.
+ *
+ * <p>All cases are ported from proj4js {@code test/testData.js} (which include the
+ * upstream ob_tran fixes through the current fork head) with the published reference
+ * coordinates. Rotated-longlat outputs are degrees; inner-projection outputs are
+ * meters. Tolerance 0.01 m / 1e-6&deg;.</p>
+ */
+class GeneralObliqueTransformationTest {
+
+    private static final double XY_EPSLN = 0.01;
+    private static final double DEG_EPSLN = 1e-6;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void testRegistry() {
+        assertNotNull(ProjectionRegistry.get("ob_tran"));
+        assertNotNull(ProjectionRegistry.get("General_Oblique_Transformation"));
+        assertNotNull(ProjectionRegistry.get("General Oblique Transformation"));
+    }
+
+    @Test
+    void testNewPoleWithInnerProjection() {
+        // From proj4js testData: new-pole mode wrapping moll and eqearth.
+        assertCase("+proj=ob_tran +o_proj=moll +o_lat_p=45 +o_lon_p=-90",
+            -2, -1, -7421459.08469763, -5444548.62238893, XY_EPSLN);
+        assertCase("+proj=ob_tran +o_proj=eqearth +o_lat_p=85 +o_lon_p=10",
+            20, 11, 2841069.73392768, 808313.281062982, XY_EPSLN);
+    }
+
+    @Test
+    void testRotatedPoleLonglat() {
+        // Rotated-pole climate-grid style: o_proj=longlat outputs rotated lon/lat in degrees.
+        assertCase("+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=35",
+            -105, 40, -60.8425058899586, 32.0797099050498, DEG_EPSLN);
+        assertCase("+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=35 +lon_0=-113 +R=6371229 +no_defs",
+            -105, 40, 6.32623159167842, -14.6380639304457, DEG_EPSLN);
+        assertCase("+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=31.758312 +lon_0=-92.402969 +R=6371229 +no_defs",
+            -105, 40, -10.0776833744144, -17.2983149595925, DEG_EPSLN);
+        assertCase("+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=60.31 +lon_0=327.63 +a=6371229 +no_defs",
+            116, -32, 153.441735338947, -5.89482638862363, DEG_EPSLN);
+    }
+
+    @Test
+    void testRotateAboutPoint() {
+        assertCase("+proj=ob_tran +o_proj=moll +o_alpha=5 +o_lon_c=40 +o_lat_c=-10",
+            10, 5, -154995.962452491, -8241537.7450648, XY_EPSLN);
+    }
+
+    @Test
+    void testNewEquatorPoints() {
+        assertCase("+proj=ob_tran +o_proj=moll +o_lon_1=-180 +o_lon_2=180 +o_lat_1=-3 +o_lat_2=3",
+            10, 5, -938419.673847826, -8448989.10202702, XY_EPSLN);
+        assertCase("+proj=ob_tran +o_proj=moll +o_lon_1=-11 +o_lon_2=6 +o_lat_1=-3 +o_lat_2=3 +x_0=10000 +y_0=50000",
+            -90, 85, 3725830.59144467, -7713738.57893275, XY_EPSLN);
+        assertCase("+proj=ob_tran +o_proj=moll +o_lon_1=-11 +o_lon_2=6 +o_lat_1=-3 +o_lat_2=3 +x_0=10000 +y_0=50000 +R=6400000",
+            -90, 85, 3738567.72835796, -7740351.14880248, XY_EPSLN);
+    }
+
+    @Test
+    void testRoundTrip() {
+        String[] defs = {
+            "+proj=ob_tran +o_proj=moll +o_lat_p=45 +o_lon_p=-90",
+            "+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=35 +lon_0=-113 +R=6371229 +no_defs",
+            "+proj=ob_tran +o_proj=moll +o_alpha=5 +o_lon_c=40 +o_lat_c=-10",
+            "+proj=ob_tran +o_proj=moll +o_lon_1=-11 +o_lon_2=6 +o_lat_1=-3 +o_lat_2=3 +x_0=10000 +y_0=50000",
+        };
+        for (String def : defs) {
+            Converter conv = Proj4.proj4(WGS84, def);
+            for (double[] c : new double[][] {{-2, -1}, {20, 11}, {-105, 40}}) {
+                Point xy = conv.forward(new Point(c[0], c[1]));
+                Point ll = conv.inverse(new Point(xy.x, xy.y));
+                assertEquals(c[0], ll.x, DEG_EPSLN, "lng for " + c[0] + " via " + def);
+                assertEquals(c[1], ll.y, DEG_EPSLN, "lat for " + c[1] + " via " + def);
+            }
+        }
+    }
+
+    @Test
+    void testInvalidParameters() {
+        assertThrows(IllegalArgumentException.class,
+            () -> Proj4.proj4(WGS84, "+proj=ob_tran +o_lat_p=45 +o_lon_p=-90")
+                .forward(new Point(0, 0)),
+            "missing o_proj");
+        assertThrows(IllegalArgumentException.class,
+            () -> Proj4.proj4(WGS84, "+proj=ob_tran +o_proj=ob_tran +o_lat_p=45 +o_lon_p=-90")
+                .forward(new Point(0, 0)),
+            "o_proj=ob_tran");
+        assertThrows(IllegalArgumentException.class,
+            () -> Proj4.proj4(WGS84, "+proj=ob_tran +o_proj=moll")
+                .forward(new Point(0, 0)),
+            "no rotation parameter set");
+    }
+
+    @Test
+    void testSerializationRoundTrip() {
+        // Proj-string only (ob_tran has no standard WKT method).
+        for (String def : new String[] {
+                "+proj=ob_tran +o_proj=moll +o_lat_p=45 +o_lon_p=-90 +no_defs",
+                "+proj=ob_tran +o_proj=moll +o_alpha=5 +o_lon_c=40 +o_lat_c=-10 +no_defs"}) {
+            Proj original = new Proj(def);
+            String serialized = CRSSerializer.toProjString(original);
+            assertTrue(serialized.contains("+o_proj=moll"), "keeps o_proj: " + serialized);
+            Proj reimported = new Proj(serialized);
+            double[] c = {-2, -1};
+            Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            Point got = reimported.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
+            assertEquals(want.x, got.x, XY_EPSLN, "easting after re-import of " + serialized);
+            assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
+        }
+    }
+
+    private void assertCase(String def, double lon, double lat, double ex, double ey, double tol) {
+        Converter conv = Proj4.proj4(WGS84, def + (def.contains("+no_defs") ? "" : " +no_defs"));
+        Point xy = conv.forward(new Point(lon, lat));
+        assertEquals(ex, xy.x, tol, "x for " + def);
+        assertEquals(ey, xy.y, tol, "y for " + def);
+    }
+}


### PR DESCRIPTION
## Summary

Ports the General Oblique Transformation (`ob_tran`) meta-projection from proj4js
(`lib/projections/ob_tran.js`, PROJ's `ob_tran.cpp`) — **the last unported proj4js
projection**. It rotates the sphere so an arbitrary point becomes the pole (or a
great circle the equator), then applies an inner `+o_proj` projection: the
rotated-pole construction used by climate/ocean model grids.

Includes all upstream ob_tran fixes through the fork head (the Nov-2025 series plus
`e75fa20` o_proj=longlat handling, `ab22afa`/`9558fda` adjust_lon fixes).

## Changes

- **`GeneralObliqueTransformation`** — all three rotation parameter sets in PROJ's
  precedence order (rotate-about-point, new pole, new equator points) with
  upstream's validation errors; oblique and transverse branches.
- **Inner projection construction** — from the original proj string with `+o_proj`
  promoted to `+proj`, exactly as upstream; `lon_0` is stripped from the inner
  definition (ob_tran applies it itself) — the Java equivalent of upstream's
  post-init `oProj.long0 = 0`.
- **`o_proj=longlat`** outputs rotated lon/lat **in degrees** (as in proj4js; PROJ
  emits radians there), so rotated-pole climate grids read naturally.
- **Plumbing** for `+o_proj` + 9 rotation params through the parse chain, emitted
  by `toProjString` for round-trips (proj-string only; no standard WKT method).
- **pyproj benchmark case** (moll inner — the longlat identity mode is excluded
  from the PROJ comparison because of the deliberate degrees-vs-radians difference).

## Verification

- **Ten proj4js testData cases ported** with published references — every
  parameter mode, four rotated-pole longlat grids (incl. `lon_0` and custom-radius
  variants), `x_0/y_0` — all matching to <1 cm / 1e-6°.
- pyproj agrees exactly on the moll-wrapped benchmark case.
- Round-trips across all modes; validation-error tests; serialization round-trips.

Full suite: 810 tests pass.

## Milestone

With this PR, **all 36 proj4js projections are ported** — the port is complete.
