### PR TITLE
Support geocentric (GeodeticCRS + Cartesian) PROJJSON documents

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -919,7 +919,7 @@ public final class CRSSerializer {
         }
 
         Map<String, Object> json = new LinkedHashMap<>();
-        
+
         boolean isGeographic = "longlat".equals(params.projName);
 
         if (isGeographic) {
@@ -927,6 +927,13 @@ public final class CRSSerializer {
             json.put("name", getCrsName(params));
             json.put("datum", buildProjJsonDatum(params));
             json.put("coordinate_system", buildProjJsonGeogCS());
+        } else if (isGeocentric(params)) {
+            // Geocentric CRSs are a GeodeticCRS with a Cartesian coordinate system in
+            // PROJJSON (e.g. EPSG:4978), not a ProjectedCRS with a conversion.
+            json.put("type", "GeodeticCRS");
+            json.put("name", getCrsName(params));
+            json.put("datum", buildProjJsonDatum(params));
+            json.put("coordinate_system", buildProjJsonGeocentricCS(params));
         } else {
             json.put("type", "ProjectedCRS");
             json.put("name", getCrsName(params));
@@ -949,6 +956,51 @@ public final class CRSSerializer {
         }
 
         return json;
+    }
+
+    /**
+     * Canonical geocentric identity, as in Transform: matches any registered alias of
+     * the Geocentric projection, not just the raw "geocent" spelling.
+     */
+    private static boolean isGeocentric(ProjectionParams params) {
+        if (params.projName == null) {
+            return false;
+        }
+        String n = params.projName.toLowerCase(Locale.ROOT);
+        return "geocent".equals(n) || "geocentric".equals(n);
+    }
+
+    private static Map<String, Object> buildProjJsonGeocentricCS(ProjectionParams params) {
+        // The linear unit lives on each axis. Well-known metre is the bare-string
+        // form (as PROJ emits for EPSG:4978); other units carry their to-metre factor.
+        Object unit;
+        if (params.toMeter == null || params.toMeter == 1.0) {
+            unit = "metre";
+        } else {
+            Map<String, Object> unitMap = new LinkedHashMap<>();
+            unitMap.put("type", "LinearUnit");
+            unitMap.put("name", params.units != null ? params.units : "unknown");
+            unitMap.put("conversion_factor", params.toMeter);
+            unit = unitMap;
+        }
+        Map<String, Object> cs = new LinkedHashMap<>();
+        cs.put("subtype", "Cartesian");
+        List<Map<String, Object>> axes = new ArrayList<>();
+        axes.add(buildGeocentricAxis("Geocentric X", "X", "geocentricX", unit));
+        axes.add(buildGeocentricAxis("Geocentric Y", "Y", "geocentricY", unit));
+        axes.add(buildGeocentricAxis("Geocentric Z", "Z", "geocentricZ", unit));
+        cs.put("axis", axes);
+        return cs;
+    }
+
+    private static Map<String, Object> buildGeocentricAxis(
+            String name, String abbreviation, String direction, Object unit) {
+        Map<String, Object> axis = new LinkedHashMap<>();
+        axis.put("name", name);
+        axis.put("abbreviation", abbreviation);
+        axis.put("direction", direction);
+        axis.put("unit", unit);
+        return axis;
     }
 
     private static Map<String, Object> buildProjJsonDatum(ProjectionParams params) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -979,7 +979,9 @@ public final class CRSSerializer {
         } else {
             Map<String, Object> unitMap = new LinkedHashMap<>();
             unitMap.put("type", "LinearUnit");
-            unitMap.put("name", params.units != null ? params.units : "unknown");
+            // Authority-style unit name, as the other PROJJSON paths emit (PROJ writes
+            // LENGTHUNIT["unknown",...] when only a bare to-metre factor is known).
+            unitMap.put("name", params.units != null ? getUnitName(params.units) : "unknown");
             unitMap.put("conversion_factor", params.toMeter);
             unit = unitMap;
         }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -87,6 +87,16 @@ public final class ProjJsonTransformer {
             case "type":
                 if ("GeographicCRS".equals(value)) {
                     def.setProjName("longlat");
+                } else if ("GeodeticCRS".equals(value)) {
+                    // A GeodeticCRS with a Cartesian coordinate system is a geocentric
+                    // CRS (e.g. EPSG:4978) and maps to the geocent projection.
+                    Object coordSys = projjson.get("coordinate_system");
+                    if (coordSys instanceof Map) {
+                        Object subtype = ((Map<String, Object>) coordSys).get("subtype");
+                        if ("Cartesian".equals(subtype)) {
+                            def.setProjName("geocent");
+                        }
+                    }
                 } else if ("ProjectedCRS".equals(value)) {
                     // projName will be set from conversion.method.name
                     Object conversion = projjson.get("conversion");
@@ -159,21 +169,7 @@ public final class ProjJsonTransformer {
                 break;
 
             case "unit":
-                if (value instanceof Map) {
-                    Map<String, Object> unit = (Map<String, Object>) value;
-                    Object unitName = unit.get("name");
-                    if (unitName != null) {
-                        String units = unitName.toString().toLowerCase();
-                        if ("metre".equals(units)) {
-                            units = "meter";
-                        }
-                        def.setUnits(units);
-                    }
-                    Object convFactor = unit.get("conversion_factor");
-                    if (convFactor != null) {
-                        def.setToMeter(toDouble(convFactor));
-                    }
-                }
+                processUnit(value, def);
                 break;
 
             case "base_crs":
@@ -352,34 +348,49 @@ public final class ProjJsonTransformer {
 
             // Process units from coordinate system
             Object unit = coordSys.get("unit");
-            if (unit instanceof Map) {
-                processUnit((Map<String, Object>) unit, def);
+            if (unit != null) {
+                processUnit(unit, def);
             } else if (!axes.isEmpty()) {
                 // Try to get unit from first axis
                 Object axisUnit = axes.get(0).get("unit");
-                if (axisUnit instanceof Map) {
-                    processUnit((Map<String, Object>) axisUnit, def);
+                if (axisUnit != null) {
+                    processUnit(axisUnit, def);
                 }
             }
         }
     }
 
     /**
-     * Process unit info.
+     * Process unit info. PROJJSON units are either an object with name and
+     * conversion_factor, or a bare string for well-known units (e.g. the "metre"
+     * on EPSG:4978's geocentric axes).
      */
-    private static void processUnit(Map<String, Object> unit, ProjectionDef def) {
-        Object unitName = unit.get("name");
-        if (unitName != null) {
-            String units = unitName.toString().toLowerCase();
-            if ("metre".equals(units)) {
-                units = "meter";
-            }
-            def.setUnits(units);
+    @SuppressWarnings("unchecked")
+    private static void processUnit(Object unit, ProjectionDef def) {
+        if (unit instanceof String) {
+            setUnitsFromName(unit.toString(), def);
+            return;
         }
-        Object convFactor = unit.get("conversion_factor");
+        if (!(unit instanceof Map)) {
+            return;
+        }
+        Map<String, Object> unitMap = (Map<String, Object>) unit;
+        Object unitName = unitMap.get("name");
+        if (unitName != null) {
+            setUnitsFromName(unitName.toString(), def);
+        }
+        Object convFactor = unitMap.get("conversion_factor");
         if (convFactor != null) {
             def.setToMeter(toDouble(convFactor));
         }
+    }
+
+    private static void setUnitsFromName(String unitName, ProjectionDef def) {
+        String units = unitName.toLowerCase();
+        if ("metre".equals(units)) {
+            units = "meter";
+        }
+        def.setUnits(units);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -88,15 +88,14 @@ public final class ProjJsonTransformer {
                 if ("GeographicCRS".equals(value)) {
                     def.setProjName("longlat");
                 } else if ("GeodeticCRS".equals(value)) {
-                    // A GeodeticCRS with a Cartesian coordinate system is a geocentric
-                    // CRS (e.g. EPSG:4978) and maps to the geocent projection.
+                    // As in wkt-parser's transformPROJJSON: a GeodeticCRS with a
+                    // Cartesian coordinate system is a geocentric CRS (e.g. EPSG:4978)
+                    // and maps to geocent; any other subtype (ellipsoidal) is a
+                    // geographic CRS and maps to longlat.
                     Object coordSys = projjson.get("coordinate_system");
-                    if (coordSys instanceof Map) {
-                        Object subtype = ((Map<String, Object>) coordSys).get("subtype");
-                        if ("Cartesian".equals(subtype)) {
-                            def.setProjName("geocent");
-                        }
-                    }
+                    boolean cartesian = coordSys instanceof Map
+                        && "Cartesian".equals(((Map<String, Object>) coordSys).get("subtype"));
+                    def.setProjName(cartesian ? "geocent" : "longlat");
                 } else if ("ProjectedCRS".equals(value)) {
                     // projName will be set from conversion.method.name
                     Object conversion = projjson.get("conversion");
@@ -325,24 +324,27 @@ public final class ProjJsonTransformer {
         Object axisList = coordSys.get("axis");
         if (axisList instanceof List) {
             List<Map<String, Object>> axes = (List<Map<String, Object>>) axisList;
+
+            // Mirrors wkt-parser's transformPROJJSON direction map: the axis string is
+            // set only when every direction maps (all-or-nothing), preserving the
+            // document's axis order — including geocentric X/Y/Z permutations — and a
+            // 2-axis system gets the implicit up axis appended.
             StringBuilder axisOrder = new StringBuilder();
-            
+            boolean allMapped = !axes.isEmpty();
             for (Map<String, Object> axis : axes) {
                 Object direction = axis.get("direction");
-                if (direction != null) {
-                    String dir = direction.toString().toLowerCase();
-                    switch (dir) {
-                        case "east": axisOrder.append('e'); break;
-                        case "north": axisOrder.append('n'); break;
-                        case "west": axisOrder.append('w'); break;
-                        case "south": axisOrder.append('s'); break;
-                        default: break;
-                    }
+                String mapped = direction == null ? null
+                    : mapAxisDirection(direction.toString().toLowerCase());
+                if (mapped == null) {
+                    allMapped = false;
+                    break;
                 }
+                axisOrder.append(mapped);
             }
-            
-            if (axisOrder.length() > 0) {
-                axisOrder.append('u'); // Add up direction
+            if (allMapped) {
+                if (axisOrder.length() == 2) {
+                    axisOrder.append('u');
+                }
                 def.setAxis(axisOrder.toString());
             }
 
@@ -369,6 +371,11 @@ public final class ProjJsonTransformer {
     private static void processUnit(Object unit, ProjectionDef def) {
         if (unit instanceof String) {
             setUnitsFromName(unit.toString(), def);
+            // wkt-parser's processUnit records the identity factor for the
+            // well-known metre; the proj-string parser does the same for +units=m.
+            if ("meter".equals(def.getUnits())) {
+                def.setToMeter(1.0);
+            }
             return;
         }
         if (!(unit instanceof Map)) {
@@ -391,6 +398,21 @@ public final class ProjJsonTransformer {
             units = "meter";
         }
         def.setUnits(units);
+    }
+
+    private static String mapAxisDirection(String direction) {
+        switch (direction) {
+            case "east": return "e";
+            case "north": return "n";
+            case "west": return "w";
+            case "south": return "s";
+            case "up": return "u";
+            case "down": return "d";
+            case "geocentricx": return "e";
+            case "geocentricy": return "n";
+            case "geocentricz": return "u";
+            default: return null;
+        }
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -221,6 +221,27 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("toProjString: PROJJSON string-form units do not leak PROJ-invalid +units=")
+    void testToProjStringNormalizesStringFormUnits() {
+        // PROJ >= 6 emits bare-string axis units in PROJJSON ("degree", "metre").
+        // Parsing stores them on params.units, but PROJ's +units= table has no
+        // angular entries and keys metre as "m" — emitting the stored value verbatim
+        // (+units=degree / +units=meter) produces strings external PROJ rejects.
+        String json = "{\"type\": \"GeographicCRS\", \"name\": \"WGS 84\","
+            + "\"datum\": {\"type\": \"GeodeticReferenceFrame\", \"name\": \"World Geodetic System 1984\","
+            + "  \"ellipsoid\": {\"name\": \"WGS 84\", \"semi_major_axis\": 6378137, \"inverse_flattening\": 298.257223563}},"
+            + "\"coordinate_system\": {\"subtype\": \"ellipsoidal\", \"axis\": ["
+            + "  {\"name\": \"Geodetic latitude\", \"abbreviation\": \"Lat\", \"direction\": \"north\", \"unit\": \"degree\"},"
+            + "  {\"name\": \"Geodetic longitude\", \"abbreviation\": \"Lon\", \"direction\": \"east\", \"unit\": \"degree\"}]},"
+            + "\"id\": {\"authority\": \"EPSG\", \"code\": 4326}}";
+        Proj proj = new Proj(json);
+        assertEquals("degree", proj.getParams().units, "string-form axis unit parsed");
+        String projStr = CRSSerializer.toProjString(proj);
+        assertFalse(projStr.contains("+units="),
+            "angular unit must not become +units=: " + projStr);
+    }
+
+    @Test
     @DisplayName("toProjString: WGS84 Geographic")
     void testToProjStringWgs84() {
         Proj proj = new Proj("EPSG:4326");

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
@@ -262,6 +262,8 @@ class GeocentricTest {
         Proj original = new Proj("+proj=geocent +datum=WGS84 +units=us-ft +no_defs");
         String json = CRSSerializer.toProjJson(original);
         assertTrue(json.contains("conversion_factor"), "unit factor emitted: " + json);
+        assertTrue(json.contains("\"US survey foot\""),
+            "authority unit name emitted, not the proj short code: " + json);
         Proj reimported = new Proj(json);
         // Proj.forward is raw projection math (unit scaling happens in Transform), so
         // the factor itself must be checked on the re-imported params.

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
@@ -182,8 +182,10 @@ class GeocentricTest {
         Proj proj = new Proj(EPSG_4978_PROJJSON);
         assertEquals("geocent", proj.getParams().projName.toLowerCase(), "projName");
         assertEquals("meter", proj.getParams().units, "string-form axis unit parsed");
+        assertEquals(1.0, proj.getParams().toMeter, 0,
+            "well-known metre records the identity factor (wkt-parser fixture: to_meter 1)");
         assertEquals("enu", proj.getParams().axis,
-            "geocentric axis directions must not corrupt the axis order");
+            "geocentricX/Y/Z in canonical order map to enu (wkt-parser fixture)");
         assertEquals("EPSG:4978", proj.toEpsgCode(), "id block parsed");
         assertTrue(CRSSerializer.toProjJson(proj).contains("4978"),
             "id survives re-export through the GeodeticCRS branch");
@@ -201,14 +203,36 @@ class GeocentricTest {
     }
 
     @Test
-    void testProjJsonGeodeticCrsWithoutCartesianCsIsNotGeocent() {
-        // The GeodeticCRS mapping is conditional on subtype Cartesian: an ellipsoidal
-        // GeodeticCRS (allowed by the PROJJSON schema for geographic CRSs) must not be
-        // silently parsed as geocentric. No other handler claims it, so parsing fails.
+    void testProjJsonGeodeticCrsEllipsoidalIsLonglat() {
+        // As in wkt-parser's transformPROJJSON: only the Cartesian subtype is
+        // geocentric; every other GeodeticCRS (ellipsoidal) is a geographic CRS.
         String ellipsoidal = EPSG_4978_PROJJSON
             .replace("\"subtype\": \"Cartesian\"", "\"subtype\": \"ellipsoidal\"");
-        assertThrows(IllegalArgumentException.class, () -> new Proj(ellipsoidal),
-            "GeodeticCRS + ellipsoidal must not map to geocent");
+        Proj proj = new Proj(ellipsoidal);
+        assertEquals("longlat", proj.getParams().projName,
+            "GeodeticCRS + ellipsoidal maps to longlat, not geocent");
+    }
+
+    @Test
+    void testProjJsonGeocentricAxisOrderHonored() {
+        // A Y/X/Z-ordered axis array maps to axis "neu" (wkt-parser preserves the
+        // document's axis order through its direction map), and enforceAxis reorders
+        // the output accordingly — same expectations as the proj-string +axis=neu
+        // case above. PROJ cannot serve as the oracle here: it rejects non-canonical
+        // geocentric axis orders outright.
+        String yxz = EPSG_4978_PROJJSON.replace(
+            "{\"name\": \"Geocentric X\", \"abbreviation\": \"X\", \"direction\": \"geocentricX\", \"unit\": \"metre\"},"
+                + "    {\"name\": \"Geocentric Y\", \"abbreviation\": \"Y\", \"direction\": \"geocentricY\", \"unit\": \"metre\"},",
+            "{\"name\": \"Geocentric Y\", \"abbreviation\": \"Y\", \"direction\": \"geocentricY\", \"unit\": \"metre\"},"
+                + "    {\"name\": \"Geocentric X\", \"abbreviation\": \"X\", \"direction\": \"geocentricX\", \"unit\": \"metre\"},");
+        Proj proj = new Proj(yxz);
+        assertEquals("neu", proj.getParams().axis, "Y/X/Z axis array maps to neu");
+
+        Converter conv = Proj4.proj4(WGS84, yxz);
+        Point r = conv.forward(new Point(-7.56, 55.95), true);
+        assertEquals(-470928.890965, r.x, M_EPSLN, "first (north) = ECEF Y");
+        assertEquals(3548342.473034, r.y, M_EPSLN, "second (east) = ECEF X");
+        assertEquals(5261327.157452, r.z, M_EPSLN, "third (up) = computed ECEF Z");
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/GeocentricTest.java
@@ -135,8 +135,8 @@ class GeocentricTest {
 
     @Test
     void testSerializationRoundTrip() {
-        // Proj-string only: geocentric CRSs use GEOCCS/GeodeticCRS WKT structures the
-        // serializer does not emit (it writes projected-CRS WKT).
+        // Proj string and PROJJSON (see below): geocentric CRSs use GEOCCS/GEODCRS WKT
+        // structures the WKT writers do not emit (they write projected-CRS WKT).
         Proj original = new Proj(GEOCENT);
         String serialized = CRSSerializer.toProjString(original);
         assertTrue(serialized.contains("+proj=geocent"), "serialized: " + serialized);
@@ -147,5 +147,106 @@ class GeocentricTest {
         assertEquals(want.x, got.x, M_EPSLN);
         assertEquals(want.y, got.y, M_EPSLN);
         assertEquals(want.z, got.z, M_EPSLN);
+    }
+
+    /** EPSG:4978 PROJJSON as emitted by PROJ 9.5.1 (datum ensemble members trimmed). */
+    private static final String EPSG_4978_PROJJSON = "{"
+        + "\"$schema\": \"https://proj.org/schemas/v0.7/projjson.schema.json\","
+        + "\"type\": \"GeodeticCRS\","
+        + "\"name\": \"WGS 84\","
+        + "\"datum_ensemble\": {"
+        + "  \"name\": \"World Geodetic System 1984 ensemble\","
+        + "  \"members\": ["
+        + "    {\"name\": \"World Geodetic System 1984 (Transit)\", \"id\": {\"authority\": \"EPSG\", \"code\": 1166}},"
+        + "    {\"name\": \"World Geodetic System 1984 (G2296)\", \"id\": {\"authority\": \"EPSG\", \"code\": 1383}}"
+        + "  ],"
+        + "  \"ellipsoid\": {\"name\": \"WGS 84\", \"semi_major_axis\": 6378137, \"inverse_flattening\": 298.257223563},"
+        + "  \"accuracy\": \"2.0\","
+        + "  \"id\": {\"authority\": \"EPSG\", \"code\": 6326}"
+        + "},"
+        + "\"coordinate_system\": {"
+        + "  \"subtype\": \"Cartesian\","
+        + "  \"axis\": ["
+        + "    {\"name\": \"Geocentric X\", \"abbreviation\": \"X\", \"direction\": \"geocentricX\", \"unit\": \"metre\"},"
+        + "    {\"name\": \"Geocentric Y\", \"abbreviation\": \"Y\", \"direction\": \"geocentricY\", \"unit\": \"metre\"},"
+        + "    {\"name\": \"Geocentric Z\", \"abbreviation\": \"Z\", \"direction\": \"geocentricZ\", \"unit\": \"metre\"}"
+        + "  ]"
+        + "},"
+        + "\"id\": {\"authority\": \"EPSG\", \"code\": 4978}"
+        + "}";
+
+    @Test
+    void testProjJsonGeocentricCrsParses() {
+        // GeodeticCRS + Cartesian coordinate system maps to geocent; the geocentric
+        // axis directions and the bare-string \"metre\" axis units must be accepted.
+        Proj proj = new Proj(EPSG_4978_PROJJSON);
+        assertEquals("geocent", proj.getParams().projName.toLowerCase(), "projName");
+        assertEquals("meter", proj.getParams().units, "string-form axis unit parsed");
+        assertEquals("enu", proj.getParams().axis,
+            "geocentric axis directions must not corrupt the axis order");
+        assertEquals("EPSG:4978", proj.toEpsgCode(), "id block parsed");
+        assertTrue(CRSSerializer.toProjJson(proj).contains("4978"),
+            "id survives re-export through the GeodeticCRS branch");
+        assertFalse(CRSSerializer.toProjString(proj).contains("+units="),
+            "\"meter\" from the string-form unit must not leak into +units= "
+                + "(PROJ's unit table keys metres as \"m\")");
+
+        // 2D input through the parsed CRS yields the computed ECEF Z (same reference
+        // values as testKnownValues3d — EPSG:4978 is geocent on WGS84).
+        Converter conv = Proj4.proj4(WGS84, EPSG_4978_PROJJSON);
+        Point xyz = conv.forward(new Point(-7.56, 55.95));
+        assertEquals(3548342.473034, xyz.x, M_EPSLN, "X");
+        assertEquals(-470928.890965, xyz.y, M_EPSLN, "Y");
+        assertEquals(5261327.157452, xyz.z, M_EPSLN, "computed ECEF Z");
+    }
+
+    @Test
+    void testProjJsonGeodeticCrsWithoutCartesianCsIsNotGeocent() {
+        // The GeodeticCRS mapping is conditional on subtype Cartesian: an ellipsoidal
+        // GeodeticCRS (allowed by the PROJJSON schema for geographic CRSs) must not be
+        // silently parsed as geocentric. No other handler claims it, so parsing fails.
+        String ellipsoidal = EPSG_4978_PROJJSON
+            .replace("\"subtype\": \"Cartesian\"", "\"subtype\": \"ellipsoidal\"");
+        assertThrows(IllegalArgumentException.class, () -> new Proj(ellipsoidal),
+            "GeodeticCRS + ellipsoidal must not map to geocent");
+    }
+
+    @Test
+    void testProjJsonSerializationRoundTrip() {
+        // Export must be GeodeticCRS + Cartesian (a ProjectedCRS with a conversion is
+        // not a valid PROJJSON representation of a geocentric CRS).
+        Proj original = new Proj(GEOCENT);
+        String json = CRSSerializer.toProjJson(original);
+        assertTrue(json.contains("\"GeodeticCRS\""), "type: " + json);
+        assertTrue(json.contains("\"Cartesian\""), "coordinate system subtype: " + json);
+        assertTrue(json.contains("\"geocentricX\""), "axis directions: " + json);
+        assertFalse(json.contains("\"conversion\""), "no conversion node: " + json);
+
+        Proj reimported = new Proj(json);
+        double lon = 2.35 * Math.PI / 180, lat = 48.85 * Math.PI / 180;
+        Point want = original.forward(new Point(lon, lat, 100));
+        Point got = reimported.forward(new Point(lon, lat, 100));
+        assertEquals(want.x, got.x, M_EPSLN, "X after PROJJSON re-import");
+        assertEquals(want.y, got.y, M_EPSLN, "Y after PROJJSON re-import");
+        assertEquals(want.z, got.z, M_EPSLN, "Z after PROJJSON re-import");
+    }
+
+    @Test
+    void testProjJsonRoundTripKeepsNonMeterUnits() {
+        // Non-metre units are carried on the axes with their to-metre factor; a
+        // round-trip must preserve the scaling instead of silently dropping it.
+        Proj original = new Proj("+proj=geocent +datum=WGS84 +units=us-ft +no_defs");
+        String json = CRSSerializer.toProjJson(original);
+        assertTrue(json.contains("conversion_factor"), "unit factor emitted: " + json);
+        Proj reimported = new Proj(json);
+        // Proj.forward is raw projection math (unit scaling happens in Transform), so
+        // the factor itself must be checked on the re-imported params.
+        assertEquals(1200.0 / 3937.0, reimported.getParams().toMeter, 1e-15,
+            "us-ft to-metre factor survives the round-trip");
+        double lon = 2.35 * Math.PI / 180, lat = 48.85 * Math.PI / 180;
+        Point want = original.forward(new Point(lon, lat, 100));
+        Point got = reimported.forward(new Point(lon, lat, 100));
+        assertEquals(want.x, got.x, M_EPSLN, "X in US feet after re-import");
+        assertEquals(want.z, got.z, M_EPSLN, "Z in US feet after re-import");
     }
 }


### PR DESCRIPTION
Closes #91.

PROJJSON documents for geocentric CRSs (`type: "GeodeticCRS"` with `coordinate_system.subtype: "Cartesian"`, e.g. EPSG:4978) were not recognized, and exporting a geocent definition produced an invalid ProjectedCRS-with-conversion document. This is an enhancement beyond reference proj4js, whose bundled wkt-parser fails on the same document (`Unknown axis direction: geocentricX`).

## Parse (`ProjJsonTransformer`)

- `type=GeodeticCRS` with a Cartesian coordinate system maps to `projName = "geocent"`. Other GeodeticCRS subtypes are untouched (a GeodeticCRS + ellipsoidal document does not silently become geocentric — covered by a negative test).
- PROJJSON bare-string units are accepted (`"unit": "metre"` on EPSG:4978's axes; the shorthand PROJ >= 6 emits for well-known units) in addition to object-form units. The top-level `unit` key now reuses the same `processUnit` path.
- The `geocentricX/geocentricY/geocentricZ` axis directions pass through without corrupting the axis order (stays `enu`).

## Export (`CRSSerializer`)

- `toProjJson` emits `GeodeticCRS` + Cartesian coordinate system with geocentric axes for geocent. **PROJ 9.5.1 accepts the emitted document** (`CRS.from_json` reports a Geocentric CRS) and transforms through it to ECEF values identical to EPSG:4978. Non-metre units carry their to-metre factor on the axes and survive the round-trip (`+units=us-ft` case tested).
- `toProjString` now normalizes stored unit values to PROJ `+units=` short codes: `meter`/`metre` fold into the `m` default, and angular/scalar well-known units (`degree`, `unity`) are skipped. Without this, any definition parsed from PROJ-emitted PROJJSON (which carries bare-string units on axes) serialized to `+units=meter` / `+units=degree` — strings external PROJ rejects with `Error 1027: Invalid value for units`. Verified against PROJ with EPSG:32633/4326 documents.
- WKT/PROJJSON unit-name output maps `meter` back to the EPSG-canonical `metre` spelling.

## Tests (819 total, 5 new + extended)

- EPSG:4978 fixture parse: projName, string-form units, axis order, id block, and computed ECEF Z for 2D input (references from pyproj 3.7.2/PROJ 9.5.1, matching the existing geocent cases).
- PROJJSON export shape (GeodeticCRS/Cartesian/geocentric axes, no conversion node) + numeric round-trip.
- `us-ft` factor preservation asserted on the re-imported params (Proj.forward is raw projection math, so the factor itself is checked, not just the output).
- GeodeticCRS-without-Cartesian negative case.
- GeographicCRS fixture with string `degree` axis units pinning the `+units=` normalization.
