### PR TITLE
Resolve prime-meridian longitudes through their angular unit

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -1,5 +1,7 @@
 package org.datasyslab.proj4sedona.parser;
 
+import org.datasyslab.proj4sedona.constants.Values;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -202,7 +204,28 @@ public final class ProjJsonBuilder {
                 Map<String, Object> primeMeridian = new HashMap<>();
                 primeMeridian.put("name", primemNode.get(1));
                 if (primemNode.size() > 2) {
-                    primeMeridian.put("longitude", parseDouble(primemNode.get(2)));
+                    // The PRIMEM value is in its own ANGLEUNIT when present, else in
+                    // the CRS's angular unit (the SIMPLIFIED form drops the local
+                    // unit — EPSG:4807's Paris meridian is 2.5969213 grads, not
+                    // degrees), else degrees. Normalized to degrees here, the plain-
+                    // number form of the PROJJSON prime_meridian.longitude field.
+                    // Divergence from wkt-parser 1.5.5, which reads the raw value as
+                    // degrees (~0.26 deg / 29 km error for grads meridians).
+                    double raw = parseDouble(primemNode.get(2));
+                    Double toRadians = angularUnitFactor(findNode(primemNode, "ANGLEUNIT"));
+                    if (toRadians == null) {
+                        toRadians = angularUnitFactor(findNode(primemNode, "UNIT"));
+                    }
+                    if (toRadians == null) {
+                        toRadians = angularUnitFactor(findNode(node, "ANGLEUNIT"));
+                    }
+                    if (toRadians == null) {
+                        toRadians = angularUnitFactor(findNode(node, "UNIT"));
+                    }
+                    double degrees = toRadians != null
+                        ? Math.round(raw * toRadians * Values.R2D * 1e9) / 1e9
+                        : raw;
+                    primeMeridian.put("longitude", degrees);
                 }
                 datum.put("prime_meridian", primeMeridian);
             }
@@ -637,6 +660,18 @@ public final class ProjJsonBuilder {
         }
 
         return unit;
+    }
+
+    /**
+     * The to-radians conversion factor of an ANGLEUNIT/UNIT node, or null when the
+     * node is absent or carries no numeric factor.
+     */
+    private static Double angularUnitFactor(List<Object> unitNode) {
+        if (unitNode == null || unitNode.size() < 3) {
+            return null;
+        }
+        double factor = parseDouble(unitNode.get(2));
+        return factor > 0 ? factor : null;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -136,7 +136,7 @@ public final class ProjJsonTransformer {
                 if (value instanceof Map) {
                     Object longitude = ((Map<String, Object>) value).get("longitude");
                     if (longitude != null) {
-                        def.setLong0(toDouble(longitude) * Values.D2R);
+                        def.setLong0(primeMeridianToRadians(longitude));
                     }
                 }
                 break;
@@ -257,9 +257,39 @@ public final class ProjJsonTransformer {
         if (primeMeridian instanceof Map) {
             Object longitude = ((Map<String, Object>) primeMeridian).get("longitude");
             if (longitude != null) {
-                def.setFromGreenwich(toDouble(longitude) * Values.D2R);
+                def.setFromGreenwich(primeMeridianToRadians(longitude));
             }
         }
+    }
+
+    /**
+     * Resolve a PROJJSON prime-meridian longitude to radians. The field is either a
+     * plain number in degrees, or a value-with-unit object as PROJ emits for
+     * non-degree meridians (EPSG:4807's Paris meridian is
+     * {"value": 2.5969213, "unit": {..."grad", "conversion_factor": 0.0157...}});
+     * the previous degree assumption fed the object through toDouble, which lost
+     * the meridian entirely (0.0). Divergence from wkt-parser 1.5.5, which assumes
+     * degrees unconditionally.
+     */
+    @SuppressWarnings("unchecked")
+    private static double primeMeridianToRadians(Object longitude) {
+        if (longitude instanceof Map) {
+            Map<String, Object> lon = (Map<String, Object>) longitude;
+            double value = toDouble(lon.get("value"));
+            Object unit = lon.get("unit");
+            if (unit instanceof Map) {
+                Object factor = ((Map<String, Object>) unit).get("conversion_factor");
+                if (factor != null && toDouble(factor) > 0) {
+                    // Rounded at 1e-9 in degrees (as the towgs84 re-encode does) so
+                    // the unit conversion's float noise does not leak into +pm=.
+                    double degrees = Math.round(
+                        value * toDouble(factor) * Values.R2D * 1e9) / 1e9;
+                    return degrees * Values.D2R;
+                }
+            }
+            return value * Values.D2R;
+        }
+        return toDouble(longitude) * Values.D2R;
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -894,6 +894,85 @@ class WktParserTest {
     }
 
     @Test
+    @DisplayName("Issue #99: grads PRIMEM resolves through its angular unit")
+    void testPrimemAngularUnits() {
+        // EPSG:4807's Paris meridian is 2.5969213 grads = 2.33722917 degrees. The
+        // raw value was read as degrees (~0.26 deg / 29 km error). Verified against
+        // PROJ, whose export of the same CRS is +pm=paris (2.33722917 deg).
+        // Divergence from wkt-parser 1.5.5, which assumes degrees unconditionally.
+        String full = "GEODCRS[\"NTF (Paris)\",DATUM[\"Nouvelle Triangulation Francaise (Paris)\","
+            + "ELLIPSOID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627,LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Paris\",2.5969213,ANGLEUNIT[\"grad\",0.015707963267949]],CS[ellipsoidal,2],"
+            + "AXIS[\"latitude\",north,ORDER[1],ANGLEUNIT[\"grad\",0.015707963267949]],"
+            + "AXIS[\"longitude\",east,ORDER[2],ANGLEUNIT[\"grad\",0.015707963267949]],ID[\"EPSG\",4807]]";
+        // The SIMPLIFIED form drops the local ANGLEUNIT; the value is in the CRS's
+        // CS-level unit (grads), not degrees.
+        String simplified = "GEODCRS[\"NTF (Paris)\",DATUM[\"Nouvelle Triangulation Francaise (Paris)\","
+            + "ELLIPSOID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627]],"
+            + "PRIMEM[\"Paris\",2.5969213],CS[ellipsoidal,2],"
+            + "AXIS[\"geodetic latitude (Lat)\",north],AXIS[\"geodetic longitude (Lon)\",east],"
+            + "UNIT[\"grad\",0.0157079632679489],ID[\"EPSG\",4807]]";
+        for (String wkt : new String[]{full, simplified}) {
+            org.datasyslab.proj4sedona.core.Proj p = new org.datasyslab.proj4sedona.core.Proj(wkt);
+            assertEquals(2.33722917, Math.toDegrees(p.getParams().fromGreenwich), 1e-9,
+                "Paris meridian in degrees");
+            assertTrue(CRSSerializer.toProjString(p).contains("+pm=2.33722917"),
+                CRSSerializer.toProjString(p));
+        }
+
+        // Internal consistency: a Greenwich longitude of 5 deg is 5 - 2.33722917 deg
+        // east of the Paris meridian.
+        Point out = org.datasyslab.proj4sedona.Proj4
+            .proj4("+proj=longlat +datum=WGS84 +no_defs", full)
+            .forward(new Point(5.0, 48.0));
+        assertEquals(5.0 - 2.33722917, out.x, 1e-9, "lon relative to Paris");
+        assertEquals(48.0, out.y, 1e-9, "lat unchanged");
+
+        // A degree-unit PRIMEM stays an identity conversion (Madrid, EPSG:4903 style).
+        String madrid = "GEODCRS[\"Madrid 1870\",DATUM[\"Madrid 1870\","
+            + "ELLIPSOID[\"Struve 1860\",6378298.3,294.73]],"
+            + "PRIMEM[\"Madrid\",-3.687375,ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "CS[ellipsoidal,2],AXIS[\"latitude\",north,ORDER[1],ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "AXIS[\"longitude\",east,ORDER[2],ANGLEUNIT[\"degree\",0.0174532925199433]]]";
+        assertEquals(-3.687375,
+            Math.toDegrees(new org.datasyslab.proj4sedona.core.Proj(madrid).getParams().fromGreenwich),
+            1e-9);
+    }
+
+    @Test
+    @DisplayName("Issue #99: PROJJSON value-with-unit prime meridian is honored")
+    void testPrimemProjJsonValueUnitObject() {
+        // PROJ's PROJJSON for EPSG:4807 carries the meridian as
+        // {"value": 2.5969213, "unit": {..."grad"...}}; the degree assumption fed the
+        // object through toDouble, which silently produced 0.0 — the meridian was
+        // lost entirely.
+        String json = "{\"type\": \"GeographicCRS\", \"name\": \"NTF (Paris)\","
+            + "\"datum\": {\"type\": \"GeodeticReferenceFrame\","
+            + "  \"name\": \"Nouvelle Triangulation Francaise (Paris)\","
+            + "  \"ellipsoid\": {\"name\": \"Clarke 1880 (IGN)\", \"semi_major_axis\": 6378249.2,"
+            + "   \"inverse_flattening\": 293.466021293627},"
+            + "  \"prime_meridian\": {\"name\": \"Paris\", \"longitude\": {\"value\": 2.5969213,"
+            + "   \"unit\": {\"type\": \"AngularUnit\", \"name\": \"grad\","
+            + "    \"conversion_factor\": 0.0157079632679489}}}},"
+            + "\"coordinate_system\": {\"subtype\": \"ellipsoidal\", \"axis\": ["
+            + " {\"name\": \"Geodetic latitude\", \"abbreviation\": \"Lat\", \"direction\": \"north\", \"unit\": \"degree\"},"
+            + " {\"name\": \"Geodetic longitude\", \"abbreviation\": \"Lon\", \"direction\": \"east\", \"unit\": \"degree\"}]},"
+            + "\"id\": {\"authority\": \"EPSG\", \"code\": 4807}}";
+        org.datasyslab.proj4sedona.core.Proj p = new org.datasyslab.proj4sedona.core.Proj(json);
+        assertEquals(2.33722917, Math.toDegrees(p.getParams().fromGreenwich), 1e-9,
+            "grads meridian object resolved, not dropped");
+
+        // Plain-number longitude stays degrees.
+        String plain = json.replace(
+            "{\"value\": 2.5969213,"
+            + "   \"unit\": {\"type\": \"AngularUnit\", \"name\": \"grad\","
+            + "    \"conversion_factor\": 0.0157079632679489}}", "2.33722917");
+        assertEquals(2.33722917,
+            Math.toDegrees(new org.datasyslab.proj4sedona.core.Proj(plain).getParams().fromGreenwich),
+            1e-9);
+    }
+
+    @Test
     @DisplayName("PROJCRS with a BASEGEODCRS base (WKT2-2015) keeps the base ellipsoid")
     void testProjcrsBaseGeodCrs2015() {
         // PROJ's WKT2:2015 output uses BASEGEODCRS (not BASEGEOGCRS) for every

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -940,7 +940,7 @@ class WktParserTest {
     }
 
     @Test
-    @DisplayName("Issue #99: PROJJSON value-with-unit prime meridian is honored")
+    @DisplayName("Issue #103: PROJJSON value-with-unit prime meridian is honored")
     void testPrimemProjJsonValueUnitObject() {
         // PROJ's PROJJSON for EPSG:4807 carries the meridian as
         // {"value": 2.5969213, "unit": {..."grad"...}}; the degree assumption fed the


### PR DESCRIPTION
Closes #99. Closes #103.

The WKT2 builder and the PROJJSON transformer assumed prime-meridian longitudes are degrees. Three concrete failure modes, all on EPSG:4807-class CRSs (NTF Paris, whose meridian is 2.5969213 grads = 2.33722917°):

| input form | old behavior | error |
|---|---|---|
| WKT2 full: `PRIMEM["Paris",2.5969213,ANGLEUNIT["grad",…]]` | read as 2.5969213° | ~0.26° / ~29 km (#99) |
| WKT2 SIMPLIFIED: `PRIMEM["Paris",2.5969213]` + CS-level `UNIT["grad",…]` | read as degrees | same misread |
| PROJJSON: `"longitude": {"value": 2.5969213, "unit": {…"grad"…}}` (PROJ's own output) | `toDouble` on the object → **0.0** | meridian lost entirely, ~174 km (#103) |

## Fix

- `ProjJsonBuilder` converts the PRIMEM value through its local `ANGLEUNIT`/`UNIT`, falling back to the CRS-level angular unit (the SIMPLIFIED form carries the value in the CS unit), then degrees — normalizing the intermediate PROJJSON to the plain-number degree form.
- `ProjJsonTransformer` accepts both the plain-number (degrees) and value-with-unit forms at both `prime_meridian` sites (top-level and datum-nested).
- Conversions are rounded at 1e-9 in degrees (as the towgs84 re-encode in #102 does), so serialization emits a clean `+pm=2.33722917` — matching PROJ's own `+pm=paris` definition exactly.

Documented divergence from proj4js/wkt-parser 1.5.5, which assumes degrees unconditionally (and NaN-poisons on the object form); same correctness-over-fidelity treatment as the rest of this series, and worth an upstream report.

## Verification

All three input forms resolve `fromGreenwich` to exactly 2.33722917°; the forward transform is self-consistent (lon 5° → 2.66277083° east of Paris); a degree-unit PRIMEM (Madrid) stays an identity conversion. 861 tests.
