### PR TITLE
Fix ellipsoid resolution: registry-wide parsing and identity-first serialization

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/constants/Datum.java
+++ b/src/main/java/org/datasyslab/proj4sedona/constants/Datum.java
@@ -174,7 +174,24 @@ public final class Datum {
         if (code == null) {
             return null;
         }
-        return DATUMS.get(code.toLowerCase());
+        Datum direct = DATUMS.get(code.toLowerCase());
+        if (direct != null) {
+            return direct;
+        }
+        // Fuzzy fallback, as proj4js's match.js applies to its datum table:
+        // whitespace, underscores, hyphens, slashes and parentheses are ignored,
+        // so +datum=s-jtsk resolves to s_jtsk.
+        String normalized = normalizeKey(code);
+        for (Map.Entry<String, Datum> entry : DATUMS.entrySet()) {
+            if (normalizeKey(entry.getKey()).equals(normalized)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeKey(String key) {
+        return key.toLowerCase().replaceAll("[\\s_\\-/()]", "");
     }
 
     /** @return The datum code (e.g., "wgs84") */

--- a/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
+++ b/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
@@ -87,6 +87,12 @@ public final class Ellipsoid {
     public static final Ellipsoid LERCH = register("lerch", 6378139, 298.257, "Lerch 1979");
     public static final Ellipsoid MPRTS = register("mprts", 6397300, 191, "Maupertius 1738");
     public static final Ellipsoid NEW_INTL = registerWithB("new_intl", 6378157.5, 6356772.2, "New International 1967");
+    /**
+     * Plessis 1817. Documented divergence from proj4js, whose table stores 6355863
+     * as the inverse flattening (a typo — it is the semi-minor axis; the derived
+     * b there is 6376521.997, a near-sphere 20.7 km off). PROJ defines plessis as
+     * a=6376523, b=6355863, which this entry matches.
+     */
     public static final Ellipsoid PLESSIS = registerWithB("plessis", 6376523, 6355863, "Plessis 1817 (France)");
     /** Krassovsky 1942 - used in Russia and Eastern Europe */
     public static final Ellipsoid KRASS = register("krass", 6378245, 298.3, "Krassovsky, 1942");
@@ -162,7 +168,24 @@ public final class Ellipsoid {
         if (code == null) {
             return null;
         }
-        return ELLIPSOIDS.get(code.toLowerCase());
+        Ellipsoid direct = ELLIPSOIDS.get(code.toLowerCase());
+        if (direct != null) {
+            return direct;
+        }
+        // Fuzzy fallback, as proj4js's match.js applies to its ellipsoid table:
+        // whitespace, underscores, hyphens, slashes and parentheses are ignored,
+        // so +ellps=bess-nam resolves to bess_nam.
+        String normalized = normalizeKey(code);
+        for (Map.Entry<String, Ellipsoid> entry : ELLIPSOIDS.entrySet()) {
+            if (normalizeKey(entry.getKey()).equals(normalized)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeKey(String key) {
+        return key.toLowerCase().replaceAll("[\\s_\\-/()]", "");
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
+++ b/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
@@ -100,6 +100,12 @@ public final class Ellipsoid {
     /** Perfect sphere - used for some projections and approximate calculations */
     public static final Ellipsoid SPHERE = registerWithB("sphere", 6370997, 6370997, "Normal Sphere (r=6370997)");
 
+    static {
+        // Legacy alias: the datum registry's carthage entry (ported from proj4js
+        // constants/Datum.js) spells Clarke 1880 mod. as "clark80".
+        ELLIPSOIDS.put("clark80", CLRK80);
+    }
+
     private final String code;
     private final double a;           // Semi-major axis (equatorial radius) in meters
     private final double b;           // Semi-minor axis (polar radius) in meters

--- a/src/main/java/org/datasyslab/proj4sedona/core/DeriveConstants.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/DeriveConstants.java
@@ -139,35 +139,29 @@ public final class DeriveConstants {
     }
 
     /**
-     * Look up ellipsoid and return its parameters.
+     * Look up ellipsoid and return its parameters as [a, b, rf].
+     *
+     * <p>Resolves against the full Ellipsoid registry, as proj4js's
+     * deriveConstants.sphere does with its complete ellipsoid table. A hardcoded
+     * 10-entry switch previously shadowed the registry here, silently defaulting
+     * the other 34 registered codes to WGS84 (issue #105) — +ellps=clrk80ign
+     * parsed 112 m off in the semi-major axis. Unknown codes still default to
+     * WGS84, matching proj4js.</p>
      */
     private static Double[] getEllipsoidValues(String key) {
-        // Common ellipsoids - [a, b, rf]
-        switch (key) {
-            case "wgs84":
-                return new Double[]{6378137.0, 6356752.314245179, 298.257223563};
-            case "grs80":
-                return new Double[]{6378137.0, 6356752.314140356, 298.257222101};
-            case "clrk66":
-                return new Double[]{6378206.4, 6356583.8, null};
-            case "clrk80":
-            case "clark80":
-                return new Double[]{6378249.145, 6356514.966398753, 293.4663};
-            case "bessel":
-                return new Double[]{6377397.155, 6356078.962818189, 299.1528128};
-            case "intl":
-                return new Double[]{6378388.0, 6356911.946127947, 297.0};
-            case "airy":
-                return new Double[]{6377563.396, 6356256.91, null};
-            case "mod_airy":
-                return new Double[]{6377340.189, 6356034.446, null};
-            case "krass":
-                return new Double[]{6378245.0, 6356863.018773047, 298.3};
-            case "sphere":
-                return new Double[]{6370997.0, 6370997.0, null};
-            default:
-                // Default to WGS84
-                return new Double[]{6378137.0, 6356752.314245179, 298.257223563};
+        org.datasyslab.proj4sedona.constants.Ellipsoid ellipsoid =
+            org.datasyslab.proj4sedona.constants.Ellipsoid.get(key);
+        if (ellipsoid == null) {
+            ellipsoid = org.datasyslab.proj4sedona.constants.Ellipsoid.WGS84;
         }
+        // A sphere entry (a == b) derives rf = a / (a - b) = Infinity in the
+        // registry; the sphere() caller expects null there, as for any
+        // b-defined ellipsoid whose rf is not meaningful.
+        double rf = ellipsoid.getRf();
+        return new Double[]{
+            ellipsoid.getA(),
+            ellipsoid.getB(),
+            rf > 0 && !Double.isInfinite(rf) ? rf : null
+        };
     }
 }

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -335,6 +335,7 @@ public class Proj {
         // Original
         p.srsCode = def.getSrsCode();
         p.datumCode = def.getDatumCode();
+        p.ellps = def.getEllps();
 
         return p;
     }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -1797,13 +1797,14 @@ public final class CRSSerializer {
             }
         }
 
-        // 2. Exact parameter match (registry b is always derived the same way the
-        //    definition's is, so equal source values compare equal).
+        // 2. Exact parameter match on the effective axes (registry b is always
+        //    derived the same way the definition's is, so equal source values
+        //    compare equal). rf is only ever used to derive b when b is absent —
+        //    an rf equality must not override a conflicting explicit b
+        //    (+a=6378137 +b=6300000 +rf=298.257223563 is not WGS84).
         for (Ellipsoid candidate : Ellipsoid.getAll().values()) {
             if (Math.abs(candidate.getA() - a) < 1e-6
-                    && (Math.abs(candidate.getB() - b) < 1e-6
-                        || (params.rf > 0 && candidate.getRf() > 0
-                            && Math.abs(candidate.getRf() - params.rf) < 1e-9))) {
+                    && Math.abs(candidate.getB() - b) < 1e-6) {
                 return candidate;
             }
         }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -1355,11 +1355,66 @@ public final class CRSSerializer {
                 // Also try with underscores replaced by spaces
                 epsg = DATUM_NAME_TO_EPSG.get(normalized.replace('_', ' '));
             }
-            if (epsg != null && matchesDefinition(params, epsg)) {
+            if (epsg != null && matchesExpectedEllipsoid(params, epsg)) {
                 return epsg;
             }
         }
         return null;
+    }
+
+    /**
+     * The ellipsoid of each geographic CRS in DATUM_NAME_TO_EPSG, as canonical
+     * (semi-major axis, inverse flattening) literals from the EPSG definitions.
+     *
+     * <p>Validating the mapped candidate against its actual reference definition
+     * (new Proj(code)) is NOT an option here: only EPSG:4326 and EPSG:4269 are
+     * built-in definitions — the rest resolve through the remote CRS provider, so
+     * toAuthority/toProjJson would perform blocking HTTP during routine
+     * serialization and silently fail offline. The canonical literals are used
+     * rather than the Ellipsoid registry because b-defined registry entries
+     * (airy) carry a rounded semi-minor axis whose derived inverse flattening is
+     * off by ~1e-5 — the rf comparison below must stay at 1e-6 to separate WGS 84
+     * from GRS 1980 (which differ by only 1.46e-6).</p>
+     */
+    private static final Map<String, double[]> EPSG_GEOGRAPHIC_ELLIPSOID = new HashMap<>();
+    static {
+        double[] wgs84 = {6378137, 298.257223563};
+        double[] grs80 = {6378137, 298.257222101};
+        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4326", wgs84);
+        for (String grs80Crs : new String[]{
+                "EPSG:4269", "EPSG:6318", "EPSG:4759", "EPSG:6783", "EPSG:4152",
+                "EPSG:4258", "EPSG:4171", "EPSG:4283", "EPSG:7844", "EPSG:6668",
+                "EPSG:4490"}) {
+            EPSG_GEOGRAPHIC_ELLIPSOID.put(grs80Crs, grs80);
+        }
+        // NAD27 / Clarke 1866 (b-defined: rf equivalent to a=6378206.4, b=6356583.8)
+        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4267", new double[]{6378206.4, 294.9786982139006});
+        // Indian 1975 / Everest 1830 (1937 Adjustment)
+        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4240", new double[]{6377276.345, 300.8017});
+        // OSGB36 / Airy 1830
+        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4277", new double[]{6377563.396, 299.3249646});
+    }
+
+    /**
+     * Validate a datum-name authority candidate against the ellipsoid its CRS is
+     * defined on, using only bundled metadata (no reference construction — see
+     * EPSG_GEOGRAPHIC_ELLIPSOID). Effective values are compared, so a stale rf
+     * that contradicts an explicit b cannot vouch for the wrong ellipsoid.
+     */
+    private static boolean matchesExpectedEllipsoid(ProjectionParams params, String epsg) {
+        double[] expected = EPSG_GEOGRAPHIC_ELLIPSOID.get(epsg);
+        if (expected == null) {
+            return false;
+        }
+        double expectedA = expected[0];
+        double expectedRf = expected[1];
+        double expectedB = expectedA * (1 - 1 / expectedRf);
+        if (Math.abs(params.a - expectedA) > 0.1
+                || Math.abs(params.b - expectedB) > 0.01) {
+            return false;
+        }
+        double effRf = effectiveRf(params);
+        return effRf <= 0 || Math.abs(effRf - expectedRf) < 1e-6;
     }
 
     /**
@@ -1479,9 +1534,12 @@ public final class CRSSerializer {
                 return false;
             }
             // rf as fine discrimination when both sides carry it: GRS 1980 and
-            // WGS 84 differ by only 0.1 mm in b, far below the axis tolerance.
-            if (params.rf != 0 && refParams.rf != 0
-                    && Math.abs(params.rf - refParams.rf) > 1e-6) {
+            // WGS 84 differ by only 0.1 mm in b, far below the axis tolerance. The
+            // effective rf is compared — a stale raw rf that contradicts an
+            // explicit b (which wins at parse time) must not vouch for a match.
+            double prf = effectiveRf(params);
+            double rrf = effectiveRf(refParams);
+            if (prf > 0 && rrf > 0 && Math.abs(prf - rrf) > 1e-6) {
                 return false;
             }
 
@@ -1837,9 +1895,13 @@ public final class CRSSerializer {
                     }
                 }
             }
+            // Exact-match epsilon: a looser tolerance here would let the stated
+            // identity swallow near-twins — +datum=WGS84 with an explicit GRS80
+            // semi-minor axis (0.105 mm away) must fall through to the exact
+            // parameter pass below and resolve as GRS80.
             if (named != null
-                    && Math.abs(named.getA() - a) < 1e-3
-                    && Math.abs(named.getB() - b) < 1e-3) {
+                    && Math.abs(named.getA() - a) < 1e-6
+                    && Math.abs(named.getB() - b) < 1e-6) {
                 return named;
             }
         }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -541,7 +541,7 @@ public final class CRSSerializer {
         String ellpsName = getEllipsoidName(params);
         sb.append("SPHEROID[\"").append(ellpsName).append("\",");
         sb.append(params.a).append(",");
-        sb.append(params.rf > 0 ? params.rf : 0);
+        sb.append(effectiveRf(params));
         sb.append("]");
 
         // TOWGS84 if present
@@ -738,7 +738,7 @@ public final class CRSSerializer {
         String ellpsName = getEllipsoidName(params);
         sb.append("ELLIPSOID[\"").append(ellpsName).append("\",");
         sb.append(params.a).append(",");
-        sb.append(params.rf > 0 ? params.rf : 0);
+        sb.append(effectiveRf(params));
         sb.append(",LENGTHUNIT[\"metre\",1]]");
 
         sb.append("]");
@@ -1035,10 +1035,16 @@ public final class CRSSerializer {
         Map<String, Object> ellipsoid = new LinkedHashMap<>();
         ellipsoid.put("name", getEllipsoidName(params));
         ellipsoid.put("semi_major_axis", params.a);
-        if (params.rf > 0) {
+        // Emit the rf literal only when it is consistent with the effective
+        // semi-minor axis; b is authoritative when both are present, so a stale
+        // conflicting rf must not be re-imported as the ellipsoid shape. The
+        // semi_minor_axis form is schema-valid and exact.
+        if (params.rf > 0 && rfConsistentWithB(params)) {
             ellipsoid.put("inverse_flattening", params.rf);
         } else if (params.b > 0) {
             ellipsoid.put("semi_minor_axis", params.b);
+        } else if (params.rf > 0) {
+            ellipsoid.put("inverse_flattening", params.rf);
         }
         return ellipsoid;
     }
@@ -1334,8 +1340,11 @@ public final class CRSSerializer {
             return null;
         }
 
-        // Try datumCode (set from PROJJSON datum.name or PROJ +datum flag)
-        if (params.datumCode != null) {
+        // Try datumCode (set from PROJJSON datum.name or PROJ +datum flag).
+        // The name alone is not enough: explicit +a/+b override the datum's
+        // ellipsoid at parse, so +datum=WGS84 +a=6378137 +b=6300000 must not be
+        // identified as EPSG:4326.
+        if (params.datumCode != null && !ellipsoidConflictsWithDatum(params)) {
             String normalized = params.datumCode.toLowerCase(Locale.ROOT).trim();
             String epsg = DATUM_NAME_TO_EPSG.get(normalized);
             if (epsg != null) {
@@ -1348,6 +1357,25 @@ public final class CRSSerializer {
             }
         }
         return null;
+    }
+
+    /**
+     * Whether the definition's effective axes contradict the ellipsoid its datum
+     * implies. Unresolvable datums or ellipses (e.g. PROJJSON datum names outside
+     * the registry) do not count as conflicts — those definitions carry their own
+     * explicit ellipsoid, which phase-3 parameter matching validates.
+     */
+    private static boolean ellipsoidConflictsWithDatum(ProjectionParams params) {
+        Datum datum = Datum.get(params.datumCode);
+        if (datum == null || datum.getEllipse() == null) {
+            return false;
+        }
+        Ellipsoid ellipse = Ellipsoid.get(datum.getEllipse());
+        if (ellipse == null) {
+            return false;
+        }
+        return Math.abs(params.a - ellipse.getA()) > 0.1
+            || Math.abs(params.b - ellipse.getB()) > 0.01;
     }
 
     /**
@@ -1459,13 +1487,17 @@ public final class CRSSerializer {
                 return false;
             }
 
-            // Check inverse flattening (distinguishes GRS 1980 from WGS 84)
-            if (params.rf != 0 && refParams.rf != 0) {
-                if (Math.abs(params.rf - refParams.rf) > 1e-6) {
-                    return false;
-                }
-            } else if (Math.abs(params.b - refParams.b) > 0.01) {
-                // Fall back to semi-minor axis comparison
+            // Check the effective semi-minor axis unconditionally: b is
+            // authoritative when both b and rf are present, so a matching rf must
+            // not accept a conflicting ellipsoid shape (+datum=WGS84 +a=... +b=6300000
+            // +rf=298.257223563 is not EPSG:4326).
+            if (Math.abs(params.b - refParams.b) > 0.01) {
+                return false;
+            }
+            // rf as fine discrimination when both sides carry it: GRS 1980 and
+            // WGS 84 differ by only 0.1 mm in b, far below the axis tolerance.
+            if (params.rf != 0 && refParams.rf != 0
+                    && Math.abs(params.rf - refParams.rf) > 1e-6) {
                 return false;
             }
 
@@ -1756,6 +1788,37 @@ public final class CRSSerializer {
     private static String getEllipsoidName(ProjectionParams params) {
         Ellipsoid resolved = resolveEllipsoid(params);
         return resolved != null ? resolved.getEllipseName() : "Custom";
+    }
+
+    /**
+     * Whether the stored inverse flattening agrees with the effective semi-minor
+     * axis. b wins over rf at parse time (here and in proj4js), so a definition can
+     * carry a stale rf that describes a different ellipsoid than its axes do.
+     */
+    private static boolean rfConsistentWithB(ProjectionParams params) {
+        if (params.b <= 0 || params.rf <= 0) {
+            return true;
+        }
+        return Math.abs(params.a * (1 - 1 / params.rf) - params.b) < 1e-6;
+    }
+
+    /**
+     * The inverse flattening implied by the effective axes, for the WKT SPHEROID/
+     * ELLIPSOID nodes (which cannot carry a semi-minor axis): the stored rf when
+     * consistent with b (keeps the clean literal), the value derived from a and b
+     * when they conflict, and 0 for spheres, per WKT convention.
+     */
+    private static double effectiveRf(ProjectionParams params) {
+        if (params.b > 0 && !rfConsistentWithB(params)) {
+            return params.a == params.b ? 0 : params.a / (params.a - params.b);
+        }
+        if (params.rf > 0) {
+            return params.rf;
+        }
+        if (params.b > 0 && params.a != params.b) {
+            return params.a / (params.a - params.b);
+        }
+        return 0;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -1341,41 +1341,25 @@ public final class CRSSerializer {
         }
 
         // Try datumCode (set from PROJJSON datum.name or PROJ +datum flag).
-        // The name alone is not enough: explicit +a/+b override the datum's
-        // ellipsoid at parse, so +datum=WGS84 +a=6378137 +b=6300000 must not be
-        // identified as EPSG:4326.
-        if (params.datumCode != null && !ellipsoidConflictsWithDatum(params)) {
+        // The name alone is not enough: explicit +a/+b (or +ellps=) override the
+        // datum's ellipsoid at parse, so +datum=WGS84 +a=6378137 +b=6300000 must
+        // not be identified as EPSG:4326, nor +datum=WGS84 +ellps=GRS80. The
+        // mapped candidate is validated against its actual reference definition
+        // (effective axes, rf discrimination, datum and projection parameters) —
+        // a registry-ellipse spot check cannot do this, since most of the mapped
+        // datum names (ETRS89, GDA2020, JGD2011, ...) are not registry datums.
+        if (params.datumCode != null) {
             String normalized = params.datumCode.toLowerCase(Locale.ROOT).trim();
             String epsg = DATUM_NAME_TO_EPSG.get(normalized);
-            if (epsg != null) {
-                return epsg;
+            if (epsg == null) {
+                // Also try with underscores replaced by spaces
+                epsg = DATUM_NAME_TO_EPSG.get(normalized.replace('_', ' '));
             }
-            // Also try with underscores replaced by spaces
-            epsg = DATUM_NAME_TO_EPSG.get(normalized.replace('_', ' '));
-            if (epsg != null) {
+            if (epsg != null && matchesDefinition(params, epsg)) {
                 return epsg;
             }
         }
         return null;
-    }
-
-    /**
-     * Whether the definition's effective axes contradict the ellipsoid its datum
-     * implies. Unresolvable datums or ellipses (e.g. PROJJSON datum names outside
-     * the registry) do not count as conflicts — those definitions carry their own
-     * explicit ellipsoid, which phase-3 parameter matching validates.
-     */
-    private static boolean ellipsoidConflictsWithDatum(ProjectionParams params) {
-        Datum datum = Datum.get(params.datumCode);
-        if (datum == null || datum.getEllipse() == null) {
-            return false;
-        }
-        Ellipsoid ellipse = Ellipsoid.get(datum.getEllipse());
-        if (ellipse == null) {
-            return false;
-        }
-        return Math.abs(params.a - ellipse.getA()) > 0.1
-            || Math.abs(params.b - ellipse.getB()) > 0.01;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -431,11 +431,10 @@ public final class CRSSerializer {
     }
 
     private static void appendEllipsoidParams(StringBuilder sb, ProjectionParams params) {
-        // Try to find matching ellipsoid by parameters
-        String ellpsCode = findEllipsoidCode(params.a, params.b, params.rf);
-        
-        if (ellpsCode != null) {
-            sb.append(" +ellps=").append(ellpsCode);
+        Ellipsoid resolved = resolveEllipsoid(params);
+
+        if (resolved != null) {
+            sb.append(" +ellps=").append(resolved.getCode());
         } else if (params.a > 0) {
             // Use explicit a/b or a/rf
             sb.append(" +a=").append(params.a);
@@ -1755,27 +1754,72 @@ public final class CRSSerializer {
     }
 
     private static String getEllipsoidName(ProjectionParams params) {
-        String code = findEllipsoidCode(params.a, params.b, params.rf);
-        if (code != null) {
-            Ellipsoid ellps = Ellipsoid.get(code);
-            if (ellps != null) {
-                return ellps.getEllipseName();
-            }
-            return code;
-        }
-        return "Custom";
+        Ellipsoid resolved = resolveEllipsoid(params);
+        return resolved != null ? resolved.getEllipseName() : "Custom";
     }
 
-    private static String findEllipsoidCode(double a, double b, double rf) {
-        // Check all registered ellipsoids (LinkedHashMap ensures deterministic order)
-        for (Map.Entry<String, Ellipsoid> entry : Ellipsoid.getAll().entrySet()) {
-            Ellipsoid ellps = entry.getValue();
-            if (Math.abs(ellps.getA() - a) < 0.1 && 
-                (Math.abs(ellps.getB() - b) < 0.1 || Math.abs(ellps.getRf() - rf) < 1e-6)) {
-                return ellps.getCode();
+    /**
+     * Resolve the definition's ellipsoid to a registry entry (issue #101).
+     *
+     * <p>Preference order:</p>
+     * <ol>
+     *   <li>The ellipsoid the definition itself names (the +ellps= code or the
+     *       WKT/PROJJSON ellipsoid name), when its parameters match the
+     *       definition's — this keeps the stated identity for twins with identical
+     *       parameters (NWL9D/WGS66) and rejects Proj's "wgs84" placeholder on
+     *       custom-parameter definitions.</li>
+     *   <li>An exact parameter match over the registry.</li>
+     *   <li>The closest entry within the legacy tolerance (0.1 m on both axes).
+     *       First-match-in-registry-order is what shadowed WGS84 behind MERIT,
+     *       whose semi-minor axis differs by only 1.6 cm.</li>
+     * </ol>
+     */
+    private static Ellipsoid resolveEllipsoid(ProjectionParams params) {
+        double a = params.a;
+        double b = params.b > 0 ? params.b
+            : (params.rf > 0 ? a * (1 - 1 / params.rf) : a);
+
+        // 1. The definition's own ellipsoid, validated against its parameters.
+        if (params.ellps != null) {
+            Ellipsoid named = Ellipsoid.get(params.ellps);
+            if (named == null) {
+                for (Ellipsoid candidate : Ellipsoid.getAll().values()) {
+                    if (params.ellps.equalsIgnoreCase(candidate.getEllipseName())) {
+                        named = candidate;
+                        break;
+                    }
+                }
+            }
+            if (named != null
+                    && Math.abs(named.getA() - a) < 1e-3
+                    && Math.abs(named.getB() - b) < 1e-3) {
+                return named;
             }
         }
-        return null;
+
+        // 2. Exact parameter match (registry b is always derived the same way the
+        //    definition's is, so equal source values compare equal).
+        for (Ellipsoid candidate : Ellipsoid.getAll().values()) {
+            if (Math.abs(candidate.getA() - a) < 1e-6
+                    && (Math.abs(candidate.getB() - b) < 1e-6
+                        || (params.rf > 0 && candidate.getRf() > 0
+                            && Math.abs(candidate.getRf() - params.rf) < 1e-9))) {
+                return candidate;
+            }
+        }
+
+        // 3. Closest within the legacy tolerance.
+        Ellipsoid best = null;
+        double bestScore = Double.MAX_VALUE;
+        for (Ellipsoid candidate : Ellipsoid.getAll().values()) {
+            double da = Math.abs(candidate.getA() - a);
+            double db = Math.abs(candidate.getB() - b);
+            if (da < 0.1 && db < 0.1 && da + db < bestScore) {
+                best = candidate;
+                bestScore = da + db;
+            }
+        }
+        return best;
     }
 
     private static String getWktMethodName(String projName) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -1370,16 +1370,23 @@ public final class CRSSerializer {
      * (new Proj(code)) is NOT an option here: only EPSG:4326 and EPSG:4269 are
      * built-in definitions — the rest resolve through the remote CRS provider, so
      * toAuthority/toProjJson would perform blocking HTTP during routine
-     * serialization and silently fail offline. The canonical literals are used
-     * rather than the Ellipsoid registry because b-defined registry entries
-     * (airy) carry a rounded semi-minor axis whose derived inverse flattening is
-     * off by ~1e-5 — the rf comparison below must stay at 1e-6 to separate WGS 84
-     * from GRS 1980 (which differ by only 1.46e-6).</p>
+     * serialization and silently fail offline.</p>
+     *
+     * <p>Each row carries its own inverse-flattening tolerance. Strict 1e-6 is
+     * needed only where a near-twin exists: WGS 84 and GRS 1980 share the
+     * semi-major axis and differ by 1.46e-6 in rf (0.1 mm in b). The unambiguous
+     * families (clrk66, evrst30, airy) use 1e-4 — an implied b window of ~7 mm,
+     * still inside the 0.01 m axis gate — because definitions reach this check
+     * from two sources whose rf disagree at the ~1e-5 level: documents carry the
+     * EPSG-canonical value, while +datum=-built definitions inherit the registry's
+     * proj4js-faithful rounded semi-minor axis (airy b=6356256.91 derives
+     * rf=299.324975 vs canonical 299.3249646).</p>
      */
     private static final Map<String, double[]> EPSG_GEOGRAPHIC_ELLIPSOID = new HashMap<>();
     static {
-        double[] wgs84 = {6378137, 298.257223563};
-        double[] grs80 = {6378137, 298.257222101};
+        // {semi-major axis, inverse flattening, rf tolerance}
+        double[] wgs84 = {6378137, 298.257223563, 1e-6};
+        double[] grs80 = {6378137, 298.257222101, 1e-6};
         EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4326", wgs84);
         for (String grs80Crs : new String[]{
                 "EPSG:4269", "EPSG:6318", "EPSG:4759", "EPSG:6783", "EPSG:4152",
@@ -1387,12 +1394,15 @@ public final class CRSSerializer {
                 "EPSG:4490"}) {
             EPSG_GEOGRAPHIC_ELLIPSOID.put(grs80Crs, grs80);
         }
-        // NAD27 / Clarke 1866 (b-defined: rf equivalent to a=6378206.4, b=6356583.8)
-        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4267", new double[]{6378206.4, 294.9786982139006});
+        // NAD27 / Clarke 1866
+        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4267",
+            new double[]{6378206.4, 294.9786982139006, 1e-4});
         // Indian 1975 / Everest 1830 (1937 Adjustment)
-        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4240", new double[]{6377276.345, 300.8017});
+        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4240",
+            new double[]{6377276.345, 300.8017, 1e-4});
         // OSGB36 / Airy 1830
-        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4277", new double[]{6377563.396, 299.3249646});
+        EPSG_GEOGRAPHIC_ELLIPSOID.put("EPSG:4277",
+            new double[]{6377563.396, 299.3249646, 1e-4});
     }
 
     /**
@@ -1408,13 +1418,14 @@ public final class CRSSerializer {
         }
         double expectedA = expected[0];
         double expectedRf = expected[1];
+        double rfTolerance = expected[2];
         double expectedB = expectedA * (1 - 1 / expectedRf);
         if (Math.abs(params.a - expectedA) > 0.1
                 || Math.abs(params.b - expectedB) > 0.01) {
             return false;
         }
         double effRf = effectiveRf(params);
-        return effRf <= 0 || Math.abs(effRf - expectedRf) < 1e-6;
+        return effRf <= 0 || Math.abs(effRf - expectedRf) < rfTolerance;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -186,6 +186,13 @@ public class ProjectionParams {
     /** Datum code from definition (e.g., "WGS84") */
     public String datumCode;
 
+    /**
+     * The ellipsoid as stated by the definition: the +ellps= code, or the WKT/PROJJSON
+     * ellipsoid name. May be the "wgs84" placeholder Proj assigns when no ellipsoid
+     * was given, so consumers must validate it against a/b before trusting it.
+     */
+    public String ellps;
+
     // ==================== Accessor Methods ====================
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1382,6 +1382,55 @@ class CRSSerializerTest {
         assertEquals(5093857.024237, p.y, 1e-4);
     }
 
+    @Test
+    @DisplayName("Issue #101: every registered +ellps code round-trips through toProjString")
+    void testAllEllipsoidCodesRoundTrip() {
+        // First-tolerance-match resolution shadowed WGS84 behind MERIT (semi-minor
+        // axes 1.6 cm apart) and could never round-trip parameter-identical twins
+        // (NWL9D/WGS66); the definition's own code now wins when its parameters
+        // match, then exact parameter match, then closest-in-tolerance.
+        for (org.datasyslab.proj4sedona.constants.Ellipsoid e :
+                org.datasyslab.proj4sedona.constants.Ellipsoid.getAll().values()) {
+            String out = CRSSerializer.toProjString(
+                new Proj("+proj=longlat +ellps=" + e.getCode() + " +no_defs"));
+            assertTrue(out.contains("+ellps=" + e.getCode()), e.getCode() + " -> " + out);
+        }
+    }
+
+    @Test
+    @DisplayName("Issue #101: WGS84 is no longer shadowed by MERIT")
+    void testWgs84NotShadowedByMerit() {
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=longlat +datum=WGS84 +no_defs"))
+            .contains("+ellps=WGS84"));
+        assertTrue(CRSSerializer.toProjString(new Proj("EPSG:4326"))
+            .contains("+ellps=WGS84"));
+        assertTrue(CRSSerializer.toProjString(new Proj("+proj=utm +zone=10 +datum=NAD83 +no_defs"))
+            .contains("+ellps=GRS80"));
+
+        // The WKT ellipsoid *name* resolves through the registry too.
+        String wkt = "GEOGCRS[\"WGS 84\",DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]]],"
+            + "CS[ellipsoidal,2],AXIS[\"lat\",north],AXIS[\"lon\",east],"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",4326]]";
+        assertTrue(CRSSerializer.toProjString(new Proj(wkt)).contains("+ellps=WGS84"));
+    }
+
+    @Test
+    @DisplayName("Issue #101: custom parameters are not snapped to a registry ellipsoid")
+    void testCustomParametersStayExplicit() {
+        // Proj assigns the "wgs84" ellps placeholder when none is given; the resolver
+        // must reject it when the actual parameters differ.
+        String custom = CRSSerializer.toProjString(
+            new Proj("+proj=longlat +a=6378137 +b=6356000 +no_defs"));
+        assertFalse(custom.contains("+ellps="), custom);
+        assertTrue(custom.contains("+a=6378137") && custom.contains("+b=6356000"), custom);
+
+        String sphere = CRSSerializer.toProjString(
+            new Proj("+proj=longlat +R=6371000 +no_defs"));
+        assertFalse(sphere.contains("+ellps="), sphere);
+        assertTrue(sphere.contains("+a=6371000") && sphere.contains("+b=6371000"), sphere);
+    }
+
     // ========== Datum token normalization (issue #98) ==========
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1532,6 +1532,19 @@ class CRSSerializerTest {
                 assertEquals(c[3], auth[1], (String) c[0]);
             }
 
+            // Registry-sourced definitions identify too: +datum=OSGB36 inherits the
+            // proj4js-faithful rounded airy semi-minor axis (b=6356256.91), whose
+            // derived rf sits ~1e-5 from the EPSG-canonical literal — the per-row
+            // tolerance must accommodate both sources.
+            String[] osgb = CRSSerializer.toAuthority(new Proj(
+                "+proj=longlat +datum=OSGB36 +no_defs").getParams());
+            assertNotNull(osgb, "registry-sourced OSGB36 identifies");
+            assertEquals("4277", osgb[1]);
+            String[] nad27 = CRSSerializer.toAuthority(new Proj(
+                "+proj=longlat +datum=NAD27 +no_defs").getParams());
+            assertNotNull(nad27, "registry-sourced NAD27 identifies");
+            assertEquals("4267", nad27[1]);
+
             // The conflict rejections hold offline too.
             assertNull(CRSSerializer.toAuthority(new Proj(
                 "+proj=longlat +datum=ETRS89 +a=6378137 +b=6300000 +no_defs").getParams()));

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1489,6 +1489,86 @@ class CRSSerializerTest {
         assertEquals("4258", pos[1]);
     }
 
+    private static String geographicDoc(String datumName, double a, double rf) {
+        return "{\"type\": \"GeographicCRS\", \"name\": \"" + datumName + "\","
+            + "\"datum\": {\"type\": \"GeodeticReferenceFrame\", \"name\": \"" + datumName + "\","
+            + " \"ellipsoid\": {\"name\": \"e\", \"semi_major_axis\": " + a + ","
+            + "  \"inverse_flattening\": " + rf + "}},"
+            + "\"coordinate_system\": {\"subtype\": \"ellipsoidal\", \"axis\": ["
+            + " {\"name\": \"Geodetic latitude\", \"abbreviation\": \"Lat\", \"direction\": \"north\", \"unit\": \"degree\"},"
+            + " {\"name\": \"Geodetic longitude\", \"abbreviation\": \"Lon\", \"direction\": \"east\", \"unit\": \"degree\"}]}}";
+    }
+
+    @Test
+    @DisplayName("Datum-name authority identification is fully offline")
+    void testDatumNameAuthorityOffline() {
+        // Phase-2 validation previously constructed the mapped EPSG reference via
+        // new Proj(code); only EPSG:4326 and EPSG:4269 are built-in definitions, so
+        // 13 of the 15 mapped codes triggered blocking HTTP through the remote CRS
+        // provider inside toAuthority/toProjJson — and failed silently offline.
+        // Validation now uses bundled ellipsoid metadata; this test runs with the
+        // remote provider removed to guard against reintroducing the construction.
+        org.datasyslab.proj4sedona.defs.Defs.globals();
+        org.datasyslab.proj4sedona.defs.Defs.removeProvider("spatialreference.org");
+        try {
+            // One name per mapped ellipsoid family, plus the previously failing
+            // spellings (CGCS2000 rejected via the reference's "China 2000" datum
+            // name; ETRS89/GDA2020/JGD2011 unvalidatable in the datum registry).
+            Object[][] sweep = {
+                {"World Geodetic System 1984", 6378137.0, 298.257223563, "4326"},
+                {"NAD83 (National Spatial Reference System 2011)", 6378137.0, 298.257222101, "6318"},
+                {"European Terrestrial Reference System 1989", 6378137.0, 298.257222101, "4258"},
+                {"Geocentric Datum of Australia 2020", 6378137.0, 298.257222101, "7844"},
+                {"Japanese Geodetic Datum 2011", 6378137.0, 298.257222101, "6668"},
+                {"China Geodetic Coordinate System 2000", 6378137.0, 298.257222101, "4490"},
+                {"North American Datum 1927", 6378206.4, 294.9786982139006, "4267"},
+                {"Indian 1975", 6377276.345, 300.8017, "4240"},
+                {"Ordnance Survey of Great Britain 1936", 6377563.396, 299.3249646, "4277"},
+            };
+            for (Object[] c : sweep) {
+                String doc = geographicDoc((String) c[0], (Double) c[1], (Double) c[2]);
+                String[] auth = CRSSerializer.toAuthority(new Proj(doc).getParams());
+                assertNotNull(auth, c[0] + " identifies offline");
+                assertEquals(c[3], auth[1], (String) c[0]);
+            }
+
+            // The conflict rejections hold offline too.
+            assertNull(CRSSerializer.toAuthority(new Proj(
+                "+proj=longlat +datum=ETRS89 +a=6378137 +b=6300000 +no_defs").getParams()));
+        } finally {
+            org.datasyslab.proj4sedona.defs.Defs.registerProvider(
+                org.datasyslab.proj4sedona.defs.UrlCRSProvider.spatialReference(), 101);
+        }
+    }
+
+    @Test
+    @DisplayName("A stale matching rf cannot vouch for the wrong authority")
+    void testStaleRfCannotVouchAuthority() {
+        // Effective b is GRS80's, the stale raw rf is WGS84's: the rf discrimination
+        // previously trusted the raw value and stamped EPSG:4326 onto an effectively
+        // GRS80 ellipsoid. The effective rf (derived from the authoritative axes)
+        // is compared instead.
+        Proj p = new Proj("+proj=longlat +datum=WGS84 +a=6378137 "
+            + "+b=6356752.314140356 +rf=298.257223563 +no_defs");
+        assertNull(CRSSerializer.toAuthority(p.getParams()),
+            "effectively-GRS80 ellipsoid must not identify as EPSG:4326");
+        assertFalse(CRSSerializer.toProjJson(p).contains("4326"));
+    }
+
+    @Test
+    @DisplayName("The stated ellipsoid identity does not swallow near-twins")
+    void testStatedIdentityDoesNotSwallowNearTwins() {
+        // +datum=WGS84 states the WGS84 identity, but the explicit semi-minor axis
+        // is GRS80's (0.105 mm away). The identity validation previously used a 1 mm
+        // tolerance, serializing +ellps=WGS84 and changing b on re-parse; the
+        // exact-parameter pass now wins and keeps the axes bit-identical.
+        Proj p = new Proj("+proj=longlat +datum=WGS84 +a=6378137 +b=6356752.314140356 +no_defs");
+        String out = CRSSerializer.toProjString(p);
+        assertTrue(out.contains("+ellps=GRS80"), out);
+        assertEquals(6356752.314140356, new Proj(out).getParams().b, 0,
+            "semi-minor axis is preserved exactly");
+    }
+
     @Test
     @DisplayName("plessis matches PROJ, not proj4js's rf typo")
     void testPlessisMatchesProj() {

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1378,8 +1378,52 @@ class CRSSerializerTest {
             .proj4("+proj=longlat +ellps=clrk80ign +no_defs",
                    "+proj=utm +zone=31 +ellps=clrk80ign +no_defs")
             .forward(new Point(2.5, 46.0));
-        assertEquals(461282.081634, p.x, 1e-4);
-        assertEquals(5093857.024237, p.y, 1e-4);
+        assertEquals(461282.081634, p.x, 0.01);
+        assertEquals(5093857.024237, p.y, 0.01);
+    }
+
+    @Test
+    @DisplayName("Ellipsoid codes resolve with match.js normalization (separators ignored)")
+    void testEllipsoidCodeNormalization() {
+        // proj4js resolves registry keys through match.js, which ignores whitespace,
+        // underscores, hyphens, slashes and parentheses — +ellps=bess-nam is
+        // Bessel Namibia upstream, and previously parsed here as WGS84 silently.
+        Proj p = new Proj("+proj=longlat +ellps=bess-nam +no_defs");
+        assertEquals(6377483.865, p.getParams().a, 1e-6, "bess-nam resolves to bess_nam");
+
+        // The legacy clark80 alias spelling resolves to clrk80 (carthage's ellipse).
+        assertEquals(6378249.145,
+            new Proj("+proj=longlat +ellps=clark80 +no_defs").getParams().a, 1e-6);
+
+        // Datum codes get the same normalization (+datum=s-jtsk -> s_jtsk).
+        assertEquals("bessel",
+            org.datasyslab.proj4sedona.constants.Datum.get("s-jtsk").getEllipse());
+    }
+
+    @Test
+    @DisplayName("A matching rf must not override a conflicting explicit b")
+    void testRfDoesNotOverrideConflictingB() {
+        // b wins over rf when both are given (here and in proj4js); the resolver
+        // previously accepted the rf equality and emitted +ellps=WGS84, silently
+        // moving the effective semi-minor axis by 56.8 km on re-parse.
+        Proj p = new Proj("+proj=longlat +a=6378137 +b=6300000 +rf=298.257223563 +no_defs");
+        assertEquals(6300000.0, p.getParams().b, 0, "explicit b is the effective b");
+        String out = CRSSerializer.toProjString(p);
+        assertFalse(out.contains("+ellps="), out);
+        assertTrue(out.contains("+a=6378137") && out.contains("+b=6300000"), out);
+        assertEquals(6300000.0, new Proj(out).getParams().b, 0,
+            "effective semi-minor axis survives the round-trip");
+    }
+
+    @Test
+    @DisplayName("plessis matches PROJ, not proj4js's rf typo")
+    void testPlessisMatchesProj() {
+        // Documented divergence: proj4js stores plessis's 6355863 as the inverse
+        // flattening (deriving the near-sphere b=6376521.997, 20.7 km off); PROJ
+        // defines a=6376523, b=6355863, which this registry matches.
+        Proj p = new Proj("+proj=longlat +ellps=plessis +no_defs");
+        assertEquals(6376523.0, p.getParams().a, 1e-6);
+        assertEquals(6355863.0, p.getParams().b, 1e-6, "b per PROJ's table");
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1354,6 +1354,34 @@ class CRSSerializerTest {
         assertTrue(projString.contains("+proj=eck6"), "re-export uses short code: " + projString);
     }
 
+    // ========== Ellipsoid resolution (issues #101, #105) ==========
+
+    @Test
+    @DisplayName("Issue #105: every registered +ellps code parses with its own axes")
+    void testAllEllipsoidCodesParse() {
+        // A hardcoded 10-entry switch shadowed the 45-entry registry, silently
+        // defaulting the rest to WGS84 (+ellps=clrk80ign parsed 112 m off in a).
+        for (org.datasyslab.proj4sedona.constants.Ellipsoid e :
+                org.datasyslab.proj4sedona.constants.Ellipsoid.getAll().values()) {
+            Proj p = new Proj("+proj=longlat +ellps=" + e.getCode() + " +no_defs");
+            assertEquals(e.getA(), p.getParams().a, 1e-6, e.getCode() + " semi-major");
+            assertEquals(e.getB(), p.getParams().b, 1e-6, e.getCode() + " semi-minor");
+        }
+    }
+
+    @Test
+    @DisplayName("Issue #105: parsed clrk80ign transforms match pyproj")
+    void testClrk80ignTransform() {
+        // Reference from pyproj 3.7.2/PROJ 9.5.1; with the WGS84 fallback this was
+        // ~100 m off.
+        Point p = org.datasyslab.proj4sedona.Proj4
+            .proj4("+proj=longlat +ellps=clrk80ign +no_defs",
+                   "+proj=utm +zone=31 +ellps=clrk80ign +no_defs")
+            .forward(new Point(2.5, 46.0));
+        assertEquals(461282.081634, p.x, 1e-4);
+        assertEquals(5093857.024237, p.y, 1e-4);
+    }
+
     // ========== Datum token normalization (issue #98) ==========
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1416,6 +1416,46 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("A stale conflicting rf does not survive WKT or PROJJSON either")
+    void testStaleRfAllFormats() {
+        // b is authoritative when both b and rf are present; the WKT writers and the
+        // PROJJSON exporter emitted the stale rf literal, so re-import changed the
+        // effective semi-minor axis by 56.8 km even though the proj-string
+        // round-trip was already fixed.
+        Proj p = new Proj("+proj=longlat +a=6378137 +b=6300000 +rf=298.257223563 +no_defs");
+        assertEquals(6300000.0, new Proj(CRSSerializer.toWkt1(p)).getParams().b, 1e-6, "WKT1");
+        assertEquals(6300000.0, new Proj(CRSSerializer.toWkt2(p)).getParams().b, 1e-6, "WKT2");
+        assertEquals(6300000.0, new Proj(CRSSerializer.toProjJson(p)).getParams().b, 1e-6, "PROJJSON");
+        assertEquals(6300000.0, new Proj(CRSSerializer.toProjString(p)).getParams().b, 1e-6, "proj string");
+
+        // A consistent rf keeps its clean literal in WKT.
+        assertTrue(CRSSerializer.toWkt2(new Proj("+proj=longlat +ellps=WGS84 +no_defs"))
+            .contains("298.257223563"));
+    }
+
+    @Test
+    @DisplayName("Authority matching validates the effective semi-minor axis")
+    void testAuthorityRejectsConflictingEllipsoid() {
+        // The datum name and rf both said WGS84, but the explicit b overrides the
+        // ellipsoid at parse — toAuthority returned EPSG:4326 and the PROJJSON
+        // export carried the 4326 id for a non-WGS84 ellipsoid.
+        Proj q = new Proj("+proj=longlat +datum=WGS84 +a=6378137 +b=6300000 +rf=298.257223563 +no_defs");
+        assertNull(CRSSerializer.toAuthority(q.getParams()), "conflicting b must not identify");
+        assertFalse(CRSSerializer.toProjJson(q).contains("4326"), "no EPSG:4326 id");
+
+        // Genuine WGS84 still identifies, and the rf discrimination still separates
+        // GRS 1980 (b only 0.1 mm away) from WGS 84.
+        String[] wgs = CRSSerializer.toAuthority(
+            new Proj("+proj=longlat +datum=WGS84 +no_defs").getParams());
+        assertNotNull(wgs);
+        assertEquals("4326", wgs[1]);
+        String[] grs80 = CRSSerializer.toAuthority(
+            new Proj("+proj=longlat +ellps=GRS80 +no_defs").getParams());
+        assertFalse(grs80 != null && "4326".equals(grs80[1]),
+            "GRS80 must not identify as EPSG:4326");
+    }
+
+    @Test
     @DisplayName("plessis matches PROJ, not proj4js's rf typo")
     void testPlessisMatchesProj() {
         // Documented divergence: proj4js stores plessis's 6355863 as the inverse

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1456,6 +1456,40 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("Datum-name authority candidates are validated against their reference")
+    void testDatumNameCandidateValidated() {
+        // The datum-name shortcut previously validated the ellipsoid only when the
+        // datum resolved in the registry — 15 of the 27 mapped names (ETRS89,
+        // GDA2020, JGD2011, CGCS2000, ...) do not, so a conflicting definition was
+        // stamped with the mapped EPSG id unchecked. Candidates now validate through
+        // matchesDefinition (effective axes, rf, datum, projection parameters).
+        Proj conflict = new Proj("+proj=longlat +datum=ETRS89 +a=6378137 +b=6300000 +no_defs");
+        assertNull(CRSSerializer.toAuthority(conflict.getParams()),
+            "conflicting axes must not identify as EPSG:4258");
+
+        // rf discrimination now applies to the shortcut too: GRS80's semi-minor axis
+        // is only 0.1 mm from WGS84's, so the coarse axis check alone cannot see it.
+        Proj mixed = new Proj("+proj=longlat +datum=WGS84 +ellps=GRS80 +no_defs");
+        String[] auth = CRSSerializer.toAuthority(mixed.getParams());
+        assertFalse(auth != null && "4326".equals(auth[1]),
+            "a GRS80 ellipsoid must not identify as EPSG:4326");
+
+        // Positive control: the realistic carrier of these names — a document with
+        // the datum name and its proper ellipsoid — still identifies.
+        String etrs89 = "{\"type\": \"GeographicCRS\", \"name\": \"ETRS89\","
+            + "\"datum\": {\"type\": \"GeodeticReferenceFrame\","
+            + " \"name\": \"European Terrestrial Reference System 1989\","
+            + " \"ellipsoid\": {\"name\": \"GRS 1980\", \"semi_major_axis\": 6378137,"
+            + "  \"inverse_flattening\": 298.257222101}},"
+            + "\"coordinate_system\": {\"subtype\": \"ellipsoidal\", \"axis\": ["
+            + " {\"name\": \"Geodetic latitude\", \"abbreviation\": \"Lat\", \"direction\": \"north\", \"unit\": \"degree\"},"
+            + " {\"name\": \"Geodetic longitude\", \"abbreviation\": \"Lon\", \"direction\": \"east\", \"unit\": \"degree\"}]}}";
+        String[] pos = CRSSerializer.toAuthority(new Proj(etrs89).getParams());
+        assertNotNull(pos, "genuine ETRS89 with GRS80 still identifies");
+        assertEquals("4258", pos[1]);
+    }
+
+    @Test
     @DisplayName("plessis matches PROJ, not proj4js's rf typo")
     void testPlessisMatchesProj() {
         // Documented divergence: proj4js stores plessis's 6355863 as the inverse


### PR DESCRIPTION
Closes #101. Closes #105.

Two stacked ellipsoid-resolution bugs, one commit each. The second was found by the exhaustive round-trip test written for the first: the serializer echoed `+ellps=WGS84` for 34 codes because the *parsed parameters* were already WGS84's.

## 1. Parse: `+ellps=` codes resolved against a hardcoded 10-entry switch (#105)

`DeriveConstants` never consulted the 45-entry `Ellipsoid` registry (a faithful port of proj4js `constants/Ellipsoid.js`) — everything outside {wgs84, grs80, clrk66, clrk80, bessel, intl, airy, mod_airy, krass, sphere} silently defaulted to WGS84, producing wrong transforms: `+ellps=clrk80ign` parsed 112 m off in the semi-major axis, `+ellps=mprts` ~19 km. proj4js resolves through the full table (`deriveConstants.sphere` → `match`), so this was a port gap.

Now resolved through `Ellipsoid.get` (the switch's legacy `clark80` spelling preserved as a registry alias for the carthage datum; the sphere entry's derived `rf = a/(a−b) = Infinity` maps to null as before). Verified against pyproj 3.7.2/PROJ 9.5.1: a UTM transform on clrk80ign now matches to the sixth decimal, and every registered code parses with its own axes.

## 2. Serialize: first-tolerance-match shadowing (#101)

`findEllipsoidCode` returned the first registry entry within 0.1 m, in registry order. MERIT precedes WGS84 with a semi-minor axis only 1.6 cm away, so every WGS84-based CRS serialized as `+ellps=MERIT`; parameter-identical twins (NWL9D/WGS66) could never round-trip at all.

The definition's stated ellipsoid (the `+ellps=` code or WKT/PROJJSON ellipsoid name) now survives into `ProjectionParams`, and resolution prefers, in order:
1. the stated ellipsoid when its parameters match the definition's (keeps identity for parameter twins; rejects the `wgs84` placeholder `Proj` assigns to custom-parameter definitions);
2. an exact parameter match;
3. the closest entry within the legacy tolerance.

## Tests (866 total)

Two exhaustive matrices — every registered code parses with its own axes, and every registered code round-trips through `toProjString` — plus the pyproj-referenced clrk80ign transform, the MERIT-shadowing repros (proj string, EPSG code, WKT name path, NAD83/GRS80), and custom/sphere definitions staying explicit `+a/+b`.
