### PR TITLE
Backport wkt-parser 1.5.5 parser fixes

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -664,14 +664,18 @@ public final class ProjJsonBuilder {
                     // Not a well-known abbreviation (e.g. "(X)" on geocentric axes):
                     // fall back to the explicit direction token, as wkt-parser does.
                     if (node.size() > 2) {
-                        direction = node.get(2).toString().toLowerCase();
+                        direction = node.get(2).toString();
                     } else {
                         throw new IllegalArgumentException("Unknown axis abbreviation: " + abbrev);
                     }
                     break;
             }
         } else if (node.size() > 2) {
-            direction = node.get(2).toString().toLowerCase();
+            // Preserve the token's case (wkt-parser 1.5.5): the PROJJSON direction
+            // enum is camelCase for geocentricX/Y/Z, so lowercasing produced
+            // schema-invalid values in the exposed intermediate PROJJSON. The
+            // transformer lowercases at lookup, so parsing tolerance is unchanged.
+            direction = node.get(2).toString();
         } else {
             direction = "unknown";
         }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/WktUtils.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/WktUtils.java
@@ -52,12 +52,13 @@ public final class WktUtils {
 
         String normalizedProjName = projName.toLowerCase().replace("_", " ");
 
-        // For Albers and Lambert Azimuthal, long0 from longc
+        // longitude_of_center feeds long0 whenever no central meridian was given,
+        // for every projection (wkt-parser 1.5.5 util.js dropped the Albers/LAEA-only
+        // restriction). Without this, GDAL-style WKT with longitude_of_center on e.g.
+        // Sinusoidal, Miller or Azimuthal_Equidistant silently projects around
+        // longitude 0. Projections that read longc directly (omerc) are unaffected.
         if (def.getLong0() == null && def.getLongc() != null) {
-            if (normalizedProjName.equals("albers conic equal area") ||
-                normalizedProjName.equals("lambert azimuthal equal area")) {
-                def.setLong0(def.getLongc());
-            }
+            def.setLong0(def.getLongc());
         }
 
         // Handle stereographic projections

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -836,6 +836,43 @@ class WktParserTest {
     }
 
     @Test
+    @DisplayName("longitude_of_center feeds long0 for every projection")
+    void testLongitudeOfCenterFeedsLong0() {
+        // wkt-parser 1.5.5 (util.js) dropped the Albers/LAEA-only restriction on the
+        // longc -> long0 fallback. GDAL-style WKT1 with longitude_of_center on other
+        // projections silently projected around longitude 0 here. Reference from
+        // pyproj 3.7.2/PROJ 9.5.1.
+        String wkt = "PROJCS[\"World_Sinusoidal\",GEOGCS[\"GCS_WGS_1984\",DATUM[\"WGS_1984\","
+            + "SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],"
+            + "UNIT[\"degree\",0.0174532925199433]],PROJECTION[\"Sinusoidal\"],"
+            + "PARAMETER[\"longitude_of_center\",100],PARAMETER[\"false_easting\",0],"
+            + "PARAMETER[\"false_northing\",0],UNIT[\"metre\",1]]";
+        ProjectionDef def = WktParser.parse(wkt);
+        assertNotNull(def.getLong0(), "long0 populated from longitude_of_center");
+        assertEquals(100 * Values.D2R, def.getLong0(), 1e-12);
+
+        org.datasyslab.proj4sedona.transform.Converter conv =
+            org.datasyslab.proj4sedona.Proj4.proj4("EPSG:4326", wkt);
+        Point xy = conv.forward(new Point(105, 10));
+        assertEquals(548196.8203407656, xy.x, 1e-4, "x with central meridian 100");
+        assertEquals(1105854.833234372, xy.y, 1e-4, "y");
+
+        // Oblique-mercator-family CRSs get long0 populated too (1.5.5 fixture
+        // expectation); omerc itself reads longc directly, so values must agree.
+        String omerc = "PROJCS[\"Hotine\",GEOGCS[\"GCS_WGS_1984\",DATUM[\"WGS_1984\","
+            + "SPHEROID[\"WGS 84\",6378137,298.257223563]],PRIMEM[\"Greenwich\",0],"
+            + "UNIT[\"degree\",0.0174532925199433]],"
+            + "PROJECTION[\"Hotine_Oblique_Mercator_Azimuth_Center\"],"
+            + "PARAMETER[\"latitude_of_center\",4],PARAMETER[\"longitude_of_center\",115],"
+            + "PARAMETER[\"azimuth\",53.315820472222],PARAMETER[\"rectified_grid_angle\",53.130102361111],"
+            + "PARAMETER[\"scale_factor\",0.99984],PARAMETER[\"false_easting\",0],"
+            + "PARAMETER[\"false_northing\",0],UNIT[\"metre\",1]]";
+        ProjectionDef omercDef = WktParser.parse(omerc);
+        assertNotNull(omercDef.getLong0(), "omerc-family long0 populated");
+        assertEquals(omercDef.getLongc(), omercDef.getLong0(), 0, "long0 equals longc");
+    }
+
+    @Test
     @DisplayName("PROJCRS with a BASEGEODCRS base (WKT2-2015) keeps the base ellipsoid")
     void testProjcrsBaseGeodCrs2015() {
         // PROJ's WKT2:2015 output uses BASEGEODCRS (not BASEGEOGCRS) for every

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -836,6 +836,27 @@ class WktParserTest {
     }
 
     @Test
+    @DisplayName("Axis direction tokens keep their case in the intermediate PROJJSON")
+    @SuppressWarnings("unchecked")
+    void testAxisDirectionCasePreserved() {
+        // wkt-parser 1.5.5 stopped lowercasing the direction token: the PROJJSON
+        // direction enum is camelCase for geocentricX/Y/Z, so the exposed
+        // intermediate PROJJSON (parseWkt2ToProjJson) carried schema-invalid
+        // "geocentricx" values. Parsing tolerance is unchanged — the transformer
+        // lowercases at lookup.
+        String wkt = GEODCRS_4978_HEAD + GEODCRS_4978_CS + ",ID[\"EPSG\",4978]]";
+        Map<String, Object> projjson = WktParser.parseWkt2ToProjJson(wkt);
+        Map<String, Object> cs = (Map<String, Object>) projjson.get("coordinate_system");
+        List<Map<String, Object>> axes = (List<Map<String, Object>>) cs.get("axis");
+        assertEquals("geocentricX", axes.get(0).get("direction"));
+        assertEquals("geocentricY", axes.get(1).get("direction"));
+        assertEquals("geocentricZ", axes.get(2).get("direction"));
+
+        // End-to-end parse still resolves the directions (case-insensitive lookup).
+        assertEquals("enu", WktParser.parse(wkt).getAxis());
+    }
+
+    @Test
     @DisplayName("longitude_of_center feeds long0 for every projection")
     void testLongitudeOfCenterFeedsLong0() {
         // wkt-parser 1.5.5 (util.js) dropped the Albers/LAEA-only restriction on the


### PR DESCRIPTION
Backports from wkt-parser 1.5.5, the reference proj4js WKT/PROJJSON engine. An audit of the full 1.5.1 → 1.5.5 diff (~450 lines across 10 source files, plus the new test fixtures) found two unported behavior changes; everything else in the delta is already present via #94/#95/#97 or is JS-packaging concern. One commit per backport.

## 1. `longitude_of_center` feeds `long0` for every projection

Upstream `util.js applyProjectionDefaults` dropped its Albers/LAEA-only restriction on the `longc → long0` fallback. Ours kept the old gate, so GDAL-style WKT carrying `longitude_of_center` on any other projection silently projected around longitude 0:

- `PROJECTION["Sinusoidal"]` + `PARAMETER["longitude_of_center",100]` at (105, 10) returned x = 11 512 km instead of 548 km. Miller, Azimuthal_Equidistant, Robinson, and Krovak with a non-default meridian were affected the same way (Krovak's built-in default masked the standard S-JTSK case).
- The copy is now unconditional when no central meridian is present, as upstream. Projections that read `longc` directly (omerc) are unaffected — both fields carry the same value, matching wkt-parser 1.5.5's oblique-mercator fixture expectations.
- Reference values from pyproj 3.7.2/PROJ 9.5.1.

## 2. Axis direction token case is preserved in the intermediate PROJJSON

Upstream `PROJJSONBuilderBase.js convertAxis` stopped lowercasing the direction token: the PROJJSON direction enum is camelCase for `geocentricX/Y/Z`, so the exposed intermediate PROJJSON (`WktParser.parseWkt2ToProjJson`) carried schema-invalid `geocentricx` values — the same public-API class as the GeodeticCRS type normalization in #97. End-to-end parsing is unchanged (the transformer lowercases at lookup).

## Audit provenance

proj4js `lib/` itself is fully covered: the 37 commits since the port baseline were audited in #86 (7 backports; the rest already ported or N/A) and the fork head has not advanced since. This PR closes out the wkt-parser side of the same question. 842 tests pass.
