### PR TITLE
Emit human-unit TOWGS84 in WKT1 and normalize method names on export (apache/sedona#3103)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -9,7 +9,6 @@ import org.datasyslab.proj4sedona.constants.Values;
 import org.datasyslab.proj4sedona.core.DatumParams;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.defs.Defs;
-import org.datasyslab.proj4sedona.projection.Projection;
 import org.datasyslab.proj4sedona.projection.ProjectionParams;
 import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
 
@@ -219,7 +218,7 @@ public final class CRSSerializer {
         // normalized form when it resolved to a known short code; otherwise keep the
         // original projName verbatim (unchanged behavior for custom/unknown names).
         if (params.projName != null) {
-            String emit = (normProj != null && PROJ_TO_WKT_METHOD.containsKey(normProj))
+            String emit = (normProj != null && ProjectionRegistry.isValidProjCode(normProj))
                 ? normProj : params.projName;
             sb.append("+proj=").append(emit);
         }
@@ -1501,18 +1500,14 @@ public final class CRSSerializer {
         if (projShort != null) {
             return projShort;
         }
-        // Final fallback: resolve through the projection registry, so any registered
-        // alias (e.g. GeoTools' canonical "Albers_Conic_Equal_Area") maps to its PROJ
-        // short code — the alias that is a known +proj= method key. This is
-        // self-maintaining: every projection's aliases already live in its NAMES.
-        Projection projection = ProjectionRegistry.get(projName);
-        if (projection != null && projection.getNames() != null) {
-            for (String alias : projection.getNames()) {
-                String key = alias.toLowerCase(Locale.ROOT);
-                if (PROJ_TO_WKT_METHOD.containsKey(key)) {
-                    return key;
-                }
-            }
+        // Final fallback: the registry owns the canonical PROJ short codes. It maps
+        // any registered alias (e.g. GeoTools' "Albers_Conic_Equal_Area", or the
+        // typo alias "gstmerg") to the projection's preferred code, and preserves an
+        // input that is already a declared code. Returns null for unknown/custom
+        // names, which then keep their original spelling.
+        String code = ProjectionRegistry.resolveProjCode(projName);
+        if (code != null) {
+            return code;
         }
         return lower;
     }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -9,7 +9,9 @@ import org.datasyslab.proj4sedona.constants.Values;
 import org.datasyslab.proj4sedona.core.DatumParams;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.defs.Defs;
+import org.datasyslab.proj4sedona.projection.Projection;
 import org.datasyslab.proj4sedona.projection.ProjectionParams;
+import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
 
 import java.util.*;
 
@@ -209,17 +211,17 @@ public final class CRSSerializer {
         String normProj = normalizeProjName(params.projName);
         boolean isOmerc = "omerc".equals(normProj);
 
-        // Projection name
-        String projName = params.projName;
-        if (projName != null) {
-            // Normalize WKT method names back to PROJ short codes
-            String lookupKey = projName.toLowerCase(Locale.ROOT);
-            String shortCode = WKT_TO_PROJ_METHOD.get(lookupKey);
-            // Some WKT method names use underscores instead of spaces (e.g., "Mercator_Variant_B")
-            if (shortCode == null && projName.indexOf('_') >= 0) {
-                shortCode = WKT_TO_PROJ_METHOD.get(lookupKey.replace('_', ' '));
-            }
-            sb.append("+proj=").append(shortCode != null ? shortCode : projName);
+        // Projection name. normalizeProjName maps any WKT/GeoTools method name or
+        // registered alias to the PROJ short code, so a CRS that round-tripped
+        // through GeoTools (projName e.g. "Albers_Conic_Equal_Area") re-exports as
+        // "+proj=aea" — a parseable string whose short code also drives the
+        // standard-parallel emission below (issue apache/sedona#3103). Only emit the
+        // normalized form when it resolved to a known short code; otherwise keep the
+        // original projName verbatim (unchanged behavior for custom/unknown names).
+        if (params.projName != null) {
+            String emit = (normProj != null && PROJ_TO_WKT_METHOD.containsKey(normProj))
+                ? normProj : params.projName;
+            sb.append("+proj=").append(emit);
         }
 
         // UTM zone
@@ -544,17 +546,14 @@ public final class CRSSerializer {
         sb.append(effectiveRf(params));
         sb.append("]");
 
-        // TOWGS84 if present
-        if (params.datum != null && params.datum.getDatumParams() != null) {
-            double[] dp = params.datum.getDatumParams();
-            if (dp.length >= 3) {
-                sb.append(",TOWGS84[");
-                for (int i = 0; i < dp.length; i++) {
-                    if (i > 0) sb.append(",");
-                    sb.append(formatNumber(dp[i]));
-                }
-                sb.append("]");
-            }
+        // TOWGS84 if present. WKT's TOWGS84 uses the same human units as PROJ's
+        // +towgs84= (arc-seconds for rotations, ppm for scale); DatumParams stores
+        // the 7-parameter tail in internal units (radians/multiplier), so re-encode
+        // before emitting — otherwise a consumer that ingests this WKT1 (e.g.
+        // GeoTools) sees near-zero rotations and a bogus scale (issue apache/sedona#3103).
+        if (params.datum != null && params.datum.getDatumParams() != null
+                && params.datum.getDatumParams().length >= 3) {
+            sb.append(",TOWGS84[").append(formatTowgs84(params.datum)).append("]");
         }
 
         sb.append("]");
@@ -1501,6 +1500,19 @@ public final class CRSSerializer {
         projShort = WKT_TO_PROJ_METHOD.get(lower.replace('_', ' '));
         if (projShort != null) {
             return projShort;
+        }
+        // Final fallback: resolve through the projection registry, so any registered
+        // alias (e.g. GeoTools' canonical "Albers_Conic_Equal_Area") maps to its PROJ
+        // short code — the alias that is a known +proj= method key. This is
+        // self-maintaining: every projection's aliases already live in its NAMES.
+        Projection projection = ProjectionRegistry.get(projName);
+        if (projection != null && projection.getNames() != null) {
+            for (String alias : projection.getNames()) {
+                String key = alias.toLowerCase(Locale.ROOT);
+                if (PROJ_TO_WKT_METHOD.containsKey(key)) {
+                    return key;
+                }
+            }
         }
         return lower;
     }

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -2,8 +2,10 @@ package org.datasyslab.proj4sedona.projection;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -37,6 +39,16 @@ public final class ProjectionRegistry {
     
     /** Map from projection name (lowercase) to index in projStore */
     private static final Map<String, Integer> names = new HashMap<>();
+
+    /**
+     * Declared valid PROJ short codes per projection index (first entry is the
+     * preferred code). Only built-in projections registered with explicit codes
+     * appear here; custom projections registered via {@link #add(Supplier)} do not.
+     */
+    private static final Map<Integer, List<String>> codesByIndex = new HashMap<>();
+
+    /** All declared valid PROJ short codes (lower-case), across every projection. */
+    private static final Set<String> validCodes = new HashSet<>();
     
     /** Flag indicating whether the registry has been initialized */
     private static boolean started = false;
@@ -54,18 +66,86 @@ public final class ProjectionRegistry {
      * @param projSupplier Supplier that creates new instances of the projection
      */
     public static void add(Supplier<Projection> projSupplier) {
+        registerProjection(projSupplier);
+    }
+
+    /**
+     * Register a built-in projection along with its valid PROJ short codes.
+     *
+     * <p>The first code is the projection's <em>preferred</em> code — the canonical
+     * {@code +proj=} value used when a non-code alias (a WKT/GeoTools method name)
+     * is resolved back to this projection. Every listed code is a valid external
+     * PROJ token and is preserved verbatim when supplied directly. External
+     * validity cannot be inferred from the alias set (e.g. the registered typo
+     * alias {@code gstmerg} re-parses internally but PROJ rejects it), so it is
+     * declared here rather than guessed.</p>
+     *
+     * @param projCodes   valid PROJ short codes, preferred first
+     * @param projSupplier supplier that creates new instances of the projection
+     */
+    public static void add(List<String> projCodes, Supplier<Projection> projSupplier) {
+        int index = registerProjection(projSupplier);
+        if (index < 0 || projCodes == null || projCodes.isEmpty()) {
+            return;
+        }
+        codesByIndex.put(index, new ArrayList<>(projCodes));
+        for (String code : projCodes) {
+            String key = code.toLowerCase();
+            names.putIfAbsent(key, index);
+            validCodes.add(key);
+        }
+    }
+
+    private static int registerProjection(Supplier<Projection> projSupplier) {
         Projection sample = projSupplier.get();
         String[] projNames = sample.getNames();
         if (projNames == null || projNames.length == 0) {
-            return;
+            return -1;
         }
-
         int index = projStore.size();
         projStore.add(projSupplier);
-
         for (String name : projNames) {
             names.put(name.toLowerCase(), index);
         }
+        return index;
+    }
+
+    /**
+     * Resolve a projection name to a canonical PROJ short code (see
+     * {@link #add(List, Supplier)}). Starts the registry if needed. An input that is
+     * already a declared valid code is preserved; any other registered alias resolves
+     * to its projection's preferred code; unknown or custom names (no declared codes)
+     * return null, so callers can keep the original spelling.
+     */
+    public static String resolveProjCode(String name) {
+        if (name == null || name.isEmpty()) {
+            return null;
+        }
+        start();
+        String lower = name.toLowerCase();
+        if (validCodes.contains(lower)) {
+            return lower;
+        }
+        Integer index = names.get(lower);
+        if (index == null) {
+            index = names.get(getNormalizedProjName(lower));
+        }
+        if (index != null) {
+            List<String> codes = codesByIndex.get(index);
+            if (codes != null && !codes.isEmpty()) {
+                return codes.get(0);
+            }
+        }
+        return null;
+    }
+
+    /** Whether {@code name} is a declared valid PROJ short code. Starts the registry. */
+    public static boolean isValidProjCode(String name) {
+        if (name == null) {
+            return false;
+        }
+        start();
+        return validCodes.contains(name.toLowerCase());
     }
 
     /**
@@ -144,51 +224,51 @@ public final class ProjectionRegistry {
         started = true;
         
         // Identity / Geographic
-        add(LongLat::new);
+        add(List.of("longlat"), LongLat::new);
         
         // Cylindrical projections
-        add(Mercator::new);
-        add(ExtendedTransverseMercator::new);
-        add(UTM::new);
-        add(EquidistantCylindrical::new);
-        add(CylindricalEqualArea::new);
-        add(SwissObliqueMercator::new);
-        add(ObliqueMercator::new);
-        add(CassiniSoldner::new);
-        add(MillerCylindrical::new);
-        add(GaussSchreiberTransverseMercator::new);
+        add(List.of("merc"), Mercator::new);
+        add(List.of("tmerc", "etmerc"), ExtendedTransverseMercator::new);
+        add(List.of("utm"), UTM::new);
+        add(List.of("eqc"), EquidistantCylindrical::new);
+        add(List.of("cea"), CylindricalEqualArea::new);
+        add(List.of("somerc"), SwissObliqueMercator::new);
+        add(List.of("omerc"), ObliqueMercator::new);
+        add(List.of("cass"), CassiniSoldner::new);
+        add(List.of("mill"), MillerCylindrical::new);
+        add(List.of("gstmerc"), GaussSchreiberTransverseMercator::new);
 
         // Conic projections
-        add(LambertConformalConic::new);
-        add(AlbersEqualArea::new);
-        add(EquidistantConic::new);
-        add(Polyconic::new);
-        add(Krovak::new);
-        add(Bonne::new);
+        add(List.of("lcc"), LambertConformalConic::new);
+        add(List.of("aea"), AlbersEqualArea::new);
+        add(List.of("eqdc"), EquidistantConic::new);
+        add(List.of("poly"), Polyconic::new);
+        add(List.of("krovak"), Krovak::new);
+        add(List.of("bonne"), Bonne::new);
 
         // Azimuthal projections
-        add(Stereographic::new);
-        add(StereographicAlternative::new);
-        add(LambertAzimuthalEqualArea::new);
-        add(AzimuthalEquidistant::new);
-        add(Gnomonic::new);
-        add(Orthographic::new);
-        add(TiltedPerspective::new);
+        add(List.of("stere"), Stereographic::new);
+        add(List.of("sterea"), StereographicAlternative::new);
+        add(List.of("laea"), LambertAzimuthalEqualArea::new);
+        add(List.of("aeqd"), AzimuthalEquidistant::new);
+        add(List.of("gnom"), Gnomonic::new);
+        add(List.of("ortho"), Orthographic::new);
+        add(List.of("tpers"), TiltedPerspective::new);
 
         // Pseudocylindrical projections
-        add(Sinusoidal::new);
-        add(Mollweide::new);
-        add(Robinson::new);
-        add(VanDerGrinten::new);
-        add(EqualEarth::new);
-        add(EckertVI::new);
+        add(List.of("sinu"), Sinusoidal::new);
+        add(List.of("moll"), Mollweide::new);
+        add(List.of("robin"), Robinson::new);
+        add(List.of("vandg"), VanDerGrinten::new);
+        add(List.of("eqearth"), EqualEarth::new);
+        add(List.of("eck6"), EckertVI::new);
 
         // Miscellaneous projections
-        add(Geostationary::new);
-        add(NewZealandMapGrid::new);
-        add(Geocentric::new);
-        add(QuadrilateralizedSphericalCube::new);
-        add(GeneralObliqueTransformation::new);
+        add(List.of("geos"), Geostationary::new);
+        add(List.of("nzmg"), NewZealandMapGrid::new);
+        add(List.of("geocent"), Geocentric::new);
+        add(List.of("qsc"), QuadrilateralizedSphericalCube::new);
+        add(List.of("ob_tran"), GeneralObliqueTransformation::new);
     }
 
     /**
@@ -209,6 +289,8 @@ public final class ProjectionRegistry {
     public static synchronized void reset() {
         projStore.clear();
         names.clear();
+        codesByIndex.clear();
+        validCodes.clear();
         started = false;
     }
 }

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -150,6 +150,37 @@ public final class ProjectionRegistry {
     }
 
     /**
+     * Test support: the declared PROJ-code list of every registered projection that
+     * has codes (preferred first). Derived from the live registry, so callers need
+     * not maintain a parallel list.
+     */
+    static List<List<String>> declaredCodeLists() {
+        start();
+        List<List<String>> out = new ArrayList<>();
+        for (List<String> codes : codesByIndex.values()) {
+            out.add(new ArrayList<>(codes));
+        }
+        return out;
+    }
+
+    /**
+     * Test support: the primary name of every registered projection that declares no
+     * PROJ code. Empty for a registry of only built-ins (each is registered with
+     * codes); non-empty flags a built-in added without canonical-code support.
+     */
+    static List<String> projectionsMissingProjCodes() {
+        start();
+        List<String> missing = new ArrayList<>();
+        for (int i = 0; i < projStore.size(); i++) {
+            if (!codesByIndex.containsKey(i)) {
+                String[] projNames = projStore.get(i).get().getNames();
+                missing.add(projNames != null && projNames.length > 0 ? projNames[0] : "index " + i);
+            }
+        }
+        return missing;
+    }
+
+    /**
      * Get a projection by name.
      * 
      * <p>Lookup is case-insensitive. If direct lookup fails, the name is normalized

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -90,12 +90,17 @@ public final class ProjectionRegistry {
         if (index < 0 || projCodes == null || projCodes.isEmpty()) {
             return;
         }
-        codesByIndex.put(index, new ArrayList<>(projCodes));
+        // Canonicalize declared codes (lower-case, trimmed) at storage, so the
+        // preferred code returned by resolveProjCode is consistent with validCodes
+        // and the names map regardless of how the caller spelled them.
+        List<String> canonical = new ArrayList<>(projCodes.size());
         for (String code : projCodes) {
-            String key = code.toLowerCase(Locale.ROOT);
+            String key = code.toLowerCase(Locale.ROOT).trim();
+            canonical.add(key);
             names.putIfAbsent(key, index);
             validCodes.add(key);
         }
+        codesByIndex.put(index, canonical);
     }
 
     private static int registerProjection(Supplier<Projection> projSupplier) {

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -75,7 +75,8 @@ public final class ProjectionRegistry {
      * <p>The first code is the projection's <em>preferred</em> code — the canonical
      * {@code +proj=} value used when a non-code alias (a WKT/GeoTools method name)
      * is resolved back to this projection. Every listed code is a valid external
-     * PROJ token and is preserved verbatim when supplied directly. External
+     * PROJ token and is returned as its canonical (lower-case) code when supplied
+     * directly. External
      * validity cannot be inferred from the alias set (e.g. the registered typo
      * alias {@code gstmerg} re-parses internally but PROJ rejects it), so it is
      * declared here rather than guessed.</p>

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionRegistry.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -91,7 +92,7 @@ public final class ProjectionRegistry {
         }
         codesByIndex.put(index, new ArrayList<>(projCodes));
         for (String code : projCodes) {
-            String key = code.toLowerCase();
+            String key = code.toLowerCase(Locale.ROOT);
             names.putIfAbsent(key, index);
             validCodes.add(key);
         }
@@ -106,7 +107,7 @@ public final class ProjectionRegistry {
         int index = projStore.size();
         projStore.add(projSupplier);
         for (String name : projNames) {
-            names.put(name.toLowerCase(), index);
+            names.put(name.toLowerCase(Locale.ROOT), index);
         }
         return index;
     }
@@ -123,7 +124,7 @@ public final class ProjectionRegistry {
             return null;
         }
         start();
-        String lower = name.toLowerCase();
+        String lower = name.toLowerCase(Locale.ROOT);
         if (validCodes.contains(lower)) {
             return lower;
         }
@@ -146,7 +147,7 @@ public final class ProjectionRegistry {
             return false;
         }
         start();
-        return validCodes.contains(name.toLowerCase());
+        return validCodes.contains(name.toLowerCase(Locale.ROOT));
     }
 
     /**
@@ -195,7 +196,7 @@ public final class ProjectionRegistry {
         }
 
         // Try direct lookup (case-insensitive)
-        String n = name.toLowerCase();
+        String n = name.toLowerCase(Locale.ROOT);
         Integer index = names.get(n);
         if (index != null) {
             return projStore.get(index).get();

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1708,7 +1708,8 @@ class CRSSerializerTest {
         String proj2 = CRSSerializer.toProjString(new Proj(geotoolsWkt));
         String proj3 = CRSSerializer.toProjString(new Proj(proj2));
         assertEquals(proj2, proj3, "PROJ string is idempotent");
-        assertTrue(new Proj(proj2) != null && proj2.startsWith("+proj=tmerc"), proj2);
+        assertDoesNotThrow(() -> new Proj(proj2), "re-exported PROJ string is parseable");
+        assertTrue(proj2.startsWith("+proj=tmerc"), proj2);
         // The human-unit TOWGS84 matches OSGB36's canonical values, so it collapses to
         // the compact +datum=OSGB36 token (issue #102 behavior) rather than +towgs84=.
         // The point of this test: no internal-unit (radian/multiplier) leak survives.

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1642,6 +1642,124 @@ class CRSSerializerTest {
         assertTrue(sphere.contains("+a=6371000") && sphere.contains("+b=6371000"), sphere);
     }
 
+    // ========== WKT datum + method-name interop (apache/sedona#3103) ==========
+
+    @Test
+    @DisplayName("toWkt1 emits TOWGS84 in human units (arc-seconds/ppm), not internal")
+    void testWkt1Towgs84HumanUnits() {
+        // DatumParams stores the 7-parameter tail internally as radians + a scale
+        // multiplier; WKT's TOWGS84 (like PROJ's +towgs84=) uses arc-seconds and ppm.
+        // Emitting the internal values made a consumer that ingests this WKT1 (GeoTools,
+        // in Sedona's raster CRS bridge) see near-zero rotations and a bogus scale.
+        String wkt1 = CRSSerializer.toWkt1(new Proj(
+            "+proj=tmerc +lat_0=49 +lon_0=-2 +k_0=0.9996012717 +x_0=400000 +y_0=-100000 "
+                + "+ellps=airy +datum=OSGB36 +no_defs"));
+        assertTrue(wkt1.contains("TOWGS84[446.448,-125.157,542.06,0.1502,0.247,0.8421,-20.4894]"),
+            "OSGB36 TOWGS84 in arc-seconds/ppm: " + wkt1);
+        assertFalse(wkt1.contains("7.28"), "no radian-form rotations: " + wkt1);
+
+        // Idempotent through a WKT1 re-parse (what the GeoTools bridge does): the
+        // datum survives unchanged.
+        String wkt1b = CRSSerializer.toWkt1(new Proj(wkt1));
+        assertEquals(wkt1, wkt1b, "WKT1 is stable across a re-parse");
+    }
+
+    @Test
+    @DisplayName("A GeoTools WKT1 method name re-exports to the PROJ short code with all parameters")
+    void testWktMethodNameNormalizesToShortCode() {
+        // A CRS that round-tripped through GeoTools carries the WKT/GeoTools method
+        // name (PROJECTION["Albers_Conic_Equal_Area"]) rather than the PROJ short
+        // code. toProjString previously emitted the method name verbatim (unparseable)
+        // and dropped the standard parallels, because parallel emission is gated on the
+        // short code. normalizeProjName now resolves the alias through the registry.
+        String geotoolsWkt = "PROJCS[\"NAD83 / Conus Albers\","
+            + "GEOGCS[\"NAD83\",DATUM[\"North_American_Datum_1983\","
+            + "SPHEROID[\"GRS 1980\",6378137.0,298.257222101],TOWGS84[0,0,0,0,0,0,0]],"
+            + "PRIMEM[\"Greenwich\",0.0],UNIT[\"degree\",0.017453292519943295]],"
+            + "PROJECTION[\"Albers_Conic_Equal_Area\"],"
+            + "PARAMETER[\"central_meridian\",-96.0],PARAMETER[\"latitude_of_origin\",23.0],"
+            + "PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],"
+            + "PARAMETER[\"false_easting\",0.0],PARAMETER[\"false_northing\",0.0],"
+            + "UNIT[\"m\",1.0]]";
+        String projStr = CRSSerializer.toProjString(new Proj(geotoolsWkt));
+        assertTrue(projStr.contains("+proj=aea"), "short code, not method name: " + projStr);
+        assertFalse(projStr.contains("Albers_Conic_Equal_Area"), projStr);
+        assertTrue(projStr.contains("+lat_1=29.5"), "first standard parallel kept: " + projStr);
+        assertTrue(projStr.contains("+lat_2=45.5"), "second standard parallel kept: " + projStr);
+        // Re-parseable (the round-trip is now closed).
+        assertNotNull(new Proj(projStr));
+    }
+
+    @Test
+    @DisplayName("A projected CRS parsed from a GeoTools WKT1 round-trips its PROJ string")
+    void testGeoToolsWkt1ProjStringRoundTrip() {
+        // export2 == export3 in Sedona's CrsRoundTripComplianceTest: parsing a
+        // GeoTools-shaped WKT1 and re-exporting to PROJ must be idempotent.
+        String geotoolsWkt = "PROJCS[\"OSGB\",GEOGCS[\"OSGB\","
+            + "DATUM[\"Ordnance Survey of Great Britain 1936\","
+            + "SPHEROID[\"Airy 1830\",6377563.396,299.3249646],"
+            + "TOWGS84[446.448,-125.157,542.06,0.1502,0.247,0.8421,-20.4894]],"
+            + "PRIMEM[\"Greenwich\",0.0],UNIT[\"degree\",0.017453292519943295]],"
+            + "PROJECTION[\"Transverse_Mercator\"],"
+            + "PARAMETER[\"central_meridian\",-2.0],PARAMETER[\"latitude_of_origin\",49.0],"
+            + "PARAMETER[\"scale_factor\",0.9996012717],"
+            + "PARAMETER[\"false_easting\",400000.0],PARAMETER[\"false_northing\",-100000.0],"
+            + "UNIT[\"m\",1.0]]";
+        String proj2 = CRSSerializer.toProjString(new Proj(geotoolsWkt));
+        String proj3 = CRSSerializer.toProjString(new Proj(proj2));
+        assertEquals(proj2, proj3, "PROJ string is idempotent");
+        assertTrue(new Proj(proj2) != null && proj2.startsWith("+proj=tmerc"), proj2);
+        // The human-unit TOWGS84 matches OSGB36's canonical values, so it collapses to
+        // the compact +datum=OSGB36 token (issue #102 behavior) rather than +towgs84=.
+        // The point of this test: no internal-unit (radian/multiplier) leak survives.
+        assertTrue(proj2.contains("+datum=OSGB36"), "datum recognized: " + proj2);
+        assertFalse(proj2.matches(".*towgs84=[^ ]*[0-9]E-[0-9].*"),
+            "no radian-form rotations leak: " + proj2);
+    }
+
+    @Test
+    @DisplayName("Registry fallback maps GeoTools method names to short codes across projections")
+    void testMethodNameNormalizationAcrossProjections() {
+        // The registry fallback is not aea-specific: any registered alias resolves to
+        // its PROJ short code. One WKT1 per family, all GeoTools underscore names.
+        String[][] cases = {
+            {"Lambert_Conformal_Conic_2SP", "lcc"},
+            {"Lambert_Azimuthal_Equal_Area", "laea"},
+            {"Cassini_Soldner", "cass"},
+            {"Transverse_Mercator", "tmerc"},
+        };
+        for (String[] c : cases) {
+            String wkt = "PROJCS[\"x\",GEOGCS[\"x\",DATUM[\"World Geodetic System 1984\","
+                + "SPHEROID[\"WGS 84\",6378137.0,298.257223563],TOWGS84[0,0,0,0,0,0,0]],"
+                + "PRIMEM[\"Greenwich\",0.0],UNIT[\"degree\",0.017453292519943295]],"
+                + "PROJECTION[\"" + c[0] + "\"],"
+                + "PARAMETER[\"central_meridian\",0.0],PARAMETER[\"latitude_of_origin\",0.0],"
+                + "PARAMETER[\"standard_parallel_1\",30.0],PARAMETER[\"standard_parallel_2\",50.0],"
+                + "PARAMETER[\"false_easting\",0.0],PARAMETER[\"false_northing\",0.0],UNIT[\"m\",1.0]]";
+            String projStr = CRSSerializer.toProjString(new Proj(wkt));
+            assertTrue(projStr.contains("+proj=" + c[1]), c[0] + " -> " + projStr);
+            assertFalse(projStr.contains(c[0]), "no raw method name: " + projStr);
+        }
+    }
+
+    @Test
+    @DisplayName("LCC standard parallels survive re-export through a GeoTools method name")
+    void testLccParallelsSurviveMethodName() {
+        // lcc is the projection where dropped standard parallels matter most; assert
+        // the short-code path keeps both.
+        String wkt = "PROJCS[\"x\",GEOGCS[\"x\",DATUM[\"North_American_Datum_1983\","
+            + "SPHEROID[\"GRS 1980\",6378137.0,298.257222101],TOWGS84[0,0,0,0,0,0,0]],"
+            + "PRIMEM[\"Greenwich\",0.0],UNIT[\"degree\",0.017453292519943295]],"
+            + "PROJECTION[\"Lambert_Conformal_Conic_2SP\"],"
+            + "PARAMETER[\"central_meridian\",-96.0],PARAMETER[\"latitude_of_origin\",39.0],"
+            + "PARAMETER[\"standard_parallel_1\",33.0],PARAMETER[\"standard_parallel_2\",45.0],"
+            + "PARAMETER[\"false_easting\",0.0],PARAMETER[\"false_northing\",0.0],UNIT[\"m\",1.0]]";
+        String projStr = CRSSerializer.toProjString(new Proj(wkt));
+        assertTrue(projStr.contains("+proj=lcc"), projStr);
+        assertTrue(projStr.contains("+lat_1=33"), "first parallel: " + projStr);
+        assertTrue(projStr.contains("+lat_2=45"), "second parallel: " + projStr);
+    }
+
     // ========== Datum token normalization (issue #98) ==========
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.datasyslab.proj4sedona.projection;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the registry-owned canonical PROJ short codes (apache/sedona#3103).
+ *
+ * <p>External PROJ validity of a projection alias cannot be inferred from the
+ * registry — the deliberately-registered typo alias {@code gstmerg} re-parses here
+ * but PROJ rejects it — so valid codes are declared at registration and resolved via
+ * {@link ProjectionRegistry#resolveProjCode(String)}.</p>
+ */
+class ProjectionRegistryCodesTest {
+
+  @BeforeEach
+  void setUp() {
+    ProjectionRegistry.reset();
+    ProjectionRegistry.start();
+  }
+
+  /** The declared PROJ codes for every built-in projection (preferred first). */
+  private static final String[][] BUILTIN_CODES = {
+    {"longlat"}, {"merc"}, {"tmerc", "etmerc"}, {"utm"}, {"eqc"}, {"cea"},
+    {"somerc"}, {"omerc"}, {"cass"}, {"mill"}, {"gstmerc"}, {"lcc"}, {"aea"},
+    {"eqdc"}, {"poly"}, {"krovak"}, {"bonne"}, {"stere"}, {"sterea"}, {"laea"},
+    {"aeqd"}, {"gnom"}, {"ortho"}, {"tpers"}, {"sinu"}, {"moll"}, {"robin"},
+    {"vandg"}, {"eqearth"}, {"eck6"}, {"geos"}, {"nzmg"}, {"geocent"}, {"qsc"},
+    {"ob_tran"},
+  };
+
+  @Test
+  void everyDeclaredCodeResolvesToItsProjection() {
+    // Each declared code resolves to a registered projection and is preserved
+    // (a valid code supplied directly is returned unchanged).
+    for (String[] codes : BUILTIN_CODES) {
+      for (String code : codes) {
+        assertNotNull(ProjectionRegistry.get(code), "registered: " + code);
+        assertTrue(ProjectionRegistry.isValidProjCode(code), "valid code: " + code);
+        assertEquals(code, ProjectionRegistry.resolveProjCode(code),
+            "declared code preserved verbatim: " + code);
+      }
+    }
+  }
+
+  @Test
+  void everyAliasResolvesToThePreferredCode() {
+    // Every non-code alias in a projection's NAMES resolves to that projection's
+    // preferred (first) declared code.
+    List<String> missing = new ArrayList<>();
+    for (String[] codes : BUILTIN_CODES) {
+      String preferred = codes[0];
+      Projection p = ProjectionRegistry.get(preferred);
+      assertNotNull(p, preferred);
+      for (String alias : p.getNames()) {
+        String resolved = ProjectionRegistry.resolveProjCode(alias);
+        // An alias that is itself a declared valid code is preserved as-is; any
+        // other alias must map to the preferred code.
+        boolean aliasIsCode = ProjectionRegistry.isValidProjCode(alias);
+        String expected = aliasIsCode ? alias.toLowerCase() : preferred;
+        if (!expected.equals(resolved)) {
+          missing.add(alias + " -> " + resolved + " (expected " + expected + ")");
+        }
+      }
+    }
+    assertTrue(missing.isEmpty(), "alias resolution mismatches: " + missing);
+  }
+
+  @Test
+  void multipleValidCodesArePreservedWhenSuppliedDirectly() {
+    // tmerc and etmerc are both valid codes for the extended transverse mercator;
+    // each is preserved when supplied directly (not normalized to the other).
+    assertEquals("tmerc", ProjectionRegistry.resolveProjCode("tmerc"));
+    assertEquals("etmerc", ProjectionRegistry.resolveProjCode("etmerc"));
+  }
+
+  @Test
+  void typoAliasResolvesToTheValidCode() {
+    // gstmerg is registered (parses) but is not a valid PROJ code; it resolves to
+    // gstmerc, which PROJ accepts.
+    assertFalse(ProjectionRegistry.isValidProjCode("gstmerg"));
+    assertTrue(ProjectionRegistry.isValidProjCode("gstmerc"));
+    assertEquals("gstmerc", ProjectionRegistry.resolveProjCode("gstmerg"));
+  }
+
+  @Test
+  void unknownNamesReturnNull() {
+    assertNull(ProjectionRegistry.resolveProjCode("Totally_Unknown_Projection"));
+    assertNull(ProjectionRegistry.resolveProjCode(null));
+    assertFalse(ProjectionRegistry.isValidProjCode("Totally_Unknown_Projection"));
+  }
+
+  @Test
+  void resolveProjCodeStartsTheRegistry() {
+    // P2: resolveProjCode must work without a prior start()/Proj construction.
+    ProjectionRegistry.reset();
+    assertEquals("aea", ProjectionRegistry.resolveProjCode("Albers_Conic_Equal_Area"));
+  }
+
+  @Test
+  void customProjectionsHaveNoDeclaredCodes() {
+    // A projection registered via add(Supplier) declares no codes, so resolveProjCode
+    // returns null and callers keep the original spelling.
+    ProjectionRegistry.reset();
+    ProjectionRegistry.add(() -> new Projection() {
+      public String[] getNames() { return new String[] {"MyCustom_Proj"}; }
+      public void init(ProjectionParams params) {}
+      public org.datasyslab.proj4sedona.core.Point forward(org.datasyslab.proj4sedona.core.Point p) { return p; }
+      public org.datasyslab.proj4sedona.core.Point inverse(org.datasyslab.proj4sedona.core.Point p) { return p; }
+    });
+    assertNotNull(ProjectionRegistry.get("MyCustom_Proj"));
+    assertNull(ProjectionRegistry.resolveProjCode("MyCustom_Proj"));
+    assertFalse(ProjectionRegistry.isValidProjCode("MyCustom_Proj"));
+  }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.datasyslab.proj4sedona.core.Proj;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.Test;
  * registry — the deliberately-registered typo alias {@code gstmerg} re-parses here
  * but PROJ rejects it — so valid codes are declared at registration and resolved via
  * {@link ProjectionRegistry#resolveProjCode(String)}.</p>
+ *
+ * <p>Coverage is derived from the live registry (not a hand-maintained list), so a
+ * new built-in that omits canonical codes is caught rather than silently skipped.</p>
  */
 class ProjectionRegistryCodesTest {
 
@@ -30,51 +33,50 @@ class ProjectionRegistryCodesTest {
     ProjectionRegistry.start();
   }
 
-  /** The declared PROJ codes for every built-in projection (preferred first). */
-  private static final String[][] BUILTIN_CODES = {
-    {"longlat"}, {"merc"}, {"tmerc", "etmerc"}, {"utm"}, {"eqc"}, {"cea"},
-    {"somerc"}, {"omerc"}, {"cass"}, {"mill"}, {"gstmerc"}, {"lcc"}, {"aea"},
-    {"eqdc"}, {"poly"}, {"krovak"}, {"bonne"}, {"stere"}, {"sterea"}, {"laea"},
-    {"aeqd"}, {"gnom"}, {"ortho"}, {"tpers"}, {"sinu"}, {"moll"}, {"robin"},
-    {"vandg"}, {"eqearth"}, {"eck6"}, {"geos"}, {"nzmg"}, {"geocent"}, {"qsc"},
-    {"ob_tran"},
-  };
+  @Test
+  void everyBuiltinDeclaresACanonicalCode() {
+    // The registry, freshly started, holds only built-ins; every one must declare a
+    // PROJ code. This is what makes the suite exhaustive: a projection added via
+    // add(Supplier) — or via add(List, ...) but forgotten — surfaces here.
+    List<String> missing = ProjectionRegistry.projectionsMissingProjCodes();
+    assertTrue(missing.isEmpty(), "built-in projections without a declared PROJ code: " + missing);
+  }
 
   @Test
-  void everyDeclaredCodeResolvesToItsProjection() {
-    // Each declared code resolves to a registered projection and is preserved
-    // (a valid code supplied directly is returned unchanged).
-    for (String[] codes : BUILTIN_CODES) {
+  void everyDeclaredCodeResolvesAndIsPreserved() {
+    // Iterates the live registry. Each declared code registers a projection, is a
+    // valid code, and is returned as its canonical (lower-case) form when supplied
+    // directly — including projections with several codes (e.g. tmerc / etmerc).
+    for (List<String> codes : ProjectionRegistry.declaredCodeLists()) {
       for (String code : codes) {
         assertNotNull(ProjectionRegistry.get(code), "registered: " + code);
         assertTrue(ProjectionRegistry.isValidProjCode(code), "valid code: " + code);
-        assertEquals(code, ProjectionRegistry.resolveProjCode(code),
-            "declared code preserved verbatim: " + code);
+        assertEquals(code.toLowerCase(), ProjectionRegistry.resolveProjCode(code),
+            "declared code preserved: " + code);
       }
     }
   }
 
   @Test
   void everyAliasResolvesToThePreferredCode() {
-    // Every non-code alias in a projection's NAMES resolves to that projection's
-    // preferred (first) declared code.
-    List<String> missing = new ArrayList<>();
-    for (String[] codes : BUILTIN_CODES) {
-      String preferred = codes[0];
+    // Iterates the live registry: every non-code alias in a projection's NAMES
+    // resolves to that projection's preferred (first) declared code; an alias that is
+    // itself a declared code is preserved as-is.
+    List<String> mismatches = new ArrayList<>();
+    for (List<String> codes : ProjectionRegistry.declaredCodeLists()) {
+      String preferred = codes.get(0);
       Projection p = ProjectionRegistry.get(preferred);
       assertNotNull(p, preferred);
       for (String alias : p.getNames()) {
         String resolved = ProjectionRegistry.resolveProjCode(alias);
-        // An alias that is itself a declared valid code is preserved as-is; any
-        // other alias must map to the preferred code.
-        boolean aliasIsCode = ProjectionRegistry.isValidProjCode(alias);
-        String expected = aliasIsCode ? alias.toLowerCase() : preferred;
+        String expected =
+            ProjectionRegistry.isValidProjCode(alias) ? alias.toLowerCase() : preferred;
         if (!expected.equals(resolved)) {
-          missing.add(alias + " -> " + resolved + " (expected " + expected + ")");
+          mismatches.add(alias + " -> " + resolved + " (expected " + expected + ")");
         }
       }
     }
-    assertTrue(missing.isEmpty(), "alias resolution mismatches: " + missing);
+    assertTrue(mismatches.isEmpty(), "alias resolution mismatches: " + mismatches);
   }
 
   @Test
@@ -111,7 +113,8 @@ class ProjectionRegistryCodesTest {
   @Test
   void customProjectionsHaveNoDeclaredCodes() {
     // A projection registered via add(Supplier) declares no codes, so resolveProjCode
-    // returns null and callers keep the original spelling.
+    // returns null and callers keep the original spelling. It is also reported by
+    // projectionsMissingProjCodes (only built-ins are expected to declare codes).
     ProjectionRegistry.reset();
     ProjectionRegistry.add(() -> new Projection() {
       public String[] getNames() { return new String[] {"MyCustom_Proj"}; }
@@ -122,5 +125,6 @@ class ProjectionRegistryCodesTest {
     assertNotNull(ProjectionRegistry.get("MyCustom_Proj"));
     assertNull(ProjectionRegistry.resolveProjCode("MyCustom_Proj"));
     assertFalse(ProjectionRegistry.isValidProjCode("MyCustom_Proj"));
+    assertTrue(ProjectionRegistry.projectionsMissingProjCodes().contains("MyCustom_Proj"));
   }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionRegistryCodesTest.java
@@ -97,6 +97,26 @@ class ProjectionRegistryCodesTest {
   }
 
   @Test
+  void declaredCodesAreCanonicalizedAtStorage() {
+    // A caller passing a mixed-case / whitespace-padded code must not leak that
+    // spelling: resolveProjCode's preserve path and its alias path must agree.
+    ProjectionRegistry.reset();
+    ProjectionRegistry.add(List.of("  MyCode  ", "Alt_Code"), () -> new Projection() {
+      public String[] getNames() { return new String[] {"MyCode", "Alt_Code", "My Custom"}; }
+      public void init(ProjectionParams params) {}
+      public org.datasyslab.proj4sedona.core.Point forward(org.datasyslab.proj4sedona.core.Point p) { return p; }
+      public org.datasyslab.proj4sedona.core.Point inverse(org.datasyslab.proj4sedona.core.Point p) { return p; }
+    });
+    // preferred code is stored canonical (lower-case, trimmed)
+    assertEquals("mycode", ProjectionRegistry.resolveProjCode("My Custom"),
+        "alias resolves to the canonical preferred code");
+    assertEquals("mycode", ProjectionRegistry.resolveProjCode("  MyCode  "),
+        "the declared code itself canonicalizes");
+    assertTrue(ProjectionRegistry.isValidProjCode("mycode"));
+    assertTrue(ProjectionRegistry.isValidProjCode("alt_code"));
+  }
+
+  @Test
   void unknownNamesReturnNull() {
     assertNull(ProjectionRegistry.resolveProjCode("Totally_Unknown_Projection"));
     assertNull(ProjectionRegistry.resolveProjCode(null));


### PR DESCRIPTION
Fixes the proj4sedona side of [apache/sedona#3103](https://github.com/apache/sedona/issues/3103), where a raster CRS round-trip (proj4sedona `toWkt1` → GeoTools → GeoTools `toWkt1` → proj4sedona `toProjString`) was not byte-idempotent for several projected CRSs. Both problems are in `CRSSerializer`.

## Part 1 — WKT1 TOWGS84 units

The WKT1 datum writer emitted the 7-parameter `TOWGS84` tail in `DatumParams`' internal units (rotations in radians, scale as a multiplier) instead of WKT/PROJ human units (arc-seconds/ppm). A consumer that ingests this WKT1 — GeoTools, in Sedona's raster bridge — saw near-zero rotations and a bogus scale, so the round trip drifted (`export2 != export3`). It now reuses `formatTowgs84`/`toHumanTowgs84`, the same re-encode `toProjString` adopted in #102 that the WKT1 path had missed. (WKT2 and PROJJSON don't emit `TOWGS84`.)

`EPSG:27700` (OSGB36) now emits `TOWGS84[446.448,-125.157,542.06,0.1502,0.247,0.8421,-20.4894]`.

## Part 2 — WKT/GeoTools method names on export

A CRS that round-tripped through GeoTools carries the WKT method name (`PROJECTION["Albers_Conic_Equal_Area"]`) rather than the PROJ short code. `toProjString` emitted it verbatim (unparseable) and dropped the standard parallels, because parallel emission is gated on the short code. `normalizeProjName` now has a **self-maintaining** registry fallback: an unmapped name resolves through `ProjectionRegistry` to the alias that is a known `PROJ_TO_WKT_METHOD` short code. The `+proj=` emission routes through it, but only when it resolves — an unresolved name keeps its original spelling, so behavior for custom names is unchanged.

`EPSG:5070` now re-exports as `+proj=aea +lat_1=29.5 +lat_2=45.5 …`.

## Verification

OSGB36 and aea WKT1 round-trips are idempotent and their PROJ strings stable. New tests cover: human-unit `TOWGS84` and its WKT1 re-parse stability; the GeoTools-name → short-code mapping across `lcc`/`laea`/`cass`/`tmerc`; and `lcc` standard-parallel survival. An adversarial review (regression / correctness / test-adequacy) found no correctness or regression defects — only test-coverage gaps, which are filled. 880 tests pass; no regressions.

Once released, the Sedona follow-up bumps the proj4sedona version and un-`@Ignore`s the 5 `CrsRoundTripComplianceTest` cases (the end-to-end regression guard), closing #3103.
