### PR TITLE
Normalize unit emission in toProjString to PROJ unit-table short codes

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/constants/Units.java
+++ b/src/main/java/org/datasyslab/proj4sedona/constants/Units.java
@@ -52,6 +52,20 @@ public final class Units {
     }
 
     /**
+     * Reverse lookup: the unit code whose to-meter factor matches within PROJ's
+     * tolerance (1e-10 relative, as in UnitOfMeasure::exportToPROJString). Returns
+     * null when no table entry matches.
+     */
+    public static String fromToMeter(double toMeter) {
+        for (Map.Entry<String, Double> entry : UNITS.entrySet()) {
+            if (Math.abs(entry.getValue() - toMeter) < 1e-10 * toMeter) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+
+    /**
      * Check if a unit exists.
      */
     public static boolean contains(String unit) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -369,10 +369,16 @@ public final class CRSSerializer {
             }
         }
 
-        // Units
-        if (params.units != null && !"m".equals(params.units)) {
-            sb.append(" +units=").append(params.units);
-        } else if (params.toMeter != null && params.toMeter != 1.0) {
+        // Units. Mirrors PROJ's CRS export (crs.cpp / UnitOfMeasure::exportToPROJString):
+        // +units= takes only pj_units short codes ("m", "us-ft", ...), so WKT/PROJJSON
+        // authority unit names resolve by conversion factor against the unit table;
+        // an unmatched linear factor falls back to +to_meter=, and angular/scalar
+        // units are never expressible as +units= and are omitted entirely.
+        String unitCode = toProjUnitCode(params.units, params.toMeter);
+        if (unitCode != null && !"m".equals(unitCode)) {
+            sb.append(" +units=").append(unitCode);
+        } else if (unitCode == null && !isNonLinearUnitName(params.units)
+                && params.toMeter != null && params.toMeter != 1.0) {
             sb.append(" +to_meter=").append(params.toMeter);
         }
 
@@ -1651,11 +1657,49 @@ public final class CRSSerializer {
                 || "bonne".equals(proj);
     }
 
+    /**
+     * Unit names +units=/+to_meter= cannot express: angular units (a geographic
+     * CRS's unit is implicit in +proj=longlat) and the PROJJSON scalar "unity".
+     */
+    private static final Set<String> NON_LINEAR_UNIT_NAMES = new HashSet<>(Arrays.asList(
+        "degree", "degrees", "deg", "radian", "radians", "rad", "grad", "grads",
+        "gradian", "gradians", "arc-second", "arcsecond", "arc-minute", "arcminute",
+        "unity"));
+
+    private static boolean isNonLinearUnitName(String units) {
+        return units != null && NON_LINEAR_UNIT_NAMES.contains(units);
+    }
+
+    /**
+     * Resolve a stored unit to a PROJ +units= short code, as PROJ's CRS export does:
+     * known short codes pass through, metre spellings fold to "m", and other linear
+     * units are matched by conversion factor (1e-10 relative) against the unit table.
+     * Returns null when no short code applies.
+     */
+    private static String toProjUnitCode(String units, Double toMeter) {
+        if (units != null) {
+            if (Units.contains(units)) {
+                return units;
+            }
+            if ("meter".equals(units) || "metre".equals(units)) {
+                return "m";
+            }
+            if (NON_LINEAR_UNIT_NAMES.contains(units)) {
+                return null;
+            }
+        }
+        if (toMeter != null) {
+            return Units.fromToMeter(toMeter);
+        }
+        return null;
+    }
+
     private static String getUnitName(String unitCode) {
         if (unitCode == null) return "metre";
         
         switch (unitCode) {
             case "m": return "metre";
+            case "meter": return "metre";
             case "ft": return "foot";
             case "us-ft": return "US survey foot";
             case "km": return "kilometre";

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -369,17 +369,26 @@ public final class CRSSerializer {
             }
         }
 
-        // Units. Mirrors PROJ's CRS export (crs.cpp / UnitOfMeasure::exportToPROJString):
-        // +units= takes only pj_units short codes ("m", "us-ft", ...), so WKT/PROJJSON
-        // authority unit names resolve by conversion factor against the unit table;
-        // an unmatched linear factor falls back to +to_meter=, and angular/scalar
-        // units are never expressible as +units= and are omitted entirely.
-        String unitCode = toProjUnitCode(params.units, params.toMeter);
-        if (unitCode != null && !"m".equals(unitCode)) {
-            sb.append(" +units=").append(unitCode);
-        } else if (unitCode == null && !isNonLinearUnitName(params.units)
-                && params.toMeter != null && params.toMeter != 1.0) {
-            sb.append(" +to_meter=").append(params.toMeter);
+        // Units. Mirrors PROJ's CRS export (crs.cpp / UnitOfMeasure::exportToPROJString),
+        // which branches on the unit's kind; the CRS kind is the reliable proxy here.
+        // A geographic CRS's unit is angular by definition and implicit in
+        // +proj=longlat — PROJ emits no unit token for any angular unit (degree,
+        // grad, microradian, ...) and drops even an explicit +units= on longlat;
+        // only a bare +to_meter= override is preserved verbatim. For projected and
+        // geocentric CRSs +units= takes only pj_units short codes, so WKT/PROJJSON
+        // authority unit names resolve by conversion factor against the unit table,
+        // and an unmatched linear factor falls back to +to_meter=.
+        if ("longlat".equals(normProj)) {
+            if (params.units == null && params.toMeter != null && params.toMeter != 1.0) {
+                sb.append(" +to_meter=").append(params.toMeter);
+            }
+        } else {
+            String unitCode = toProjUnitCode(params.units, params.toMeter);
+            if (unitCode != null && !"m".equals(unitCode)) {
+                sb.append(" +units=").append(unitCode);
+            } else if (unitCode == null && params.toMeter != null && params.toMeter != 1.0) {
+                sb.append(" +to_meter=").append(params.toMeter);
+            }
         }
 
         // Prime meridian offset
@@ -1658,23 +1667,11 @@ public final class CRSSerializer {
     }
 
     /**
-     * Unit names +units=/+to_meter= cannot express: angular units (a geographic
-     * CRS's unit is implicit in +proj=longlat) and the PROJJSON scalar "unity".
-     */
-    private static final Set<String> NON_LINEAR_UNIT_NAMES = new HashSet<>(Arrays.asList(
-        "degree", "degrees", "deg", "radian", "radians", "rad", "grad", "grads",
-        "gradian", "gradians", "arc-second", "arcsecond", "arc-minute", "arcminute",
-        "unity"));
-
-    private static boolean isNonLinearUnitName(String units) {
-        return units != null && NON_LINEAR_UNIT_NAMES.contains(units);
-    }
-
-    /**
      * Resolve a stored unit to a PROJ +units= short code, as PROJ's CRS export does:
      * known short codes pass through, metre spellings fold to "m", and other linear
      * units are matched by conversion factor (1e-10 relative) against the unit table.
-     * Returns null when no short code applies.
+     * Returns null when no short code applies. Only meaningful for projected and
+     * geocentric CRSs — geographic CRS units are angular and never emitted.
      */
     private static String toProjUnitCode(String units, Double toMeter) {
         if (units != null) {
@@ -1683,9 +1680,6 @@ public final class CRSSerializer {
             }
             if ("meter".equals(units) || "metre".equals(units)) {
                 return "m";
-            }
-            if (NON_LINEAR_UNIT_NAMES.contains(units)) {
-                return null;
             }
         }
         if (toMeter != null) {

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -172,6 +172,44 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("toProjString: geographic CRS with any angular unit emits no unit token")
+    void testToProjStringGeographicAngularUnitNoToken() {
+        // PROJ branches on the unit's kind, not its name — a geographic CRS's unit is
+        // angular by definition, so no name list can be complete (microradian, gon,
+        // centesimal minute, ...). PROJ 9.5.1 exports this CRS as
+        // "+proj=longlat +datum=WGS84 +no_defs". Also pins that the WKT parser's
+        // internally derived to-metre artifact for angular units does not leak out
+        // (it produced +to_meter=6.378137 here: 1e-6 x semi-major axis).
+        String wkt = "GEOGCS[\"unknown\",DATUM[\"WGS_1984\","
+            + "SPHEROID[\"WGS 84\",6378137,298.257223563]],"
+            + "PRIMEM[\"Greenwich\",0],UNIT[\"microradian\",0.000001]]";
+        String result = CRSSerializer.toProjString(new Proj(wkt));
+        assertFalse(result.contains("+units="), result);
+        assertFalse(result.contains("+to_meter="), result);
+    }
+
+    @Test
+    @DisplayName("toProjString: explicit +to_meter= on longlat is preserved verbatim")
+    void testToProjStringLonglatExplicitToMeterPreserved() {
+        // PROJ parity: CRS.from_proj4("+proj=longlat +to_meter=0.3048").to_proj4()
+        // keeps +to_meter=0.3048 — the factor must not be rewritten into a linear
+        // +units= code on a geographic CRS.
+        String result = CRSSerializer.toProjString(new Proj("+proj=longlat +to_meter=0.3048"));
+        assertTrue(result.contains("+to_meter=0.3048"), result);
+        assertFalse(result.contains("+units="), result);
+    }
+
+    @Test
+    @DisplayName("toProjString: explicit +units= on longlat is dropped")
+    void testToProjStringLonglatLinearUnitsDropped() {
+        // PROJ parity: CRS.from_proj4("+proj=longlat +units=ft").to_proj4() drops the
+        // linear unit — it has no meaning on a geographic CRS.
+        String result = CRSSerializer.toProjString(new Proj("+proj=longlat +units=ft"));
+        assertFalse(result.contains("+units="), result);
+        assertFalse(result.contains("+to_meter="), result);
+    }
+
+    @Test
     @DisplayName("toWkt1: parsed \"meter\" spelling re-exports as EPSG-canonical \"metre\"")
     void testWkt1MeterSpellingNormalized() {
         Proj proj = new Proj(projectedCrsWithUnit(

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -21,6 +21,101 @@ class CRSSerializerTest {
 
     // ==================== PROJ String Export Tests ====================
 
+    /**
+     * Compact ProjectedCRS PROJJSON whose axis unit is substituted per test.
+     * PROJJSON/WKT carry authority unit names ("US survey foot"), not PROJ +units=
+     * short codes ("us-ft"); PROJ's own CRS export resolves the emitted code by
+     * conversion factor against its unit table (UnitOfMeasure::exportToPROJString)
+     * and falls back to +to_meter= for unmatched linear factors.
+     */
+    private static final String PROJECTED_CRS_TEMPLATE = "{"
+        + "\"type\": \"ProjectedCRS\", \"name\": \"unit test\","
+        + "\"base_crs\": {\"type\": \"GeographicCRS\", \"name\": \"WGS 84\","
+        + "  \"datum\": {\"type\": \"GeodeticReferenceFrame\", \"name\": \"World Geodetic System 1984\","
+        + "    \"ellipsoid\": {\"name\": \"WGS 84\", \"semi_major_axis\": 6378137, \"inverse_flattening\": 298.257223563}}},"
+        + "\"conversion\": {\"name\": \"unnamed\", \"method\": {\"name\": \"Transverse Mercator\"},"
+        + "  \"parameters\": ["
+        + "    {\"name\": \"Latitude of natural origin\", \"value\": 0, \"unit\": \"degree\"},"
+        + "    {\"name\": \"Longitude of natural origin\", \"value\": 15, \"unit\": \"degree\"},"
+        + "    {\"name\": \"Scale factor at natural origin\", \"value\": 0.9996, \"unit\": \"unity\"},"
+        + "    {\"name\": \"False easting\", \"value\": 500000, \"unit\": \"metre\"},"
+        + "    {\"name\": \"False northing\", \"value\": 0, \"unit\": \"metre\"}]},"
+        + "\"coordinate_system\": {\"subtype\": \"Cartesian\", \"axis\": ["
+        + "  {\"name\": \"Easting\", \"abbreviation\": \"E\", \"direction\": \"east\", \"unit\": UNIT},"
+        + "  {\"name\": \"Northing\", \"abbreviation\": \"N\", \"direction\": \"north\", \"unit\": UNIT}]}"
+        + "}";
+
+    private static String projectedCrsWithUnit(String unitJson) {
+        return PROJECTED_CRS_TEMPLATE.replace("UNIT", unitJson);
+    }
+
+    @Test
+    @DisplayName("toProjString: metre unit object folds into the m default")
+    void testToProjStringMetreObjectUnit() {
+        Proj proj = new Proj(projectedCrsWithUnit(
+            "{\"type\": \"LinearUnit\", \"name\": \"metre\", \"conversion_factor\": 1}"));
+        String result = CRSSerializer.toProjString(proj);
+        assertFalse(result.contains("+units="),
+            "\"meter\" must not be emitted (PROJ's unit table keys metres as \"m\"): " + result);
+        assertFalse(result.contains("+to_meter="), result);
+    }
+
+    @Test
+    @DisplayName("toProjString: authority unit name resolves to the +units= short code by factor")
+    void testToProjStringAuthorityUnitNameResolvesByFactor() {
+        // As in PROJ-emitted PROJJSON for EPSG:2225 (NAD83 / California zone 1, ftUS).
+        Proj proj = new Proj(projectedCrsWithUnit(
+            "{\"type\": \"LinearUnit\", \"name\": \"US survey foot\", \"conversion_factor\": 0.304800609601219}"));
+        String result = CRSSerializer.toProjString(proj);
+        assertTrue(result.contains("+units=us-ft"),
+            "factor 1200/3937 must resolve to the us-ft short code: " + result);
+        assertFalse(result.contains("+units=us survey foot"), result);
+        assertFalse(result.contains("+to_meter="), result);
+    }
+
+    @Test
+    @DisplayName("toProjString: unmatched linear factor falls back to +to_meter=")
+    void testToProjStringUnknownLinearUnitFallsBackToToMeter() {
+        Proj proj = new Proj(projectedCrsWithUnit(
+            "{\"type\": \"LinearUnit\", \"name\": \"local foot\", \"conversion_factor\": 0.31}"));
+        String result = CRSSerializer.toProjString(proj);
+        assertFalse(result.contains("+units="),
+            "no unit-table entry has factor 0.31; the name must not be emitted: " + result);
+        assertTrue(result.contains("+to_meter=0.31"), result);
+    }
+
+    @Test
+    @DisplayName("toProjString: angular unit objects emit neither +units= nor +to_meter=")
+    void testToProjStringAngularUnitObjectOmitted() {
+        // As in PROJ-emitted PROJJSON for EPSG:4807 (NTF (Paris), grads). +units= has
+        // no angular entries, and the angular factor must not leak into +to_meter=.
+        String json = "{\"type\": \"GeographicCRS\", \"name\": \"grads test\","
+            + "\"datum\": {\"type\": \"GeodeticReferenceFrame\", \"name\": \"World Geodetic System 1984\","
+            + "  \"ellipsoid\": {\"name\": \"WGS 84\", \"semi_major_axis\": 6378137, \"inverse_flattening\": 298.257223563}},"
+            + "\"coordinate_system\": {\"subtype\": \"ellipsoidal\", \"axis\": ["
+            + "  {\"name\": \"Geodetic latitude\", \"abbreviation\": \"Lat\", \"direction\": \"north\","
+            + "   \"unit\": {\"type\": \"AngularUnit\", \"name\": \"grad\", \"conversion_factor\": 0.0157079632679489}},"
+            + "  {\"name\": \"Geodetic longitude\", \"abbreviation\": \"Lon\", \"direction\": \"east\","
+            + "   \"unit\": {\"type\": \"AngularUnit\", \"name\": \"grad\", \"conversion_factor\": 0.0157079632679489}}]}"
+            + "}";
+        Proj proj = new Proj(json);
+        String result = CRSSerializer.toProjString(proj);
+        assertFalse(result.contains("+units="), result);
+        assertFalse(result.contains("+to_meter="),
+            "angular conversion factor must not become a linear +to_meter=: " + result);
+    }
+
+    @Test
+    @DisplayName("toWkt1: parsed \"meter\" spelling re-exports as EPSG-canonical \"metre\"")
+    void testWkt1MeterSpellingNormalized() {
+        Proj proj = new Proj(projectedCrsWithUnit(
+            "{\"type\": \"LinearUnit\", \"name\": \"metre\", \"conversion_factor\": 1}"));
+        String wkt = CRSSerializer.toWkt1(proj);
+        assertTrue(wkt.contains("UNIT[\"metre\""),
+            "unit name must round-trip to the canonical spelling: " + wkt);
+        assertFalse(wkt.contains("\"meter\""), wkt);
+    }
+
     @Test
     @DisplayName("toProjString: WGS84 Geographic")
     void testToProjStringWgs84() {

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -105,6 +105,72 @@ class CRSSerializerTest {
             "angular conversion factor must not become a linear +to_meter=: " + result);
     }
 
+    // ---- Cases ported from PROJ's own test suite (test/unit/test_crs.cpp,
+    // test_io.cpp at 9.5.1). Inputs are PROJ's verbatim; assertions cover the
+    // unit tokens only — full-string equality would pin datum/ellipsoid name
+    // resolution that differs from PROJ's EPSG database and is out of scope here.
+
+    @Test
+    @DisplayName("PROJ crs.EPSG_2222: WKT2 foot CS unit exports +units=ft")
+    void testProjSuiteEpsg2222FootUnit() {
+        // PROJ expects "+proj=tmerc ... +x_0=213360 ... +units=ft": the CS unit name
+        // "foot" is not a +units= code; factor 0.3048 resolves to ft.
+        String wkt2 = "PROJCRS[\"NAD83 / Arizona East (ft)\",BASEGEODCRS[\"NAD83\","
+            + "DATUM[\"North American Datum 1983\","
+            + "ELLIPSOID[\"GRS 1980\",6378137,298.257222101,LENGTHUNIT[\"metre\",1.0]]]],"
+            + "CONVERSION[\"SPCS83 Arizona East zone (International feet)\","
+            + "METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],"
+            + "PARAMETER[\"Latitude of natural origin\",31,ANGLEUNIT[\"degree\",0.01745329252]],"
+            + "PARAMETER[\"Longitude of natural origin\",-110.166666666667,ANGLEUNIT[\"degree\",0.01745329252]],"
+            + "PARAMETER[\"Scale factor at natural origin\",0.9999,SCALEUNIT[\"unity\",1.0]],"
+            + "PARAMETER[\"False easting\",700000,LENGTHUNIT[\"foot\",0.3048]],"
+            + "PARAMETER[\"False northing\",0,LENGTHUNIT[\"foot\",0.3048]]],"
+            + "CS[cartesian,2],AXIS[\"easting (X)\",east,ORDER[1]],AXIS[\"northing (Y)\",north,ORDER[2]],"
+            + "LENGTHUNIT[\"foot\",0.3048],ID[\"EPSG\",2222]]";
+        String result = CRSSerializer.toProjString(new Proj(wkt2));
+        assertTrue(result.contains("+units=ft"), result);
+        assertFalse(result.contains("+units=foot"), result);
+        assertFalse(result.contains("+to_meter="), result);
+    }
+
+    @Test
+    @DisplayName("PROJ crs.EPSG_4807_as_PROJ_string: grads CRS exports no unit token")
+    void testProjSuiteEpsg4807GradsNoUnitToken() {
+        // PROJ expects "+proj=longlat +ellps=clrk80ign +pm=paris +no_defs" — no
+        // +units=, no +to_meter=. Input is PROJ's WKT1_GDAL form of EPSG:4807
+        // (crs.EPSG_4807_as_WKT1_GDAL); the WKT2 GEODCRS keyword is not yet parsed.
+        String wkt1 = "GEOGCS[\"NTF (Paris)\",DATUM[\"Nouvelle_Triangulation_Francaise_Paris\","
+            + "SPHEROID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627,AUTHORITY[\"EPSG\",\"7011\"]],"
+            + "AUTHORITY[\"EPSG\",\"6807\"]],"
+            + "PRIMEM[\"Paris\",2.33722917,AUTHORITY[\"EPSG\",\"8903\"]],"
+            + "UNIT[\"grad\",0.015707963267949,AUTHORITY[\"EPSG\",\"9105\"]],"
+            + "AUTHORITY[\"EPSG\",\"4807\"]]";
+        String result = CRSSerializer.toProjString(new Proj(wkt1));
+        assertFalse(result.contains("+units="), result);
+        assertFalse(result.contains("+to_meter="), result);
+    }
+
+    @Test
+    @DisplayName("PROJ io.projparse_projected_to_meter_known: factor recognized as us-ft")
+    void testProjSuiteToMeterKnownFactor() {
+        // PROJ resolves to_meter=0.304800609601219 to the US survey foot; on
+        // proj-string re-export that is the us-ft code.
+        String result = CRSSerializer.toProjString(
+            new Proj("+proj=tmerc +to_meter=0.304800609601219"));
+        assertTrue(result.contains("+units=us-ft"), result);
+        assertFalse(result.contains("+to_meter="), result);
+    }
+
+    @Test
+    @DisplayName("PROJ io.projparse_projected_to_meter_unknown: factor preserved as +to_meter=")
+    void testProjSuiteToMeterUnknownFactor() {
+        // PROJ keeps an unrecognized factor as LENGTHUNIT["unknown",0.1234]; on
+        // proj-string re-export that is +to_meter=, never a made-up +units= token.
+        String result = CRSSerializer.toProjString(new Proj("+proj=tmerc +to_meter=0.1234"));
+        assertTrue(result.contains("+to_meter=0.1234"), result);
+        assertFalse(result.contains("+units="), result);
+    }
+
     @Test
     @DisplayName("toWkt1: parsed \"meter\" spelling re-exports as EPSG-canonical \"metre\"")
     void testWkt1MeterSpellingNormalized() {


### PR DESCRIPTION
Definitions parsed from WKT/PROJJSON store authority unit names on `params.units` ("metre", "US survey foot", "grad"), and `toProjString` emitted them verbatim. PROJ's `+units=` parameter only accepts `pj_units` short codes, so the resulting strings were rejected by external PROJ/pyproj/GDAL with `Error 1027: Invalid value for units`:

- `projinfo -o PROJJSON EPSG:2225` (NAD83 / California zone 1, ftUS; object-form unit `{"name": "US survey foot", "conversion_factor": 0.304800609601219}`) exported `+units=us survey foot` — a broken token.
- Object-form `{"name": "metre", "conversion_factor": 1}` exported `+units=meter` (PROJ's table keys metres as `m`).
- Angular unit objects (e.g. EPSG:4807, grads) exported `+units=grad` — `+units=` has no angular entries.

## Fix

Follow PROJ's own CRS export algorithm (`crs.cpp` unit/axis export and `UnitOfMeasure::exportToPROJString`, checked against the 9.5.1 sources):

- known short codes pass through unchanged (`+units=us-ft` keeps round-tripping);
- `meter`/`metre` spellings fold into the `m` default;
- other linear units resolve **by conversion factor** against the unit table, with PROJ's 1e-10 relative tolerance (new `Units.fromToMeter` reverse lookup; the registry already mirrors `pj_units` entry-for-entry) — "US survey foot" + 1200/3937 now emits `+units=us-ft`;
- an unmatched linear factor falls back to `+to_meter=`;
- angular/scalar units are omitted entirely — including their conversion factor, which must not leak into a linear `+to_meter=`.

Also maps the stored `meter` spelling back to the EPSG-canonical `metre` in WKT/PROJJSON unit-name output.

## Verification

- EPSG:2225 PROJJSON → `toProjString` now yields `... +units=us-ft ...`; PROJ 9.5.1 accepts the string and transforms to reference values (X exact at the zone origin).
- Five new tests covering each branch: metre-fold, factor-resolved short code, `+to_meter=` fallback, angular omission (grads), and WKT unit-name spelling. All 819 tests pass.

Split out of #94 (review of the geocentric PROJJSON work surfaced this as a standalone pre-existing bug); #94 will be rebased on this.
