### PR TITLE
Parse the WKT2-2015 GEODCRS keyword (geographic and geocentric CRSs)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -168,7 +168,9 @@ public final class ProjJsonBuilder {
     }
 
     /**
-     * Convert GEOGCRS or BASEGEOGCRS node.
+     * Convert a geodetic CRS node: GEOGCRS/BASEGEOGCRS (WKT2-2019) or
+     * GEODCRS/BASEGEODCRS (WKT2-2015; GEODCRS also covers geocentric CRSs via
+     * the Cartesian coordinate-system subtype).
      */
     @SuppressWarnings("unchecked")
     private static void convertGeogCrs(List<Object> node, Map<String, Object> result) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -175,11 +175,15 @@ public final class ProjJsonBuilder {
     @SuppressWarnings("unchecked")
     private static void convertGeogCrs(List<Object> node, Map<String, Object> result) {
         // The WKT2-2015 GEODCRS keyword covers both geographic and geocentric CRSs;
-        // GEOGCRS (2019) is geographic only. Mirrors wkt-parser PROJJSONBuilderBase
-        // (type selection) — but the coordinate-system subtype below intentionally
-        // diverges from it.
+        // GEOGCRS (2019) is geographic only. The PROJJSON type is decided by the
+        // coordinate-system subtype, not the keyword: PROJ rejects a GeodeticCRS
+        // document with an ellipsoidal coordinate system ("expected a Cartesian or
+        // spherical CS") and itself normalizes an ellipsoidal GEODCRS to
+        // GeographicCRS. Divergence from wkt-parser 1.5.5, which stamps GeodeticCRS
+        // on every GEODCRS — its intermediate PROJJSON is internal, while ours is
+        // exposed via WktParser.parseWkt2ToProjJson. (The transformer still accepts
+        // GeodeticCRS + ellipsoidal leniently on input.)
         boolean isGeodetic = "GEODCRS".equals(node.get(0).toString());
-        result.put("type", isGeodetic ? "GeodeticCRS" : "GeographicCRS");
         if (node.size() > 1) {
             result.put("name", node.get(1));
         }
@@ -219,6 +223,8 @@ public final class ProjJsonBuilder {
         if (isGeodetic && csNode != null && csNode.size() > 1) {
             subtype = csNode.get(1).toString();
         }
+        result.put("type",
+            isGeodetic && "Cartesian".equals(subtype) ? "GeodeticCRS" : "GeographicCRS");
         coordSystem.put("subtype", subtype);
         coordSystem.put("axis", extractAxes(node));
         // The WKT2 SIMPLIFIED conventions carry a single CS-level unit (plain UNIT

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -55,6 +55,7 @@ public final class ProjJsonBuilder {
                 break;
 
             case "BASEGEOGCRS":
+            case "BASEGEODCRS":
             case "GEOGCRS":
             case "GEODCRS":
                 convertGeogCrs(node, result);
@@ -118,8 +119,12 @@ public final class ProjJsonBuilder {
             result.put("name", node.get(1));
         }
 
-        // Find and convert BASEGEOGCRS
+        // Find and convert the base CRS: BASEGEOGCRS (WKT2-2019) or BASEGEODCRS
+        // (WKT2-2015 — PROJ's WKT2:2015 output uses it for every projected CRS).
         List<Object> baseCrsNode = findNode(node, "BASEGEOGCRS");
+        if (baseCrsNode == null) {
+            baseCrsNode = findNode(node, "BASEGEODCRS");
+        }
         if (baseCrsNode != null) {
             result.put("base_crs", convert(baseCrsNode, new HashMap<>()));
         }
@@ -141,8 +146,12 @@ public final class ProjJsonBuilder {
             result.put("coordinate_system", coordSystem);
         }
 
-        // Find and convert LENGTHUNIT
+        // Find and convert the coordinate-system unit: LENGTHUNIT, or the plain
+        // UNIT keyword the WKT2 SIMPLIFIED conventions emit.
         List<Object> lengthUnitNode = findNode(node, "LENGTHUNIT");
+        if (lengthUnitNode == null) {
+            lengthUnitNode = findNode(node, "UNIT");
+        }
         if (lengthUnitNode != null) {
             Map<String, Object> unit = convertUnit(lengthUnitNode);
             Map<String, Object> coordSystem = (Map<String, Object>) result.get("coordinate_system");
@@ -210,6 +219,19 @@ public final class ProjJsonBuilder {
         }
         coordSystem.put("subtype", subtype);
         coordSystem.put("axis", extractAxes(node));
+        // The WKT2 SIMPLIFIED conventions carry a single CS-level unit (plain UNIT
+        // keyword) instead of per-axis units; without it a non-metre simplified
+        // geocentric CRS would silently lose its scale.
+        List<Object> csUnitNode = findNode(node, "LENGTHUNIT");
+        if (csUnitNode == null) {
+            csUnitNode = findNode(node, "ANGLEUNIT");
+        }
+        if (csUnitNode == null) {
+            csUnitNode = findNode(node, "UNIT");
+        }
+        if (csUnitNode != null) {
+            coordSystem.put("unit", convertUnit(csUnitNode));
+        }
         result.put("coordinate_system", coordSystem);
 
         // Find ID

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -56,6 +56,7 @@ public final class ProjJsonBuilder {
 
             case "BASEGEOGCRS":
             case "GEOGCRS":
+            case "GEODCRS":
                 convertGeogCrs(node, result);
                 break;
 
@@ -162,7 +163,12 @@ public final class ProjJsonBuilder {
      */
     @SuppressWarnings("unchecked")
     private static void convertGeogCrs(List<Object> node, Map<String, Object> result) {
-        result.put("type", "GeographicCRS");
+        // The WKT2-2015 GEODCRS keyword covers both geographic and geocentric CRSs;
+        // GEOGCRS (2019) is geographic only. Mirrors wkt-parser PROJJSONBuilderBase
+        // (type selection) — but the coordinate-system subtype below intentionally
+        // diverges from it.
+        boolean isGeodetic = "GEODCRS".equals(node.get(0).toString());
+        result.put("type", isGeodetic ? "GeodeticCRS" : "GeographicCRS");
         if (node.size() > 1) {
             result.put("name", node.get(1));
         }
@@ -189,9 +195,20 @@ public final class ProjJsonBuilder {
             result.put("datum_ensemble", convert(ensembleNode, new HashMap<>()));
         }
 
-        // Coordinate system
+        // Coordinate system. For GEODCRS the CS node's subtype decides geographic
+        // (ellipsoidal) vs geocentric (Cartesian) in the downstream transformer.
+        // Divergence from proj4js/wkt-parser 1.5.5, which honors the CS node only in
+        // its WKT2-2019 builder: PROJ's own WKT2:2015 output for EPSG:4978 carries
+        // CS[Cartesian,3] and no USAGE node (USAGE is 2019-only), and PROJ parses it
+        // as geocentric, while proj4js silently yields longlat for it. The subtype is
+        // read here for both forms, matching PROJ.
         Map<String, Object> coordSystem = new HashMap<>();
-        coordSystem.put("type", "ellipsoidal");
+        String subtype = "ellipsoidal";
+        List<Object> csNode = findNode(node, "CS");
+        if (isGeodetic && csNode != null && csNode.size() > 1) {
+            subtype = csNode.get(1).toString();
+        }
+        coordSystem.put("subtype", subtype);
         coordSystem.put("axis", extractAxes(node));
         result.put("coordinate_system", coordSystem);
 
@@ -613,7 +630,15 @@ public final class ProjJsonBuilder {
                 case "U": direction = "up"; break;
                 case "W": direction = "west"; break;
                 case "S": direction = "south"; break;
-                default: direction = "unknown"; break;
+                default:
+                    // Not a well-known abbreviation (e.g. "(X)" on geocentric axes):
+                    // fall back to the explicit direction token, as wkt-parser does.
+                    if (node.size() > 2) {
+                        direction = node.get(2).toString().toLowerCase();
+                    } else {
+                        throw new IllegalArgumentException("Unknown axis abbreviation: " + abbrev);
+                    }
+                    break;
             }
         } else if (node.size() > 2) {
             direction = node.get(2).toString().toLowerCase();

--- a/src/main/java/org/datasyslab/proj4sedona/parser/WktVersion.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/WktVersion.java
@@ -45,9 +45,14 @@ public enum WktVersion {
 
         String normalizedWkt = wkt.toUpperCase();
 
-        // Check for WKT2-specific keywords
+        // Check for WKT2-specific keywords. GEODCRS (WKT2-2015; also covers
+        // BASEGEODCRS by substring) is not in wkt-parser's detection list, but the
+        // WKT2_2015_SIMPLIFIED convention drops the typed unit keywords
+        // (LENGTHUNIT/ANGLEUNIT become UNIT), so without it a simplified GEODCRS
+        // document would fall through to the WKT1 branch via its UNIT node.
         if (normalizedWkt.contains("PROJCRS") ||
             normalizedWkt.contains("GEOGCRS") ||
+            normalizedWkt.contains("GEODCRS") ||
             normalizedWkt.contains("BOUNDCRS") ||
             normalizedWkt.contains("VERTCRS") ||
             normalizedWkt.contains("LENGTHUNIT") ||

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -662,4 +662,82 @@ class WktParserTest {
         assertNotNull(def.getLat1());
         assertEquals(def.getLat0(), def.getLat1(), 1e-9);
     }
+
+    // ========== WKT2 GEODCRS (geographic + geocentric) ==========
+
+    private static final String GEODCRS_4978_CS =
+        "CS[Cartesian,3],"
+        + "AXIS[\"(X)\",geocentricX,ORDER[1],LENGTHUNIT[\"metre\",1]],"
+        + "AXIS[\"(Y)\",geocentricY,ORDER[2],LENGTHUNIT[\"metre\",1]],"
+        + "AXIS[\"(Z)\",geocentricZ,ORDER[3],LENGTHUNIT[\"metre\",1]]";
+
+    private static final String GEODCRS_4978_HEAD =
+        "GEODCRS[\"WGS 84\",ENSEMBLE[\"World Geodetic System 1984 ensemble\","
+        + "MEMBER[\"World Geodetic System 1984 (Transit)\"],"
+        + "MEMBER[\"World Geodetic System 1984 (G2296)\"],"
+        + "ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]],"
+        + "ENSEMBLEACCURACY[2.0]],"
+        + "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],";
+
+    private void assertGeocentric4978(String wkt) {
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals("geocent", def.getProjName(), "projName");
+        assertEquals("enu", def.getAxis(), "geocentric X/Y/Z axes map to enu");
+        assertEquals("meter", def.getUnits(), "axis unit");
+        assertEquals(1.0, def.getToMeter(), 0, "identity to-metre factor");
+
+        // Same ECEF references as GeocentricTest (pyproj/PROJ 9.5.1).
+        org.datasyslab.proj4sedona.transform.Converter conv =
+            org.datasyslab.proj4sedona.Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", wkt);
+        Point xyz = conv.forward(new Point(-7.56, 55.95));
+        assertEquals(3548342.473034, xyz.x, 1e-4, "X");
+        assertEquals(-470928.890965, xyz.y, 1e-4, "Y");
+        assertEquals(5261327.157452, xyz.z, 1e-4, "computed ECEF Z");
+    }
+
+    @Test
+    @DisplayName("GEODCRS geocentric (WKT2-2019 form with USAGE) parses as geocent")
+    void testGeodcrsGeocentric2019() {
+        // wkt-parser 1.5.5 test fixture (expected: projName geocent, axis enu,
+        // units meter, to_meter 1); trimmed ensemble members.
+        assertGeocentric4978(GEODCRS_4978_HEAD + GEODCRS_4978_CS
+            + ",USAGE[SCOPE[\"Geodesy.\"],AREA[\"World.\"],BBOX[-90,-180,90,180]]"
+            + ",ID[\"EPSG\",4978]]");
+    }
+
+    @Test
+    @DisplayName("GEODCRS geocentric (WKT2-2015 form, no USAGE) parses as geocent")
+    void testGeodcrsGeocentric2015() {
+        // Documented divergence from proj4js/wkt-parser 1.5.5, which honors the CS
+        // subtype only in its WKT2-2019 builder and silently parses this form as
+        // longlat. USAGE does not exist in WKT2-2015, and PROJ's own WKT2:2015
+        // output for EPSG:4978 is exactly this shape — PROJ parses it as geocentric
+        // (verified via pyproj 3.7.2: CRS.from_wkt(...).is_geocentric == True).
+        assertGeocentric4978(GEODCRS_4978_HEAD + GEODCRS_4978_CS + ",ID[\"EPSG\",4978]]");
+    }
+
+    @Test
+    @DisplayName("PROJ crs.EPSG_4807_as_WKT2: ellipsoidal GEODCRS parses as longlat")
+    void testGeodcrsEllipsoidal4807() {
+        // Input verbatim from PROJ 9.5.1 test/unit/test_crs.cpp (crs.EPSG_4807_as_WKT2);
+        // PROJ exports it as "+proj=longlat +ellps=clrk80ign +pm=paris +no_defs" —
+        // assertions cover the projection kind and unit tokens only (datum and prime
+        // meridian name resolution differ from PROJ's EPSG database).
+        String wkt = "GEODCRS[\"NTF (Paris)\","
+            + "DATUM[\"Nouvelle Triangulation Francaise (Paris)\","
+            + "ELLIPSOID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627,LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Paris\",2.5969213,ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "CS[ellipsoidal,2],"
+            + "AXIS[\"latitude\",north,ORDER[1],ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "AXIS[\"longitude\",east,ORDER[2],ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "ID[\"EPSG\",4807]]";
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals("longlat", def.getProjName(), "ellipsoidal GEODCRS is geographic");
+
+        String projStr = CRSSerializer.toProjString(
+            new org.datasyslab.proj4sedona.core.Proj(wkt));
+        assertTrue(projStr.contains("+proj=longlat"), projStr);
+        assertFalse(projStr.contains("+units="), projStr);
+        assertFalse(projStr.contains("+to_meter="), projStr);
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -740,4 +740,93 @@ class WktParserTest {
         assertFalse(projStr.contains("+units="), projStr);
         assertFalse(projStr.contains("+to_meter="), projStr);
     }
+
+    // ========== WKT2_2015_SIMPLIFIED (plain UNIT keyword, no per-axis units) ==========
+
+    @Test
+    @DisplayName("GEODCRS geocentric in WKT2_2015_SIMPLIFIED form parses as geocent")
+    void testGeodcrsSimplified4978() {
+        // PROJ 9.5.1's to_wkt('WKT2_2015_SIMPLIFIED') for EPSG:4978: no LENGTHUNIT/
+        // ANGLEUNIT/USAGE keywords at all — detection must key on GEODCRS itself,
+        // and the single CS-level UNIT applies to the axes.
+        String wkt = "GEODCRS[\"WGS 84\",DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563]],"
+            + "CS[Cartesian,3],AXIS[\"(X)\",geocentricX],AXIS[\"(Y)\",geocentricY],"
+            + "AXIS[\"(Z)\",geocentricZ],UNIT[\"metre\",1],"
+            + "SCOPE[\"Geodesy.\"],AREA[\"World.\"],BBOX[-90,-180,90,180],ID[\"EPSG\",4978]]";
+        assertEquals(WktVersion.WKT2, WktVersion.detect(wkt), "simplified GEODCRS is WKT2");
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals("geocent", def.getProjName());
+        assertEquals("enu", def.getAxis());
+        assertEquals(1.0, def.getToMeter(), 0, "CS-level metre unit propagated");
+
+        org.datasyslab.proj4sedona.transform.Converter conv =
+            org.datasyslab.proj4sedona.Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", wkt);
+        Point xyz = conv.forward(new Point(-7.56, 55.95));
+        assertEquals(3548342.473034, xyz.x, 1e-4, "X");
+        assertEquals(-470928.890965, xyz.y, 1e-4, "Y");
+        assertEquals(5261327.157452, xyz.z, 1e-4, "computed ECEF Z");
+    }
+
+    @Test
+    @DisplayName("Simplified geocentric CRS with non-metre CS unit keeps its scale")
+    void testGeodcrsSimplifiedNonMetreKeepsScale() {
+        // PROJ 9.5.1's WKT2_2015_SIMPLIFIED for +proj=geocent +datum=WGS84 +units=us-ft.
+        // The CS-level UNIT is the only unit in the document; dropping it would
+        // silently produce metre output. References match GeocentricTest's us-ft
+        // case (pyproj/PROJ 9.5.1).
+        String wkt = "GEODCRS[\"unknown\",DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563],ID[\"EPSG\",6326]],"
+            + "CS[Cartesian,3],AXIS[\"(X)\",geocentricX],AXIS[\"(Y)\",geocentricY],"
+            + "AXIS[\"(Z)\",geocentricZ],"
+            + "UNIT[\"US survey foot\",0.304800609601219,ID[\"EPSG\",9003]]]";
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals("geocent", def.getProjName());
+        assertEquals(0.304800609601219, def.getToMeter(), 1e-15, "us-ft factor propagated");
+
+        org.datasyslab.proj4sedona.transform.Converter conv =
+            org.datasyslab.proj4sedona.Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", wkt);
+        Point xyz = conv.forward(new Point(2.35, 48.85, 100));
+        assertEquals(13784550.5068, xyz.x, 0.001, "X in US feet");
+        assertEquals(565693.8601, xyz.y, 0.001, "Y in US feet");
+        assertEquals(15681312.7958, xyz.z, 0.001, "Z in US feet");
+    }
+
+    @Test
+    @DisplayName("GEODCRS ellipsoidal in WKT2_2015_SIMPLIFIED form parses as longlat")
+    void testGeodcrsSimplified4807() {
+        // PROJ 9.5.1's WKT2_2015_SIMPLIFIED for EPSG:4807 (grads CS-level UNIT).
+        String wkt = "GEODCRS[\"NTF (Paris)\",DATUM[\"Nouvelle Triangulation Francaise (Paris)\","
+            + "ELLIPSOID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627]],"
+            + "PRIMEM[\"Paris\",2.5969213],CS[ellipsoidal,2],"
+            + "AXIS[\"geodetic latitude (Lat)\",north],AXIS[\"geodetic longitude (Lon)\",east],"
+            + "UNIT[\"grad\",0.0157079632679489],ID[\"EPSG\",4807]]";
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals("longlat", def.getProjName());
+
+        String projStr = CRSSerializer.toProjString(
+            new org.datasyslab.proj4sedona.core.Proj(wkt));
+        assertFalse(projStr.contains("+units="), projStr);
+        assertFalse(projStr.contains("+to_meter="),
+            "angular CS unit must not leak into +to_meter=: " + projStr);
+    }
+
+    @Test
+    @DisplayName("PROJCRS with a BASEGEODCRS base (WKT2-2015) keeps the base ellipsoid")
+    void testProjcrsBaseGeodCrs2015() {
+        // PROJ's WKT2:2015 output uses BASEGEODCRS (not BASEGEOGCRS) for every
+        // projected CRS; dropping it silently falls back to the WGS84 default
+        // ellipsoid. Bessel-based CRS so the loss is observable (EPSG:5514-style).
+        String wkt = "PROJCRS[\"S-JTSK / Krovak East North\","
+            + "BASEGEODCRS[\"S-JTSK\",DATUM[\"System of the Unified Trigonometrical Cadastral Network\","
+            + "ELLIPSOID[\"Bessel 1841\",6377397.155,299.1528128,LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]]],"
+            + "CONVERSION[\"Krovak\",METHOD[\"Krovak (North Orientated)\",ID[\"EPSG\",1041]],"
+            + "PARAMETER[\"Latitude of projection centre\",49.5,ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "PARAMETER[\"Longitude of origin\",24.8333333333333,ANGLEUNIT[\"degree\",0.0174532925199433]]],"
+            + "CS[Cartesian,2],AXIS[\"x\",south,ORDER[1]],AXIS[\"y\",west,ORDER[2]],"
+            + "LENGTHUNIT[\"metre\",1],ID[\"EPSG\",5514]]";
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals(6377397.155, def.getA(), 1e-6, "Bessel semi-major from BASEGEODCRS");
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -812,6 +812,30 @@ class WktParserTest {
     }
 
     @Test
+    @DisplayName("GEODCRS PROJJSON type follows the CS subtype, not the keyword")
+    void testGeodcrsProjJsonTypeBySubtype() {
+        // PROJ rejects GeodeticCRS + ellipsoidal PROJJSON ("expected a Cartesian or
+        // spherical CS") and normalizes an ellipsoidal GEODCRS to GeographicCRS, so
+        // the intermediate PROJJSON must pick the type from the coordinate system.
+        String cartesian = GEODCRS_4978_HEAD + GEODCRS_4978_CS + ",ID[\"EPSG\",4978]]";
+        assertEquals("GeodeticCRS",
+            WktParser.parseWkt2ToProjJson(cartesian).get("type"),
+            "Cartesian CS keeps the geocentric type");
+
+        String ellipsoidal = "GEODCRS[\"NTF (Paris)\","
+            + "DATUM[\"Nouvelle Triangulation Francaise (Paris)\","
+            + "ELLIPSOID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627,LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Paris\",2.5969213,ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "CS[ellipsoidal,2],"
+            + "AXIS[\"latitude\",north,ORDER[1],ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "AXIS[\"longitude\",east,ORDER[2],ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "ID[\"EPSG\",4807]]";
+        assertEquals("GeographicCRS",
+            WktParser.parseWkt2ToProjJson(ellipsoidal).get("type"),
+            "ellipsoidal GEODCRS normalizes to GeographicCRS, as PROJ does");
+    }
+
+    @Test
     @DisplayName("PROJCRS with a BASEGEODCRS base (WKT2-2015) keeps the base ellipsoid")
     void testProjcrsBaseGeodCrs2015() {
         // PROJ's WKT2:2015 output uses BASEGEODCRS (not BASEGEOGCRS) for every


### PR DESCRIPTION
Closes #96.

The WKT2-2015 `GEODCRS` keyword was not recognized: PROJ's own WKT2 output for EPSG:4807 or EPSG:4978 failed with "Could not parse SRS code". Ported from wkt-parser 1.5.5, the reference proj4js dependency that added GEODCRS support.

## Changes

- `ProjJsonBuilder` routes `GEODCRS` through the geographic-CRS conversion with type `GeodeticCRS`; the downstream `ProjJsonTransformer` (#94) then maps a Cartesian coordinate system to geocent and anything else to longlat — the same WKT2 → PROJJSON → transform pipeline reuse as upstream.
- Axis abbreviations that are not well-known (`(X)`/`(Y)`/`(Z)` on geocentric axes) fall back to the explicit direction token, as upstream does; `geocentricX/Y/Z` then map to `enu` through the #94 direction map.
- The CS node's subtype is read for GEODCRS in **both** the 2015 and 2019 forms. Documented divergence: wkt-parser 1.5.5 honors the CS subtype only in its WKT2-2019 builder, so PROJ's WKT2:2015 output for EPSG:4978 (`CS[Cartesian,3]` with no `USAGE` node — `USAGE` is 2019-only) silently parses as **longlat** there (verified by running its `transformPROJJSON` directly). PROJ parses the same string as geocentric (verified via pyproj 3.7.2: `CRS.from_wkt(...).is_geocentric == True`); we follow PROJ, consistent with the project's established precedent.

## Tests (835 total, 3 new)

- wkt-parser 1.5.5's EPSG:4978 WKT2 fixture (2019 form with `USAGE`), asserting its expected values (`geocent`, axis `enu`, units `meter`, `to_meter` 1) plus the pyproj/PROJ 9.5.1 ECEF references shared with `GeocentricTest`.
- The WKT2-2015 form of the same document (the divergence case above).
- PROJ's `crs.EPSG_4807_as_WKT2` verbatim (ellipsoidal GEODCRS with grads axes): parses as longlat and serializes with no unit token, matching PROJ's `crs.EPSG_4807_as_PROJ_string` expectation on the unit dimension.

Two pre-existing issues surfaced while testing, filed separately: `toProjString` emits datum names containing spaces as broken `+datum=` tokens, and the transformer treats a grads-valued `PRIMEM` longitude as degrees (a bug shared with proj4js).
