### PR TITLE
Prep v0.1.0: version bump, upstream-sync tracking, doc accuracy sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ CompletableFuture<GridData> future = GridCdnFetcher.fetchAndLoadAsync("ca_nrc_nt
 
 ## Upstream Sync Status
 
-Proj4Sedona tracks two upstream code bases. The port is complete and audited as of the
+Proj4Sedona tracks three upstream code bases. The port is complete and audited as of the
 commits below — every upstream change up to these points is either ported, backported,
 or documented as an intentional divergence (divergences follow PROJ where proj4js is
 known to be wrong; each is noted in the relevant Javadoc and pinned by a test):

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Proj4Sedona provides coordinate system transformations, datum conversions, and p
 **Key Features:**
 - High-performance: faster than Python's pyproj
 - Format support: PROJ strings, WKT1/WKT2, PROJJSON, EPSG codes
-- 30 map projections (Mercator, UTM, Lambert, Albers, Krovak, Oblique Mercator, Equal Earth, etc.)
+- 34 map projections (Mercator, UTM, Lambert, Albers, Krovak, Oblique Mercator, Equal Earth, Geocentric, etc.)
 - MGRS coordinate conversion
 - GeoTIFF datum grids with PROJ CDN integration
 - JTS geometry transformation support
@@ -22,7 +22,7 @@ Full documentation is available in the [docs/](docs/) folder:
 - [Getting Started](docs/getting-started.md) -- installation and first transformation
 - [Coordinate Transformations](docs/coordinate-transformations.md) -- single, batch, and flat array transforms
 - [CRS Formats](docs/crs-formats.md) -- PROJ strings, WKT1, WKT2, PROJJSON, EPSG codes
-- [Projections](docs/projections.md) -- all 15 supported map projections
+- [Projections](docs/projections.md) -- all 34 supported map projections
 - [Datum Transformations](docs/datum-transformations.md) -- 3-param, 7-param, and grid-based shifts
 - [Grid Shifts](docs/grid-shifts.md) -- NTv2/GeoTIFF grid loading and CDN auto-fetching
 - [MGRS Coordinates](docs/mgrs.md) -- Military Grid Reference System conversion
@@ -210,12 +210,38 @@ CompletableFuture<GridData> future = GridCdnFetcher.fetchAndLoadAsync("ca_nrc_nt
 
 ## Supported Projections
 
-30 map projections:
-- **Cylindrical**: Mercator, Transverse Mercator, UTM, Miller, Equirectangular, Cylindrical Equal Area, Cassini-Soldner, Swiss Oblique Mercator, Hotine Oblique Mercator
+34 map projections — the complete proj4js set:
+- **Cylindrical**: Mercator, Transverse Mercator, UTM, Miller, Equirectangular, Cylindrical Equal Area, Cassini-Soldner, Swiss Oblique Mercator, Hotine Oblique Mercator, Gauss-Schreiber Transverse Mercator
 - **Pseudocylindrical**: Sinusoidal, Mollweide, Robinson, Equal Earth, Eckert VI, Van der Grinten
 - **Conic**: Lambert Conformal Conic, Albers Equal Area, Equidistant Conic, Polyconic, Krovak, Bonne
-- **Azimuthal**: Lambert Azimuthal Equal Area, Stereographic, Oblique Stereographic Alternative, Azimuthal Equidistant, Orthographic, Gnomonic
-- **Other**: Geostationary Satellite, Identity (longlat)
+- **Azimuthal**: Lambert Azimuthal Equal Area, Stereographic, Oblique Stereographic Alternative, Azimuthal Equidistant, Orthographic, Gnomonic, Tilted Perspective
+- **Other**: Geostationary Satellite, New Zealand Map Grid, Geocentric (ECEF), Quadrilateralized Spherical Cube, General Oblique Transformation (rotated pole), Identity (longlat)
+
+## Upstream Sync Status
+
+Proj4Sedona tracks two upstream code bases. The port is complete and audited as of the
+commits below — every upstream change up to these points is either ported, backported,
+or documented as an intentional divergence (divergences follow PROJ where proj4js is
+known to be wrong; each is noted in the relevant Javadoc and pinned by a test):
+
+| Upstream | Ported through | Date |
+|---|---|---|
+| [proj4js](https://github.com/proj4js/proj4js) | commit `695c191` | 2026-07-05 |
+| [wkt-parser](https://github.com/proj4js/wkt-parser) | v1.5.5 | 2026-07-13 (audit) |
+| [mgrs](https://github.com/proj4js/mgrs) | v1.0.0 | — |
+
+To find upstream changes that may need porting since the last sync:
+
+```bash
+# In a proj4js checkout:
+git log 695c191..origin/master -- lib/
+
+# For wkt-parser, diff the published packages:
+npm pack wkt-parser@1.5.5 && npm pack wkt-parser@latest
+```
+
+When updating this table, audit each new commit/diff hunk as ported, not applicable,
+or needs-backport, and land backports one commit per upstream change.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Proj4Sedona provides coordinate system transformations, datum conversions, and p
 **Key Features:**
 - High-performance: faster than Python's pyproj
 - Format support: PROJ strings, WKT1/WKT2, PROJJSON, EPSG codes
-- 34 map projections (Mercator, UTM, Lambert, Albers, Krovak, Oblique Mercator, Equal Earth, Geocentric, etc.)
+- 34 map projections (Mercator, UTM, Lambert, Albers, Krovak, Oblique Mercator, Equal Earth, Geocentric, etc.), plus the longlat identity transform
 - MGRS coordinate conversion
 - GeoTIFF datum grids with PROJ CDN integration
 - JTS geometry transformation support
@@ -22,7 +22,7 @@ Full documentation is available in the [docs/](docs/) folder:
 - [Getting Started](docs/getting-started.md) -- installation and first transformation
 - [Coordinate Transformations](docs/coordinate-transformations.md) -- single, batch, and flat array transforms
 - [CRS Formats](docs/crs-formats.md) -- PROJ strings, WKT1, WKT2, PROJJSON, EPSG codes
-- [Projections](docs/projections.md) -- all 34 supported map projections
+- [Projections](docs/projections.md) -- all 34 map projections plus the longlat identity
 - [Datum Transformations](docs/datum-transformations.md) -- 3-param, 7-param, and grid-based shifts
 - [Grid Shifts](docs/grid-shifts.md) -- NTv2/GeoTIFF grid loading and CDN auto-fetching
 - [MGRS Coordinates](docs/mgrs.md) -- Military Grid Reference System conversion
@@ -210,7 +210,7 @@ CompletableFuture<GridData> future = GridCdnFetcher.fetchAndLoadAsync("ca_nrc_nt
 
 ## Supported Projections
 
-34 map projections — the complete proj4js set:
+34 map projections — the complete proj4js set — plus the longlat identity transform. Identity is listed under Other below but is not counted among the 34:
 - **Cylindrical**: Mercator, Transverse Mercator, UTM, Miller, Equirectangular, Cylindrical Equal Area, Cassini-Soldner, Swiss Oblique Mercator, Hotine Oblique Mercator, Gauss-Schreiber Transverse Mercator
 - **Pseudocylindrical**: Sinusoidal, Mollweide, Robinson, Equal Earth, Eckert VI, Van der Grinten
 - **Conic**: Lambert Conformal Conic, Albers Equal Area, Equidistant Conic, Polyconic, Krovak, Bonne

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
 # Proj4Sedona Documentation
 
-Proj4Sedona is a high-performance Java library for coordinate system transformations, ported from [Proj4js](https://github.com/proj4js/proj4js). It supports PROJ strings, WKT1, WKT2, PROJJSON, and EPSG code inputs, 34 map projections, datum transformations with grid shift support, MGRS conversion, and JTS geometry integration.
+Proj4Sedona is a high-performance Java library for coordinate system transformations, ported from [Proj4js](https://github.com/proj4js/proj4js). It supports PROJ strings, WKT1, WKT2, PROJJSON, and EPSG code inputs, 34 map projections (plus the longlat identity transform), datum transformations with grid shift support, MGRS conversion, and JTS geometry integration.
 
 ## Guides
 
 - [Getting Started](getting-started.md) -- Installation, first transformation, core concepts
 - [Coordinate Transformations](coordinate-transformations.md) -- Single, batch, and flat array transforms; converters and performance tips
 - [CRS Formats](crs-formats.md) -- Parsing and exporting PROJ strings, WKT1, WKT2, PROJJSON, and EPSG codes
-- [Projections](projections.md) -- All 34 supported map projections with examples
+- [Projections](projections.md) -- All 34 map projections plus the longlat identity, with examples
 - [Datum Transformations](datum-transformations.md) -- 3-parameter, 7-parameter, and grid-based datum shifts
 - [Grid Shifts](grid-shifts.md) -- NTv2 and GeoTIFF grid loading, PROJ CDN auto-fetching, cache configuration
 - [MGRS Coordinates](mgrs.md) -- Military Grid Reference System conversion and UPS polar support

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
 # Proj4Sedona Documentation
 
-Proj4Sedona is a high-performance Java library for coordinate system transformations, ported from [Proj4js](https://github.com/proj4js/proj4js). It supports PROJ strings, WKT1, WKT2, PROJJSON, and EPSG code inputs, 15 map projections, datum transformations with grid shift support, MGRS conversion, and JTS geometry integration.
+Proj4Sedona is a high-performance Java library for coordinate system transformations, ported from [Proj4js](https://github.com/proj4js/proj4js). It supports PROJ strings, WKT1, WKT2, PROJJSON, and EPSG code inputs, 34 map projections, datum transformations with grid shift support, MGRS conversion, and JTS geometry integration.
 
 ## Guides
 
 - [Getting Started](getting-started.md) -- Installation, first transformation, core concepts
 - [Coordinate Transformations](coordinate-transformations.md) -- Single, batch, and flat array transforms; converters and performance tips
 - [CRS Formats](crs-formats.md) -- Parsing and exporting PROJ strings, WKT1, WKT2, PROJJSON, and EPSG codes
-- [Projections](projections.md) -- All 15 supported map projections with examples
+- [Projections](projections.md) -- All 34 supported map projections with examples
 - [Datum Transformations](datum-transformations.md) -- 3-parameter, 7-parameter, and grid-based datum shifts
 - [Grid Shifts](grid-shifts.md) -- NTv2 and GeoTIFF grid loading, PROJ CDN auto-fetching, cache configuration
 - [MGRS Coordinates](mgrs.md) -- Military Grid Reference System conversion and UPS polar support

--- a/docs/constants-reference.md
+++ b/docs/constants-reference.md
@@ -90,7 +90,7 @@ Retrieved via `Ellipsoid.get(code)`. Each ellipsoid defines the shape of the Ear
 | `walbeck` | 6376896 | b=6355834.8467 | Walbeck |
 | `WGS60` | 6378165 | rf=298.3 | WGS 60 |
 | `WGS66` | 6378145 | rf=298.25 | WGS 66 |
-| `WGS72` | 6378135 | rf=298.26 | WGS 72 |
+| `WGS7` | 6378135 | rf=298.26 | WGS 72 |
 | `WGS84` | 6378137 | rf=298.257223563 | WGS 84 |
 | `sphere` | 6370997 | b=6370997 | Normal Sphere (r=6370997) |
 

--- a/docs/coordinate-transformations.md
+++ b/docs/coordinate-transformations.md
@@ -170,13 +170,18 @@ double[] results = Proj4.transformFlat3D(
 Some CRS definitions specify non-standard axis orders (e.g., northing/easting instead of easting/northing). By default, Proj4Sedona assumes standard ENU (east, north, up) order and does not reorder coordinates. Set the `enforceAxis` parameter on `Converter` to honor the axis order declared in the CRS definition:
 
 ```java
-Converter conv = Proj4.proj4("EPSG:4326", "EPSG:32618");
+// A source CRS whose declared axis order is northing, easting, up.
+String neuSource = "+proj=longlat +datum=WGS84 +axis=neu +no_defs";
+Converter conv = Proj4.proj4(neuSource, "EPSG:32618");
 
-// Default: assumes standard ENU order; the CRS axis order is not applied
+// Default: assumes standard ENU order; the +axis=neu declaration is ignored,
+// so the point is still read as (longitude, latitude).
 Point result1 = conv.forward(new Point(-77.0, 38.9));
 
-// enforceAxis=true: honor the CRS-declared axis order
-Point result2 = conv.forward(new Point(-77.0, 38.9), true);
+// enforceAxis=true: honor the CRS-declared order, so the point is read as
+// (north, east) = (latitude, longitude). This yields the same projected
+// coordinate as result1 above.
+Point result2 = conv.forward(new Point(38.9, -77.0), true);
 ```
 
 ## Choosing the Right Method

--- a/docs/coordinate-transformations.md
+++ b/docs/coordinate-transformations.md
@@ -167,15 +167,15 @@ double[] results = Proj4.transformFlat3D(
 
 ## Axis Order and Enforcement
 
-Some CRS definitions specify non-standard axis orders (e.g., northing/easting instead of easting/northing). By default, Proj4Sedona uses the order defined in the CRS. You can override this with the `enforceAxis` parameter on `Converter`:
+Some CRS definitions specify non-standard axis orders (e.g., northing/easting instead of easting/northing). By default, Proj4Sedona assumes standard ENU (east, north, up) order and does not reorder coordinates. Set the `enforceAxis` parameter on `Converter` to honor the axis order declared in the CRS definition:
 
 ```java
 Converter conv = Proj4.proj4("EPSG:4326", "EPSG:32618");
 
-// Default: respects CRS axis order
+// Default: assumes standard ENU order; the CRS axis order is not applied
 Point result1 = conv.forward(new Point(-77.0, 38.9));
 
-// Force standard ENU (east, north, up) order
+// enforceAxis=true: honor the CRS-declared axis order
 Point result2 = conv.forward(new Point(-77.0, 38.9), true);
 ```
 

--- a/docs/crs-formats.md
+++ b/docs/crs-formats.md
@@ -23,7 +23,7 @@ Proj fromJson = new Proj("{\"type\": \"ProjectedCRS\", ...}");
 |--------|-------------------|
 | PROJ string | Starts with `+` |
 | WKT1 | Contains `[` and starts with `PROJCS`, `GEOGCS`, `GEOCCS`, or `LOCAL_CS` |
-| WKT2 | Contains `[` and starts with `PROJCRS`, `GEOGCRS`, `GEODCRS`, `ENGCRS`, or `VERTCRS` |
+| WKT2 | Contains `[` and starts with `PROJCRS`, `GEOGCRS`, `GEODCRS`, `BOUNDCRS`, or `VERTCRS` |
 | PROJJSON | Starts with `{` |
 | Authority code | Matches pattern `AUTHORITY:CODE` (e.g., `EPSG:4326`, `ESRI:102001`, `IAU_2015:49900`) |
 | Shorthand alias | Matches a pre-registered name like `WGS84` or `GOOGLE` |
@@ -205,15 +205,16 @@ Proj proj = new Proj("EPSG:32618");
 
 // Export to PROJ string
 String projStr = proj.toProjString();
-// "+proj=utm +zone=18 +datum=WGS84 +units=m +no_defs"
+// "+proj=utm +zone=18 +lon_0=-75 +k_0=0.9996 +x_0=500000.0 +ellps=WGS84 +datum=WGS84 +no_defs"
+// (metre CRSs emit no +units= token, matching PROJ)
 
 // Export to WKT1
 String wkt1 = proj.toWkt1();
-// "PROJCS[\"WGS 84 / UTM zone 18N\", ...]"
+// "PROJCS[\"EPSG:32618\", ...]"  (the CRS name is the input srsCode)
 
 // Export to WKT2
 String wkt2 = proj.toWkt2();
-// "PROJCRS[\"WGS 84 / UTM zone 18N\", ...]"
+// "PROJCRS[\"EPSG:32618\", ...]"
 
 // Export to PROJJSON
 String json = proj.toProjJson();
@@ -226,7 +227,7 @@ String prettyJson = proj.toProjJson(true);
 String epsg = proj.toEpsgCode();    // "EPSG:32618"
 
 // Get full authority reference
-String auth = proj.toAuthority();   // "EPSG:32618"
+String[] auth = proj.toAuthority();   // {"EPSG", "32618"}
 ```
 
 ### Using CRSSerializer Directly
@@ -241,7 +242,7 @@ String wkt1 = CRSSerializer.toWkt1(proj);
 String wkt2 = CRSSerializer.toWkt2(proj);
 String json = CRSSerializer.toProjJson(proj);
 String epsg = CRSSerializer.toEpsgCode(proj);
-String auth = CRSSerializer.toAuthority(proj);
+String[] auth = CRSSerializer.toAuthority(proj);
 ```
 
 ## See Also

--- a/docs/crs-registry.md
+++ b/docs/crs-registry.md
@@ -91,15 +91,16 @@ Build a provider for your own CRS service:
 
 ```java
 import org.datasyslab.proj4sedona.defs.UrlCRSProvider;
+import org.datasyslab.proj4sedona.defs.CRSResult;
 
-UrlCRSProvider myProvider = new UrlCRSProvider.Builder()
-    .name("my-crs-service")
+UrlCRSProvider myProvider = UrlCRSProvider.builder("my-crs-service")
     .baseUrl("https://crs.example.com/api")
     .pathTemplate("/{authority}/{code}.proj4")
     .authorities("EPSG", "ESRI")
     .format(CRSResult.Format.PROJ4)
-    .timeout(5000)
-    .retries(2)
+    .connectTimeout(5)   // seconds
+    .readTimeout(5)      // seconds
+    .maxRetries(2)
     .build();
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,14 +12,14 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.0.6</version>
+    <version>0.1.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'org.datasyslab:proj4sedona:0.0.6'
+implementation 'org.datasyslab:proj4sedona:0.1.0'
 ```
 
 ### Building from Source

--- a/docs/grid-shifts.md
+++ b/docs/grid-shifts.md
@@ -143,7 +143,8 @@ import org.datasyslab.proj4sedona.grid.NadgridInfo;
 
 List<NadgridInfo> grids = GridLoader.getNadgrids("@conus,@alaska,@ntv2_0.gsb,null");
 // Returns list with each grid's name, mandatory flag, and loaded data
-// "null" entries are skipped (identity grid)
+// "null" entries are returned as a NadgridInfo with isNull() == true
+// (an identity / no-shift step, not dropped from the list)
 // "@" prefix means optional (mandatory=false)
 ```
 
@@ -188,7 +189,7 @@ double[] nad83 = Proj4.proj4(
     new double[]{-77.0, 38.9}
 );
 
-// 3. Transform OSGB36 to WGS84 via ETRS89 grid
+// 3. Transform OSGB36 to WGS84 (7-parameter Helmert from the OSGB36 datum)
 double[] wgs84 = Proj4.proj4(
     "EPSG:4277",  // OSGB36
     "EPSG:4326",  // WGS84

--- a/docs/jts-integration.md
+++ b/docs/jts-integration.md
@@ -4,7 +4,7 @@ Proj4Sedona integrates with the [JTS Topology Suite](https://github.com/location
 
 ## Setup
 
-The JTS integration uses the `org.locationtech.jts` library. Make sure it is on your classpath (it is included as a dependency of Proj4Sedona).
+The JTS integration uses the `org.locationtech.jts:jts-core` library. Proj4Sedona declares it as an *optional* dependency, so it is not pulled in transitively — add `org.locationtech.jts:jts-core` (1.20.0 or compatible) to your own build to use the integration.
 
 ## Creating a Transformer
 

--- a/docs/mgrs.md
+++ b/docs/mgrs.md
@@ -126,10 +126,10 @@ UPS.UPSCoordinate ups = UPS.fromLatLon(85.0, 10.0);
 // ups.easting, ups.northing, ups.zone
 
 // Convert back to lat/lon
-double[] latLon = UPS.toLatLon("N", ups.easting, ups.northing);
+double[] latLon = UPS.toLatLon(ups);
 
-// Get UPS zone letter
-String zone = UPS.getZoneLetter(85.0, 10.0); // "Z" (North Pole)
+// Get the UPS zone letter
+char zone = UPS.getZone(85.0, 10.0); // 'Z' (North Pole)
 ```
 
 ## Round-Trip Example

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -503,7 +503,7 @@ double[] result = Proj4.proj4(
 Not a map projection: converts geodetic longitude/latitude/height to Earth-centered, Earth-fixed X/Y/Z coordinates (e.g. EPSG:4978). Two-dimensional input returns the computed Z. Geocentric CRSs are also recognized when parsed from PROJJSON (`GeodeticCRS` + Cartesian coordinate system) and WKT2 (`GEODCRS` with `CS[Cartesian,3]`).
 
 - PROJ name: `geocent`
-- Aliases: `Geocentric`, `geocentric`
+- Aliases: `Geocentric`, `geocentric`, `Geocent`
 
 ```java
 double[] xyz = Proj4.proj4(

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections
 
-Proj4Sedona supports 15 map projections covering cylindrical, pseudocylindrical, conic, and azimuthal families. This page lists each projection with its PROJ name, aliases, and a usage example.
+Proj4Sedona supports 34 map projections — the complete proj4js set — covering cylindrical, pseudocylindrical, conic, azimuthal, and special families. This page lists each projection with its PROJ name, aliases, and a usage example.
 
 ## Cylindrical Projections
 
@@ -144,6 +144,21 @@ double[] result = Proj4.proj4(
     "+proj=longlat +datum=WGS84",
     "+proj=omerc +lat_0=4 +lonc=102.25 +alpha=323.0257964667 +k=0.99984 +x_0=804671 +y_0=0 +no_uoff +gamma=323.1301023611 +ellps=GRS80 +units=m",
     new double[]{102.5, 4.2}
+);
+```
+
+### Gauss-Schreiber Transverse Mercator
+
+Double-projection variant of the Transverse Mercator via a Gauss sphere. Used by legacy French grids (e.g. IGNF Reunion, Martinique).
+
+- PROJ name: `gstmerc`
+- Aliases: `gstmerg`, `Gauss_Schreiber_Transverse_Mercator`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=gstmerc +lat_0=-21.116666667 +lon_0=55.53333333 +k_0=1 +x_0=160000 +y_0=50000 +ellps=intl +units=m",
+    new double[]{55.5, -21.1}
 );
 ```
 
@@ -354,7 +369,7 @@ double[] result = Proj4.proj4(
 Conformal azimuthal projection. Used for polar regions and some national grids.
 
 - PROJ name: `stere`
-- Aliases: `Stereographic`, `Stereographic_South_Pole`, `Stereographic_North_Pole`, `Polar_Stereographic`, `Polar_Stereographic_variant_A`, `Polar_Stereographic_variant_B`, `Oblique_Stereographic`
+- Aliases: `Stereographic`, `Stereographic_South_Pole`, `Stereographic_North_Pole`, `Polar_Stereographic`, `Polar_Stereographic_variant_A`, `Polar_Stereographic_variant_B`
 
 ```java
 // Polar stereographic (North Pole)
@@ -425,6 +440,21 @@ double[] result = Proj4.proj4(
 );
 ```
 
+### Tilted Perspective
+
+General perspective view of the globe from an arbitrary height, azimuth, and tilt — a satellite or aerial camera view. The untilted case is the vertical near-side perspective (`nsper`).
+
+- PROJ name: `tpers`
+- Aliases: `Tilted_Perspective`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=tpers +h=5500000 +lat_0=40 +lon_0=-75 +azi=20 +tilt=30 +units=m",
+    new double[]{-74, 40.7}
+);
+```
+
 ## Other Projections
 
 ### Identity (Longitude/Latitude)
@@ -450,6 +480,67 @@ double[] result = Proj4.proj4(
     "+proj=longlat +datum=WGS84",
     "+proj=geos +h=35785831 +sweep=y +lon_0=0 +datum=WGS84 +units=m",
     new double[]{10.0, -5.0}
+);
+```
+
+### New Zealand Map Grid
+
+Sixth-order conformal fit specific to New Zealand (EPSG:27200). Defined only for the New Zealand region.
+
+- PROJ name: `nzmg`
+- Aliases: `New_Zealand_Map_Grid`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 +ellps=intl +units=m",
+    new double[]{174.78, -41.29}
+);
+```
+
+### Geocentric (ECEF)
+
+Not a map projection: converts geodetic longitude/latitude/height to Earth-centered, Earth-fixed X/Y/Z coordinates (e.g. EPSG:4978). Two-dimensional input returns the computed Z. Geocentric CRSs are also recognized when parsed from PROJJSON (`GeodeticCRS` + Cartesian coordinate system) and WKT2 (`GEODCRS` with `CS[Cartesian,3]`).
+
+- PROJ name: `geocent`
+- Aliases: `Geocentric`, `geocentric`
+
+```java
+double[] xyz = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=geocent +datum=WGS84 +units=m",
+    new double[]{2.35, 48.85, 100}
+);
+```
+
+### Quadrilateralized Spherical Cube
+
+Projects the sphere onto the six faces of a circumscribed cube with approximately equal-area facets. Used by astronomical and planetary data sets (COBE).
+
+- PROJ name: `qsc`
+- Aliases: `Quadrilateralized Spherical Cube`, `Quadrilateralized_Spherical_Cube`
+
+```java
+double[] result = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=qsc +lat_0=0 +lon_0=0 +ellps=WGS84 +units=m",
+    new double[]{5, 15}
+);
+```
+
+### General Oblique Transformation
+
+Meta-projection that rotates the sphere so an arbitrary point becomes the pole (or an arbitrary great circle the equator) before applying an inner projection given by `+o_proj`. Standard for rotated-pole grids in climate and ocean modeling.
+
+- PROJ name: `ob_tran`
+- Aliases: `General Oblique Transformation`, `General_Oblique_Transformation`
+
+```java
+// Rotated-pole longitude/latitude grid (output in degrees)
+double[] rotated = Proj4.proj4(
+    "+proj=longlat +datum=WGS84",
+    "+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=35 +lon_0=-113 +R=6371229",
+    new double[]{-105, 40}
 );
 ```
 
@@ -485,6 +576,12 @@ double[] result = Proj4.proj4(
 | Azimuthal | Gnomonic | `gnom` | Gnomonic |
 | Azimuthal | Orthographic | `ortho` | Perspective |
 | Other | Geostationary Satellite | `geos` | Perspective |
+| Cylindrical | Gauss-Schreiber Transverse Mercator | `gstmerc` | Conformal |
+| Azimuthal | Tilted Perspective | `tpers` | Perspective |
+| Other | New Zealand Map Grid | `nzmg` | Conformal (regional fit) |
+| Other | Geocentric (ECEF) | `geocent` | Coordinate conversion |
+| Other | Quadrilateralized Spherical Cube | `qsc` | Approximately equal-area |
+| Other | General Oblique Transformation | `ob_tran` | Meta-projection (rotated pole) |
 | Other | Identity | `longlat` | None |
 
 ## See Also

--- a/docs/projections.md
+++ b/docs/projections.md
@@ -1,6 +1,6 @@
 # Projections
 
-Proj4Sedona supports 34 map projections — the complete proj4js set — covering cylindrical, pseudocylindrical, conic, azimuthal, and special families. This page lists each projection with its PROJ name, aliases, and a usage example.
+Proj4Sedona supports 34 map projections — the complete proj4js set — plus the geographic identity (longlat) transform, covering cylindrical, pseudocylindrical, conic, azimuthal, and special families. The identity transform is documented under Other Projections but is not itself a map projection and is not counted among the 34. This page lists each projection with its PROJ name, aliases, and a usage example.
 
 ## Cylindrical Projections
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.0.9</version>
+    <version>0.1.0</version>
     <packaging>jar</packaging>
 
     <name>Proj4Sedona</name>


### PR DESCRIPTION
Release preparation for **v0.1.0** — docs and pom only, no source or test changes.

## Version

`pom.xml` 0.0.9 → 0.1.0, marking the completed proj4js port (34 map projections, geocentric PROJJSON/WKT2 support, and the parser/serializer overhauls since 0.0.9).

## Upstream sync tracking (primary goal)

New **Upstream Sync Status** section in the README recording where each upstream is ported through, so future syncs have a concrete baseline:

| Upstream | Ported through | Date |
|---|---|---|
| proj4js | commit `695c191` | 2026-07-05 |
| wkt-parser | v1.5.5 | 2026-07-13 (audit) |
| mgrs | v1.0.0 | — |

Includes the `git log 695c191..origin/master -- lib/` command for finding proj4js changes since, and the npm-pack diff approach for wkt-parser.

## Projection docs

Corrected the projection count (README claimed 30 in one place and 15 in another; docs said 15) to the actual **34**, listed the newly ported families, and added the six projection sections missing from `docs/projections.md` (gstmerc, tpers, nzmg, geocent, qsc, ob_tran) — aliases taken from the projection classes, examples runnable — plus summary-table rows.

## Documentation accuracy sweep

An audit of all 12 doc files against the current code surfaced 14 stale claims (several pre-existing); each was verified against the source and its corrected example compiled and run:

- Version pins `0.0.6` → `0.1.0` (getting-started Maven + Gradle).
- `toAuthority()` returns `String[]`, not `String` — the crs-formats examples now compile.
- `toProjString`/`toWkt` export outputs updated to what the reworked serializer emits (full UTM parameters, no `+units=m` token, srsCode-based CRS name).
- WKT2 format-detection keyword list corrected: `ENGCRS` is parsed as WKT1; `BOUNDCRS` is the WKT2 keyword.
- `enforceAxis` semantics were documented backwards — default assumes ENU; the flag honors the CRS-declared axis order.
- JTS documented as an optional dependency that consumers must add explicitly (it is `<optional>true</optional>`, not transitive).
- nadgrids `null` entries are returned with `isNull()`, not dropped.
- Ellipsoid code is `WGS7` (proj4js-faithful), not `WGS72`.
- `UrlCRSProvider` example rewritten to the real `builder(name)` API with second-based connect/read timeouts.
- UPS examples use `getZone` (returns `char`) and `toLatLon(UPSCoordinate)`.
