### PR TITLE
Normalize datum emission in toProjString to PROJ's +datum= tokens

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/core/DatumParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/DatumParams.java
@@ -56,6 +56,15 @@ public class DatumParams {
         this.datumType = Values.PJD_NODATUM;
 
         if (datumParamsArray != null) {
+            // PROJ accepts exactly 3 or 7 towgs84 values and rejects any other arity
+            // at parse time. Neither reference behavior for malformed input is worth
+            // mirroring: this port previously threw ArrayIndexOutOfBounds for 4-6
+            // values, and proj4js silently reads past the array end, poisoning the
+            // 7-parameter branch with NaN rotations. Fail loudly instead.
+            if (datumParamsArray.length != 3 && datumParamsArray.length != 7) {
+                throw new IllegalArgumentException(
+                    "towgs84 requires 3 or 7 parameters, got " + datumParamsArray.length);
+            }
             this.datumType = Values.PJD_WGS84;
             this.datumParams = datumParamsArray.clone();
             

--- a/src/main/java/org/datasyslab/proj4sedona/core/DatumParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/DatumParams.java
@@ -15,6 +15,12 @@ import java.util.List;
 public class DatumParams {
 
     private int datumType;         // PJD_3PARAM, PJD_7PARAM, PJD_GRIDSHIFT, PJD_WGS84, PJD_NODATUM
+    // True when the 7-parameter tail was converted at parse time (arc-seconds to
+    // radians, ppm to multiplier). datumType alone cannot answer this after a
+    // nadgrids override flips it to PJD_GRIDSHIFT: the converted values stay in
+    // datumParams, while an all-zero tail is never converted. Serialization needs
+    // the distinction to re-encode correctly.
+    private boolean sevenParamsConverted;
     private double[] datumParams;  // 3 or 7 transformation parameters
     private double a;              // Semi-major axis of the ellipsoid
     private double b;              // Semi-minor axis of the ellipsoid
@@ -72,6 +78,7 @@ public class DatumParams {
                     this.datumParams[4] *= Values.SEC_TO_RAD;
                     this.datumParams[5] *= Values.SEC_TO_RAD;
                     this.datumParams[6] = (this.datumParams[6] / 1000000.0) + 1.0;
+                    this.sevenParamsConverted = true;
                 }
             }
         }
@@ -147,6 +154,7 @@ public class DatumParams {
     // Getters
 
     public int getDatumType() { return datumType; }
+    public boolean hasConverted7Params() { return sevenParamsConverted; }
     public double[] getDatumParams() { return datumParams; }
     public double getA() { return a; }
     public double getB() { return b; }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -375,9 +375,9 @@ public final class CRSSerializer {
         if (projDatumToken != null) {
             sb.append(" +datum=").append(projDatumToken);
         } else if (params.datum != null) {
-            // PROJ accepts only 3- or 7-value +towgs84= lists; a degenerate array
-            // (the proj-string parser, like proj4js's, does not validate arity)
-            // must not be re-emitted as a token PROJ rejects.
+            // PROJ accepts only 3- or 7-value +towgs84= lists. DatumParams now
+            // rejects any other arity at parse time (as PROJ does), so this guard is
+            // a defensive net for datum objects constructed outside the parsers.
             if (params.datum.getDatumParams() != null
                     && params.datum.getDatumParams().length >= 3) {
                 sb.append(" +towgs84=").append(formatTowgs84(params.datum));
@@ -1646,9 +1646,10 @@ public final class CRSSerializer {
      * DatumParams converts on parse (rotations arc-seconds → radians, scale
      * ppm → multiplier, on the 7-parameter path only); emitting the stored values
      * verbatim would make a re-parse convert them a second time (a +datum=mgi
-     * round-trip moved WGS84 results by ~12.4 m). Values are rounded to 1e-9 in
-     * human units — far below any real datum accuracy — to strip the float noise
-     * of the radian round-trip. The re-encode keys on the converted-at-parse flag,
+     * round-trip moved WGS84 results by ~12.4 m). The re-encoded rotation and
+     * scale slots are rounded to 1e-9 in human units — far below any real datum
+     * accuracy — to strip the float noise of the radian round-trip; translations
+     * are never unit-converted and pass through untouched. The re-encode keys on the converted-at-parse flag,
      * not the datum type: a nadgrids override flips the type to PJD_GRIDSHIFT while
      * the converted values stay in the array (and an all-zero tail is never
      * converted, so keying on array length would corrupt the scale slot).

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -1556,11 +1556,21 @@ public final class CRSSerializer {
     /**
      * PROJ's fixed set of {@code +datum=} tokens, keyed by lower-case registry code.
      * PROJ's datum lookup is case-sensitive — {@code WGS84}/{@code NAD83} are
-     * upper-case while {@code potsdam}/{@code carthage} are lower-case — and it
-     * accepts no other datum names. Note potsdam: PROJ defines it as
-     * nadgrids=@BETA2007.gsb (the legacy 7-parameter transform is commented out in
-     * datums.cpp), while our registry, like proj4js, carries the 7-parameter form —
-     * so a registry potsdam never matches the token and serializes as +towgs84=.
+     * upper-case while {@code carthage}/{@code nzgd49} are lower-case — and it
+     * accepts no other datum names. potsdam is omitted deliberately: PROJ's token
+     * means nadgrids=@BETA2007.gsb (the legacy 7-parameter transform is commented
+     * out in datums.cpp), while our registry — like proj4js — expands the same
+     * token to that legacy 7-parameter transform. No definition can round-trip
+     * the token consistently on both sides, so potsdam definitions always
+     * serialize their explicit transform (+towgs84= or +nadgrids=).
+     *
+     * <p>Note on modern PROJ: it resolves +datum= tokens through its EPSG database
+     * at transform time rather than attaching the pj_datums values, which can give
+     * marginally different (usually better) transformations — ~5 cm for ire65,
+     * ~5 mm for OSGB36, exact for the rest. That applies equally to the original
+     * +datum= input string, so the token remains the faithful representation of
+     * the datum's identity; the alternative — always expanding to +towgs84= —
+     * would freeze the legacy Helmert values and lose the identity.</p>
      */
     private static final Map<String, ProjDatum> PROJ_DATUMS = new HashMap<>();
     static {
@@ -1570,7 +1580,6 @@ public final class CRSSerializer {
         PROJ_DATUMS.put("nad83", new ProjDatum("NAD83", new double[]{0, 0, 0}, null, "GRS80"));
         PROJ_DATUMS.put("nad27", new ProjDatum("NAD27",
             null, "@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat", "clrk66"));
-        PROJ_DATUMS.put("potsdam", new ProjDatum("potsdam", null, "@BETA2007.gsb", "bessel"));
         PROJ_DATUMS.put("carthage", new ProjDatum("carthage",
             new double[]{-263.0, 6.0, 431.0}, null, "clrk80ign"));
         PROJ_DATUMS.put("hermannskogel", new ProjDatum("hermannskogel",
@@ -1639,14 +1648,17 @@ public final class CRSSerializer {
      * verbatim would make a re-parse convert them a second time (a +datum=mgi
      * round-trip moved WGS84 results by ~12.4 m). Values are rounded to 1e-9 in
      * human units — far below any real datum accuracy — to strip the float noise
-     * of the radian round-trip.
+     * of the radian round-trip. The re-encode keys on the converted-at-parse flag,
+     * not the datum type: a nadgrids override flips the type to PJD_GRIDSHIFT while
+     * the converted values stay in the array (and an all-zero tail is never
+     * converted, so keying on array length would corrupt the scale slot).
      */
     private static double[] toHumanTowgs84(DatumParams datum) {
         double[] out = datum.getDatumParams().clone();
-        if (datum.is7Param()) {
-            out[3] = out[3] / Values.SEC_TO_RAD;
-            out[4] = out[4] / Values.SEC_TO_RAD;
-            out[5] = out[5] / Values.SEC_TO_RAD;
+        if (datum.hasConverted7Params()) {
+            out[3] = Math.round(out[3] / Values.SEC_TO_RAD * 1e9) / 1e9;
+            out[4] = Math.round(out[4] / Values.SEC_TO_RAD * 1e9) / 1e9;
+            out[5] = Math.round(out[5] / Values.SEC_TO_RAD * 1e9) / 1e9;
             out[6] = Math.round((out[6] - 1.0) * 1000000.0 * 1e9) / 1e9;
         }
         return out;

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -357,9 +357,18 @@ public final class CRSSerializer {
         // Ellipsoid parameters
         appendEllipsoidParams(sb, params);
 
-        // Datum
-        if (params.datumCode != null && !params.datumCode.isEmpty()) {
-            sb.append(" +datum=").append(params.datumCode.toUpperCase());
+        // Datum. Mirrors PROJ's CRS export: +datum= accepts only the fixed pj_datums
+        // short codes (in their exact canonical case — "WGS84" and "NAD83" are
+        // uppercase but "potsdam" and "carthage" are lowercase), never the full datum
+        // name. Emitting params.datumCode verbatim produced tokens external PROJ
+        // rejects: unparseable names with spaces/parens from WKT ("Nouvelle
+        // Triangulation Francaise (Paris)") and wrong-case short codes ("POTSDAM").
+        // When the datum is not one of PROJ's, fall back to the transformation itself
+        // (+towgs84=/+nadgrids=, which PROJ and proj4sedona both accept) and otherwise
+        // rely on the ellipsoid already emitted above.
+        String projDatumToken = resolveProjDatumToken(params.datumCode);
+        if (projDatumToken != null) {
+            sb.append(" +datum=").append(projDatumToken);
         } else if (params.datum != null && params.datum.getDatumParams() != null) {
             double[] dp = params.datum.getDatumParams();
             sb.append(" +towgs84=");
@@ -367,6 +376,9 @@ public final class CRSSerializer {
                 if (i > 0) sb.append(",");
                 sb.append(formatNumber(dp[i]));
             }
+        } else if (params.datum != null && params.datum.getNadgrids() != null
+                && !params.datum.getNadgrids().isEmpty()) {
+            sb.append(" +nadgrids=").append(params.datum.getNadgrids());
         }
 
         // Units. Mirrors PROJ's CRS export (crs.cpp / UnitOfMeasure::exportToPROJString),
@@ -1513,6 +1525,44 @@ public final class CRSSerializer {
         // This matches pyproj behavior: unknown datum names drop confidence
         // below the identification threshold (60% < 70%), so to_epsg() returns None.
         return false;
+    }
+
+    /**
+     * PROJ's fixed set of {@code +datum=} tokens (its {@code pj_datums} table),
+     * keyed by our lower-case registry code and valued with PROJ's exact canonical
+     * casing. PROJ's datum lookup is case-sensitive — {@code WGS84}/{@code NAD83} are
+     * upper-case while {@code potsdam}/{@code carthage} are lower-case — and it
+     * accepts no other datum names. Datums outside this set (which our registry also
+     * carries, e.g. ch1903, s_jtsk) are serialized via +towgs84=/+nadgrids= instead.
+     */
+    private static final Map<String, String> PROJ_DATUM_TOKENS = new HashMap<>();
+    static {
+        PROJ_DATUM_TOKENS.put("wgs84", "WGS84");
+        PROJ_DATUM_TOKENS.put("ggrs87", "GGRS87");
+        PROJ_DATUM_TOKENS.put("nad83", "NAD83");
+        PROJ_DATUM_TOKENS.put("nad27", "NAD27");
+        PROJ_DATUM_TOKENS.put("potsdam", "potsdam");
+        PROJ_DATUM_TOKENS.put("carthage", "carthage");
+        PROJ_DATUM_TOKENS.put("hermannskogel", "hermannskogel");
+        PROJ_DATUM_TOKENS.put("ire65", "ire65");
+        PROJ_DATUM_TOKENS.put("nzgd49", "nzgd49");
+        PROJ_DATUM_TOKENS.put("osgb36", "OSGB36");
+    }
+
+    /**
+     * Resolve a stored datum code or name to PROJ's canonical {@code +datum=} token,
+     * or null when it is not one of PROJ's datums. The stored value may be a short
+     * code ("nad83"), a full datum name from WKT/PROJJSON ("North American Datum
+     * 1983"), or unknown; the registry resolves the first two to a canonical datum.
+     */
+    private static String resolveProjDatumToken(String datumCode) {
+        if (datumCode == null || datumCode.isEmpty()
+                || "none".equalsIgnoreCase(datumCode)) {
+            return null;
+        }
+        Datum datum = Datum.get(datumCode);
+        String code = datum != null ? datum.getCode() : datumCode;
+        return PROJ_DATUM_TOKENS.get(code.toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -5,6 +5,8 @@ import com.google.gson.GsonBuilder;
 import org.datasyslab.proj4sedona.constants.Datum;
 import org.datasyslab.proj4sedona.constants.Ellipsoid;
 import org.datasyslab.proj4sedona.constants.Units;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.DatumParams;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.defs.Defs;
 import org.datasyslab.proj4sedona.projection.ProjectionParams;
@@ -360,25 +362,30 @@ public final class CRSSerializer {
         // Datum. Mirrors PROJ's CRS export: +datum= accepts only the fixed pj_datums
         // short codes (in their exact canonical case — "WGS84" and "NAD83" are
         // uppercase but "potsdam" and "carthage" are lowercase), never the full datum
-        // name. Emitting params.datumCode verbatim produced tokens external PROJ
-        // rejects: unparseable names with spaces/parens from WKT ("Nouvelle
-        // Triangulation Francaise (Paris)") and wrong-case short codes ("POTSDAM").
-        // When the datum is not one of PROJ's, fall back to the transformation itself
-        // (+towgs84=/+nadgrids=, which PROJ and proj4sedona both accept) and otherwise
-        // rely on the ellipsoid already emitted above.
-        String projDatumToken = resolveProjDatumToken(params.datumCode);
+        // name. A token is emitted only when the definition's effective transform and
+        // ellipsoid match PROJ's canonical meaning of that token — a name match alone
+        // is not enough (a WKT NAD83 datum with an explicit TOWGS84[1,2,3] override
+        // is not PROJ's NAD83, and our registry's potsdam is the legacy 7-parameter
+        // transform while PROJ's +datum=potsdam means nadgrids=@BETA2007.gsb).
+        // Otherwise the transform itself is serialized: +towgs84= re-encoded to
+        // PROJ's arc-second/ppm representation, and +nadgrids= for grid shifts (both
+        // are emitted when both are present, so the re-parsed datum state is
+        // identical — the grid stays authoritative, as in proj4js).
+        String projDatumToken = resolveProjDatumToken(params);
         if (projDatumToken != null) {
             sb.append(" +datum=").append(projDatumToken);
-        } else if (params.datum != null && params.datum.getDatumParams() != null) {
-            double[] dp = params.datum.getDatumParams();
-            sb.append(" +towgs84=");
-            for (int i = 0; i < dp.length; i++) {
-                if (i > 0) sb.append(",");
-                sb.append(formatNumber(dp[i]));
+        } else if (params.datum != null) {
+            // PROJ accepts only 3- or 7-value +towgs84= lists; a degenerate array
+            // (the proj-string parser, like proj4js's, does not validate arity)
+            // must not be re-emitted as a token PROJ rejects.
+            if (params.datum.getDatumParams() != null
+                    && params.datum.getDatumParams().length >= 3) {
+                sb.append(" +towgs84=").append(formatTowgs84(params.datum));
             }
-        } else if (params.datum != null && params.datum.getNadgrids() != null
-                && !params.datum.getNadgrids().isEmpty()) {
-            sb.append(" +nadgrids=").append(params.datum.getNadgrids());
+            if (params.datum.isGridShift() && params.datum.getNadgrids() != null
+                    && !params.datum.getNadgrids().isEmpty()) {
+                sb.append(" +nadgrids=").append(params.datum.getNadgrids());
+            }
         }
 
         // Units. Mirrors PROJ's CRS export (crs.cpp / UnitOfMeasure::exportToPROJString),
@@ -1528,41 +1535,133 @@ public final class CRSSerializer {
     }
 
     /**
-     * PROJ's fixed set of {@code +datum=} tokens (its {@code pj_datums} table),
-     * keyed by our lower-case registry code and valued with PROJ's exact canonical
-     * casing. PROJ's datum lookup is case-sensitive — {@code WGS84}/{@code NAD83} are
-     * upper-case while {@code potsdam}/{@code carthage} are lower-case — and it
-     * accepts no other datum names. Datums outside this set (which our registry also
-     * carries, e.g. ch1903, s_jtsk) are serialized via +towgs84=/+nadgrids= instead.
+     * An entry of PROJ's {@code pj_datums} table (src/datums.cpp): the canonical
+     * {@code +datum=} token in PROJ's exact case, the transform that token means to
+     * PROJ (towgs84 in human units — metres/arc-seconds/ppm — or a grid list), and
+     * the ellipsoid it implies (PROJ's +datum= sets the ellipsoid too).
      */
-    private static final Map<String, String> PROJ_DATUM_TOKENS = new HashMap<>();
-    static {
-        PROJ_DATUM_TOKENS.put("wgs84", "WGS84");
-        PROJ_DATUM_TOKENS.put("ggrs87", "GGRS87");
-        PROJ_DATUM_TOKENS.put("nad83", "NAD83");
-        PROJ_DATUM_TOKENS.put("nad27", "NAD27");
-        PROJ_DATUM_TOKENS.put("potsdam", "potsdam");
-        PROJ_DATUM_TOKENS.put("carthage", "carthage");
-        PROJ_DATUM_TOKENS.put("hermannskogel", "hermannskogel");
-        PROJ_DATUM_TOKENS.put("ire65", "ire65");
-        PROJ_DATUM_TOKENS.put("nzgd49", "nzgd49");
-        PROJ_DATUM_TOKENS.put("osgb36", "OSGB36");
+    private static final class ProjDatum {
+        final String token;
+        final double[] towgs84;
+        final String nadgrids;
+        final String ellipseCode;
+        ProjDatum(String token, double[] towgs84, String nadgrids, String ellipseCode) {
+            this.token = token;
+            this.towgs84 = towgs84;
+            this.nadgrids = nadgrids;
+            this.ellipseCode = ellipseCode;
+        }
     }
 
     /**
-     * Resolve a stored datum code or name to PROJ's canonical {@code +datum=} token,
-     * or null when it is not one of PROJ's datums. The stored value may be a short
-     * code ("nad83"), a full datum name from WKT/PROJJSON ("North American Datum
-     * 1983"), or unknown; the registry resolves the first two to a canonical datum.
+     * PROJ's fixed set of {@code +datum=} tokens, keyed by lower-case registry code.
+     * PROJ's datum lookup is case-sensitive — {@code WGS84}/{@code NAD83} are
+     * upper-case while {@code potsdam}/{@code carthage} are lower-case — and it
+     * accepts no other datum names. Note potsdam: PROJ defines it as
+     * nadgrids=@BETA2007.gsb (the legacy 7-parameter transform is commented out in
+     * datums.cpp), while our registry, like proj4js, carries the 7-parameter form —
+     * so a registry potsdam never matches the token and serializes as +towgs84=.
      */
-    private static String resolveProjDatumToken(String datumCode) {
+    private static final Map<String, ProjDatum> PROJ_DATUMS = new HashMap<>();
+    static {
+        PROJ_DATUMS.put("wgs84", new ProjDatum("WGS84", new double[]{0, 0, 0}, null, "WGS84"));
+        PROJ_DATUMS.put("ggrs87", new ProjDatum("GGRS87",
+            new double[]{-199.87, 74.79, 246.62}, null, "GRS80"));
+        PROJ_DATUMS.put("nad83", new ProjDatum("NAD83", new double[]{0, 0, 0}, null, "GRS80"));
+        PROJ_DATUMS.put("nad27", new ProjDatum("NAD27",
+            null, "@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat", "clrk66"));
+        PROJ_DATUMS.put("potsdam", new ProjDatum("potsdam", null, "@BETA2007.gsb", "bessel"));
+        PROJ_DATUMS.put("carthage", new ProjDatum("carthage",
+            new double[]{-263.0, 6.0, 431.0}, null, "clrk80ign"));
+        PROJ_DATUMS.put("hermannskogel", new ProjDatum("hermannskogel",
+            new double[]{577.326, 90.129, 463.919, 5.137, 1.474, 5.297, 2.4232}, null, "bessel"));
+        PROJ_DATUMS.put("ire65", new ProjDatum("ire65",
+            new double[]{482.530, -130.596, 564.557, -1.042, -0.214, -0.631, 8.15}, null, "mod_airy"));
+        PROJ_DATUMS.put("nzgd49", new ProjDatum("nzgd49",
+            new double[]{59.47, -5.04, 187.44, 0.47, -0.1, 1.024, -4.5993}, null, "intl"));
+        PROJ_DATUMS.put("osgb36", new ProjDatum("OSGB36",
+            new double[]{446.448, -125.157, 542.060, 0.1502, 0.2470, 0.8421, -20.4894}, null, "airy"));
+    }
+
+    /**
+     * Resolve a definition to PROJ's canonical {@code +datum=} token, or null when
+     * its datum is not semantically one of PROJ's. The stored datumCode may be a
+     * short code ("nad83"), a full datum name from WKT/PROJJSON ("North American
+     * Datum 1983"), or unknown; the registry resolves the first two. The token is
+     * used only when the definition's effective transform (towgs84 values or grid
+     * list — a WKT TOWGS84 node can override the registry's) and ellipsoid match the
+     * token's canonical PROJ definition, since +datum= replaces both on re-parse.
+     */
+    private static String resolveProjDatumToken(ProjectionParams params) {
+        String datumCode = params.datumCode;
         if (datumCode == null || datumCode.isEmpty()
                 || "none".equalsIgnoreCase(datumCode)) {
             return null;
         }
-        Datum datum = Datum.get(datumCode);
-        String code = datum != null ? datum.getCode() : datumCode;
-        return PROJ_DATUM_TOKENS.get(code.toLowerCase(Locale.ROOT));
+        Datum registryDatum = Datum.get(datumCode);
+        String code = registryDatum != null ? registryDatum.getCode() : datumCode;
+        ProjDatum canon = PROJ_DATUMS.get(code.toLowerCase(Locale.ROOT));
+        if (canon == null) {
+            return null;
+        }
+
+        Ellipsoid ellipse = Ellipsoid.get(canon.ellipseCode);
+        double canonB = ellipse.getB() > 0
+            ? ellipse.getB()
+            : ellipse.getA() * (1 - 1 / ellipse.getRf());
+        if (Math.abs(params.a - ellipse.getA()) > 0.1 || Math.abs(params.b - canonB) > 0.1) {
+            return null;
+        }
+
+        DatumParams datum = params.datum;
+        if (canon.nadgrids != null) {
+            return datum != null && datum.isGridShift()
+                && canon.nadgrids.equals(datum.getNadgrids()) ? canon.token : null;
+        }
+        if (datum == null || datum.isGridShift() || datum.getDatumParams() == null) {
+            return null;
+        }
+        double[] human = toHumanTowgs84(datum);
+        for (int i = 0; i < 7; i++) {
+            double have = i < human.length ? human[i] : 0;
+            double want = i < canon.towgs84.length ? canon.towgs84[i] : 0;
+            if (Math.abs(have - want) > 1e-6) {
+                return null;
+            }
+        }
+        return canon.token;
+    }
+
+    /**
+     * Re-encode stored datum parameters to PROJ's +towgs84= representation.
+     * DatumParams converts on parse (rotations arc-seconds → radians, scale
+     * ppm → multiplier, on the 7-parameter path only); emitting the stored values
+     * verbatim would make a re-parse convert them a second time (a +datum=mgi
+     * round-trip moved WGS84 results by ~12.4 m). Values are rounded to 1e-9 in
+     * human units — far below any real datum accuracy — to strip the float noise
+     * of the radian round-trip.
+     */
+    private static double[] toHumanTowgs84(DatumParams datum) {
+        double[] out = datum.getDatumParams().clone();
+        if (datum.is7Param()) {
+            out[3] = out[3] / Values.SEC_TO_RAD;
+            out[4] = out[4] / Values.SEC_TO_RAD;
+            out[5] = out[5] / Values.SEC_TO_RAD;
+            out[6] = Math.round((out[6] - 1.0) * 1000000.0 * 1e9) / 1e9;
+        }
+        return out;
+    }
+
+    private static String formatTowgs84(DatumParams datum) {
+        double[] human = toHumanTowgs84(datum);
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < human.length; i++) {
+            if (i > 0) {
+                b.append(",");
+            }
+            b.append(formatNumber(human[i]));
+        }
+        return b.toString();
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1419,6 +1419,14 @@ class CRSSerializerTest {
         String out = CRSSerializer.toProjString(new Proj("+proj=longlat +datum=potsdam +no_defs"));
         assertFalse(out.contains("+datum="), out);
         assertTrue(out.contains("+towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7"), out);
+
+        // Even a definition that carries PROJ's exact @BETA2007.gsb grid must not be
+        // tokenized: our own parser (like proj4js) re-reads +datum=potsdam as the
+        // legacy Helmert, so the token cannot round-trip on both sides.
+        String grid = CRSSerializer.toProjString(
+            new Proj("+proj=longlat +datum=potsdam +nadgrids=@BETA2007.gsb +no_defs"));
+        assertFalse(grid.contains("+datum="), grid);
+        assertTrue(grid.contains("+nadgrids=@BETA2007.gsb"), grid);
     }
 
     @Test
@@ -1485,6 +1493,8 @@ class CRSSerializerTest {
         Proj p = new Proj("+proj=longlat +datum=ch1903 +nadgrids=@foo.gsb +no_defs");
         String out = CRSSerializer.toProjString(p);
         assertTrue(out.contains("+nadgrids=@foo.gsb"), out);
+        assertTrue(out.contains("+towgs84=674.374,15.056,405.346"),
+            "the dormant towgs84 half of the state is preserved too: " + out);
         Proj reimported = new Proj(out);
         assertTrue(reimported.getParams().datum.isGridShift(),
             "grid shift stays authoritative after the round-trip");
@@ -1497,6 +1507,108 @@ class CRSSerializerTest {
         // semantic gate passes and the compact token is kept.
         assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=NAD27 +no_defs"))
             .contains("+datum=NAD27"));
+
+        // A different grid list must reject the token and keep the explicit grid.
+        String out = CRSSerializer.toProjString(
+            new Proj("+proj=longlat +datum=NAD27 +nadgrids=@other.gsb +no_defs"));
+        assertFalse(out.contains("+datum="), out);
+        assertTrue(out.contains("+nadgrids=@other.gsb"), out);
+    }
+
+    @Test
+    @DisplayName("toProjString: grid-shift datum with a converted 7-param tail re-encodes it")
+    void testGridShiftWithConverted7ParamTail() {
+        // The nadgrids override flips the datum type to PJD_GRIDSHIFT after the
+        // 7-parameter tail was already converted to radians/multiplier, so the
+        // re-encode must key on the converted-at-parse flag, not the datum type —
+        // otherwise the dormant tail is emitted in internal units and every
+        // round-trip converts it again.
+        String def = "+proj=longlat +ellps=bessel "
+            + "+towgs84=597.1,71.4,412.1,0.894,0.068,-1.563,7.58 +nadgrids=@foo.gsb +no_defs";
+        String s1 = CRSSerializer.toProjString(new Proj(def));
+        assertTrue(s1.contains("+towgs84=597.1,71.4,412.1,0.894,0.068,-1.563,7.58"), s1);
+        assertTrue(s1.contains("+nadgrids=@foo.gsb"), s1);
+        assertEquals(s1, CRSSerializer.toProjString(new Proj(s1)), "serialization is idempotent");
+    }
+
+    @Test
+    @DisplayName("toProjString: rotation/scale re-encode is float-noise free")
+    void testTowgs84ReEncodeRounding() {
+        // The radian round-trip (x * SEC_TO_RAD / SEC_TO_RAD) is not exact in
+        // binary floating point; the 1e-9 human-unit rounding keeps the emitted
+        // values byte-identical to the input.
+        String out = CRSSerializer.toProjString(
+            new Proj("+proj=longlat +ellps=bessel +towgs84=1,2,3,0.1,0.2,0.3,0.4 +no_defs"));
+        assertTrue(out.contains("+towgs84=1,2,3,0.1,0.2,0.3,0.4"), out);
+    }
+
+    @Test
+    @DisplayName("toProjString: token gate compares 3- and 7-value transforms padded")
+    void testTokenGatePaddedComparison() {
+        // A 7-value all-zero-tail TOWGS84 equals PROJ's 3-value canonical WGS84.
+        String wgs = "GEOGCS[\"WGS 84\",DATUM[\"World Geodetic System 1984\","
+            + "SPHEROID[\"WGS 84\",6378137,298.257223563],TOWGS84[0,0,0,0,0,0,0]],"
+            + "PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+        assertTrue(CRSSerializer.toProjString(new Proj(wgs)).contains("+datum=WGS84"));
+
+        // A 3-value transform does not equal a canonical 7-value one (hermannskogel).
+        String herm = "GEOGCS[\"MGI-ish\",DATUM[\"Hermannskogel\","
+            + "SPHEROID[\"Bessel 1841\",6377397.155,299.1528128],"
+            + "TOWGS84[577.326,90.129,463.919]],"
+            + "PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+        String out = CRSSerializer.toProjString(new Proj(herm));
+        assertFalse(out.contains("+datum="), out);
+        assertTrue(out.contains("+towgs84=577.326,90.129,463.919"), out);
+    }
+
+    @Test
+    @DisplayName("toProjString: token gate rejects a datum name on the wrong ellipsoid")
+    void testEllipsoidGateRejectsToken() {
+        // PROJ's +datum=NAD83 implies GRS80; a document claiming the NAD83 datum on
+        // a Bessel spheroid must not be tokenized (the token would replace the
+        // ellipsoid on re-parse).
+        String wkt = "GEOGCS[\"odd\",DATUM[\"North_American_Datum_1983\","
+            + "SPHEROID[\"Bessel 1841\",6377397.155,299.1528128]],"
+            + "PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+        String out = CRSSerializer.toProjString(new Proj(wkt));
+        assertFalse(out.contains("+datum="), out);
+        assertTrue(out.contains("+ellps=bessel"), out);
+    }
+
+    @Test
+    @DisplayName("toProjString: every PROJ datum token row is exercised")
+    void testAllProjDatumTokens() {
+        // One assertion per pj_datums row we tokenize (potsdam is deliberately
+        // absent — see testPotsdamSemanticMismatch).
+        String[][] cases = {
+            {"WGS84", "+datum=WGS84"}, {"GGRS87", "+datum=GGRS87"},
+            {"NAD83", "+datum=NAD83"}, {"NAD27", "+datum=NAD27"},
+            {"carthage", "+datum=carthage"}, {"hermannskogel", "+datum=hermannskogel"},
+            {"ire65", "+datum=ire65"}, {"nzgd49", "+datum=nzgd49"},
+            {"OSGB36", "+datum=OSGB36"},
+        };
+        for (String[] c : cases) {
+            String out = CRSSerializer.toProjString(
+                new Proj("+proj=longlat +datum=" + c[0] + " +no_defs"));
+            assertTrue(out.contains(c[1]), c[0] + " -> " + out);
+        }
+    }
+
+    @Test
+    @DisplayName("toProjString: PROJJSON-parsed datum name goes through the same gate")
+    void testProjJsonDatumNameTokenized() {
+        // EPSG:4277-style PROJJSON: the datum name resolves through the registry and
+        // the gate (transform + airy ellipsoid match), yielding the compact token.
+        String json = "{\"type\": \"GeographicCRS\", \"name\": \"OSGB36\","
+            + "\"datum\": {\"type\": \"GeodeticReferenceFrame\","
+            + "  \"name\": \"Ordnance Survey of Great Britain 1936\","
+            + "  \"ellipsoid\": {\"name\": \"Airy 1830\", \"semi_major_axis\": 6377563.396,"
+            + "   \"inverse_flattening\": 299.3249646}},"
+            + "\"coordinate_system\": {\"subtype\": \"ellipsoidal\", \"axis\": ["
+            + " {\"name\": \"Geodetic latitude\", \"abbreviation\": \"Lat\", \"direction\": \"north\", \"unit\": \"degree\"},"
+            + " {\"name\": \"Geodetic longitude\", \"abbreviation\": \"Lon\", \"direction\": \"east\", \"unit\": \"degree\"}]}}";
+        String out = CRSSerializer.toProjString(new Proj(json));
+        assertTrue(out.contains("+datum=OSGB36"), out);
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1353,4 +1353,75 @@ class CRSSerializerTest {
         String projString = CRSSerializer.toProjString(ext);
         assertTrue(projString.contains("+proj=eck6"), "re-export uses short code: " + projString);
     }
+
+    // ========== Datum token normalization (issue #98) ==========
+
+    @Test
+    @DisplayName("toProjString: WKT datum name resolves to the PROJ +datum= short code")
+    void testDatumNameResolvesToShortCode() {
+        // A WKT/PROJJSON-parsed CRS stores the full datum name; PROJ's +datum= accepts
+        // only its short codes, so the name was emitted verbatim as an unparseable
+        // token. The name now resolves to the canonical code.
+        String wkt4326 = "GEOGCRS[\"WGS 84\",DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]]],"
+            + "CS[ellipsoidal,2],AXIS[\"lat\",north],AXIS[\"lon\",east],"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",4326]]";
+        String out = CRSSerializer.toProjString(new Proj(wkt4326));
+        assertTrue(out.contains("+datum=WGS84"), out);
+        assertFalse(out.contains("WORLD GEODETIC SYSTEM"), out);
+
+        String wkt4269 = "GEOGCRS[\"NAD83\",DATUM[\"North American Datum 1983\","
+            + "ELLIPSOID[\"GRS 1980\",6378137,298.257222101,LENGTHUNIT[\"metre\",1]]],"
+            + "CS[ellipsoidal,2],AXIS[\"lat\",north],AXIS[\"lon\",east],"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",4269]]";
+        assertTrue(CRSSerializer.toProjString(new Proj(wkt4269)).contains("+datum=NAD83"));
+    }
+
+    @Test
+    @DisplayName("toProjString: unknown datum name is dropped, not emitted as a broken token")
+    void testUnknownDatumNameDropped() {
+        // PROJ's WKT2 for EPSG:4807 (issue #98 repro): the datum "Nouvelle
+        // Triangulation Francaise (Paris)" is not one of PROJ's datums, so PROJ emits
+        // only +ellps=. We previously emitted +datum=NOUVELLE TRIANGULATION FRANCAISE
+        // (PARIS), which splits into garbage tokens.
+        String wkt4807 = "GEODCRS[\"NTF (Paris)\","
+            + "DATUM[\"Nouvelle Triangulation Francaise (Paris)\","
+            + "ELLIPSOID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627,LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Paris\",2.5969213,ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "CS[ellipsoidal,2],AXIS[\"lat\",north],AXIS[\"lon\",east],"
+            + "ANGLEUNIT[\"grad\",0.015707963267949],ID[\"EPSG\",4807]]";
+        String out = CRSSerializer.toProjString(new Proj(wkt4807));
+        assertFalse(out.contains("+datum="), "unknown datum must not be emitted: " + out);
+        assertTrue(out.contains("+ellps="), "relies on the ellipsoid instead: " + out);
+    }
+
+    @Test
+    @DisplayName("toProjString: PROJ datum short code keeps PROJ's canonical case")
+    void testDatumCanonicalCase() {
+        // PROJ's +datum= lookup is case-sensitive: potsdam is lower-case, so the old
+        // blanket toUpperCase() emitted +datum=POTSDAM, which PROJ rejects.
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=potsdam +no_defs"))
+            .contains("+datum=potsdam"));
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=carthage +no_defs"))
+            .contains("+datum=carthage"));
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=WGS84 +no_defs"))
+            .contains("+datum=WGS84"));
+    }
+
+    @Test
+    @DisplayName("toProjString: datum outside PROJ's set falls back to +towgs84= and round-trips")
+    void testNonProjDatumFallsBackToTowgs84() {
+        // ch1903 is in our registry but not PROJ's pj_datums; PROJ serializes it as
+        // +ellps=bessel +towgs84=... We do the same, which round-trips exactly.
+        Proj original = new Proj("+proj=longlat +datum=ch1903 +no_defs");
+        String out = CRSSerializer.toProjString(original);
+        assertFalse(out.contains("+datum="), "not a PROJ datum: " + out);
+        assertTrue(out.contains("+towgs84=674.374,15.056,405.346"), out);
+
+        Proj reimported = new Proj(out);
+        assertArrayEquals(
+            original.getParams().datum.getDatumParams(),
+            reimported.getParams().datum.getDatumParams(), 0.0,
+            "the datum transform survives the +towgs84= round-trip");
+    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1398,14 +1398,105 @@ class CRSSerializerTest {
     @Test
     @DisplayName("toProjString: PROJ datum short code keeps PROJ's canonical case")
     void testDatumCanonicalCase() {
-        // PROJ's +datum= lookup is case-sensitive: potsdam is lower-case, so the old
-        // blanket toUpperCase() emitted +datum=POTSDAM, which PROJ rejects.
-        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=potsdam +no_defs"))
-            .contains("+datum=potsdam"));
-        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=carthage +no_defs"))
-            .contains("+datum=carthage"));
+        // PROJ's +datum= lookup is case-sensitive: nzgd49/hermannskogel/carthage are
+        // lower-case, so the old blanket toUpperCase() emitted tokens PROJ rejects.
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=nzgd49 +no_defs"))
+            .contains("+datum=nzgd49"));
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=hermannskogel +no_defs"))
+            .contains("+datum=hermannskogel"));
         assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=WGS84 +no_defs"))
             .contains("+datum=WGS84"));
+    }
+
+    @Test
+    @DisplayName("toProjString: potsdam is not tokenized — PROJ's potsdam means a grid shift")
+    void testPotsdamSemanticMismatch() {
+        // Our registry (like proj4js) defines potsdam as the legacy 7-parameter
+        // transform, but PROJ's pj_datums defines +datum=potsdam as
+        // nadgrids=@BETA2007.gsb (the towgs84 form is commented out in datums.cpp).
+        // Emitting the token would silently change the transform for external PROJ,
+        // so the actual parameters are serialized instead, in human units.
+        String out = CRSSerializer.toProjString(new Proj("+proj=longlat +datum=potsdam +no_defs"));
+        assertFalse(out.contains("+datum="), out);
+        assertTrue(out.contains("+towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7"), out);
+    }
+
+    @Test
+    @DisplayName("toProjString: 7-parameter datums re-encode to arc-seconds/ppm")
+    void testSevenParamReEncoded() {
+        // DatumParams stores rotations in radians and scale as a multiplier;
+        // emitting those raw made a re-parse convert them a second time (a
+        // +datum=mgi round-trip moved WGS84 results by ~12.4 m at (16,48)).
+        Proj mgi = new Proj("+proj=longlat +datum=mgi +no_defs");
+        String out = CRSSerializer.toProjString(mgi);
+        assertTrue(out.contains("+towgs84=577.326,90.129,463.919,5.137,1.474,5.297,2.4232"), out);
+
+        Proj reimported = new Proj(out);
+        assertArrayEquals(
+            mgi.getParams().datum.getDatumParams(),
+            reimported.getParams().datum.getDatumParams(), 1e-15,
+            "7-parameter transform survives the round-trip");
+
+        org.datasyslab.proj4sedona.transform.Converter a =
+            org.datasyslab.proj4sedona.Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs",
+                "+proj=longlat +datum=mgi +no_defs");
+        org.datasyslab.proj4sedona.transform.Converter b =
+            org.datasyslab.proj4sedona.Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs", out);
+        Point pa = a.inverse(new Point(16, 48));
+        Point pb = b.inverse(new Point(16, 48));
+        assertEquals(pa.x, pb.x, 1e-12, "lon identical after round-trip");
+        assertEquals(pa.y, pb.y, 1e-12, "lat identical after round-trip");
+    }
+
+    @Test
+    @DisplayName("toProjString: all-zero 7-value towgs84 is not scale-corrupted")
+    void testAllZeroTailTowgs84() {
+        // A 7-value +towgs84 whose rotation/scale entries are all zero stays on the
+        // 3-parameter path (no unit conversion at parse), so re-encoding must not
+        // treat the zero scale slot as a multiplier ((0-1)*1e6 = -1000000 ppm).
+        String out = CRSSerializer.toProjString(
+            new Proj("+proj=longlat +ellps=bessel +towgs84=1,2,3,0,0,0,0 +no_defs"));
+        assertTrue(out.contains("+towgs84=1,2,3,0,0,0,0"), out);
+    }
+
+    @Test
+    @DisplayName("toProjString: explicit TOWGS84 override blocks the +datum= token")
+    void testExplicitTowgs84OverrideBlocksToken() {
+        // A WKT datum named NAD83 with TOWGS84[1,2,3] is not PROJ's NAD83 (whose
+        // canonical transform is 0,0,0): emitting the token would replace the
+        // explicit override with the registry values on re-parse.
+        String wkt = "GEOGCS[\"NAD83-ish\",DATUM[\"North_American_Datum_1983\","
+            + "SPHEROID[\"GRS 1980\",6378137,298.257222101],TOWGS84[1,2,3]],"
+            + "PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433]]";
+        String out = CRSSerializer.toProjString(new Proj(wkt));
+        assertFalse(out.contains("+datum="), out);
+        assertTrue(out.contains("+towgs84=1,2,3"), out);
+        assertArrayEquals(new double[]{1, 2, 3},
+            new Proj(out).getParams().datum.getDatumParams(), 0,
+            "the override survives the round-trip");
+    }
+
+    @Test
+    @DisplayName("toProjString: grid shift is preserved and stays authoritative")
+    void testGridShiftPreserved() {
+        // Grids are authoritative over towgs84 (DatumParams sets PJD_GRIDSHIFT last,
+        // as proj4js does); both are emitted so the re-parsed datum state is
+        // identical. Previously the grid was silently dropped.
+        Proj p = new Proj("+proj=longlat +datum=ch1903 +nadgrids=@foo.gsb +no_defs");
+        String out = CRSSerializer.toProjString(p);
+        assertTrue(out.contains("+nadgrids=@foo.gsb"), out);
+        Proj reimported = new Proj(out);
+        assertTrue(reimported.getParams().datum.isGridShift(),
+            "grid shift stays authoritative after the round-trip");
+    }
+
+    @Test
+    @DisplayName("toProjString: NAD27 keeps its token — the grid lists match PROJ's")
+    void testNad27GridTokenKept() {
+        // NAD27 is grid-shift on both sides with the identical grid list, so the
+        // semantic gate passes and the compact token is kept.
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=NAD27 +no_defs"))
+            .contains("+datum=NAD27"));
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/ParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/ParserTest.java
@@ -222,6 +222,27 @@ class ParserTest {
         assertEquals(6.7, def.getDatumParams()[6], DELTA);
     }
 
+    @Test
+    void testTowgs84InvalidArityRejected() {
+        // PROJ accepts exactly 3 or 7 towgs84 values and rejects any other arity at
+        // parse time. Mirroring the malformed-input behavior of either reference was
+        // not an option: this port previously threw ArrayIndexOutOfBounds for 4-6
+        // values, and proj4js silently reads past the array end, producing NaN
+        // rotations. Documented divergence from proj4js: fail loudly, as PROJ does.
+        for (String v : new String[]{"1,2", "1,2,3,4", "1,2,3,4,5,6", "1,2,3,4,5,6,7,8"}) {
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new org.datasyslab.proj4sedona.core.Proj(
+                    "+proj=longlat +ellps=bessel +towgs84=" + v + " +no_defs"),
+                v);
+            assertTrue(e.getMessage().contains("towgs84"), e.getMessage());
+        }
+        // The valid arities still parse.
+        assertNotNull(new org.datasyslab.proj4sedona.core.Proj(
+            "+proj=longlat +ellps=bessel +towgs84=1,2,3 +no_defs").getParams().datum);
+        assertNotNull(new org.datasyslab.proj4sedona.core.Proj(
+            "+proj=longlat +ellps=bessel +towgs84=1,2,3,4,5,6,7 +no_defs").getParams().datum);
+    }
+
     // ========== Units Tests ==========
 
     @Test


### PR DESCRIPTION
Closes #98.

`toProjString` emitted `params.datumCode` verbatim (upper-cased) into `+datum=`. For WKT/PROJJSON-parsed definitions `datumCode` is the full datum *name*, so every such CRS produced an unparseable token, and the blanket `toUpperCase()` broke the lower-case-canonical short codes too:

| input | old output | problem |
|---|---|---|
| EPSG:4326 WKT2 | `+datum=WORLD GEODETIC SYSTEM 1984` | spaces split into garbage tokens |
| EPSG:4807 WKT2 | `+datum=NOUVELLE TRIANGULATION FRANCAISE (PARIS)` | ditto (the #98 repro) |
| EPSG:4269 WKT2 | `+datum=NORTH AMERICAN DATUM 1983` | ditto |
| `+datum=potsdam` | `+datum=POTSDAM` | PROJ's datum lookup is case-sensitive; `POTSDAM` is rejected |

## Fix

Follows PROJ's CRS export (`src/datums.cpp` `pj_datums`): `+datum=` accepts only a fixed set of short codes in their exact canonical case (`WGS84`/`NAD83` upper-case, `potsdam`/`carthage` lower-case), never a datum name.

- `resolveProjDatumToken` resolves the stored code or name through the `Datum` registry (`"North American Datum 1983"` → `nad83`) and emits the PROJ token only when the datum is one of PROJ's ten.
- Datums our registry carries but PROJ doesn't (ch1903, s_jtsk, …) fall back to `+towgs84=`/`+nadgrids=` — accepted by both PROJ and proj4sedona, and round-trips the datum transform exactly.
- Unknown datums (NTF Paris, DHDN) emit no `+datum=` and rely on the ellipsoid, as PROJ does.

## Verification

Every affected CRS's re-exported proj string now parses in pyproj 3.7.2/PROJ 9.5.1 (7/7 probe cases, including the previously-rejected `+datum=potsdam`). The `+towgs84=` fallback reconstructs the identical datum transform on re-import (dx=dy=0). Four new tests; 846 total.

Filed separately while here: #101 (`toProjString` reverse-resolves `+ellps=WGS84` to `+ellps=MERIT` — an ellipsoid-name shadowing bug, masked when a `+datum=` is present).
