### PR TITLE
Make Polar Stereographic variant selection consistent (apache/sedona#3103)

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -2057,10 +2057,11 @@ public final class CRSSerializer {
             return false;
         }
         // Degenerate (drop latTs) only when the standard parallel coincides with the
-        // origin pole (lat0), where the derived scale is 1. A standard parallel at the
-        // opposite pole derives a different scale (lat_0=90, lat_ts=-90 gives k=0), so
-        // it must stay variant B — dropping it would silently change the transform.
-        return params.lat0 == null || Math.abs(params.latTs - params.lat0) >= 1e-10;
+        // origin pole (lat0 is non-null here — isPolarStereographic required it), where
+        // the derived scale is 1. A standard parallel at the opposite pole derives a
+        // different scale (lat_0=90, lat_ts=-90 gives k=0), so it must stay variant B —
+        // dropping it would silently change the transform.
+        return Math.abs(params.latTs - params.lat0) >= 1e-10;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -257,8 +257,13 @@ public final class CRSSerializer {
             }
         }
 
-        // Latitude of true scale (for Mercator)
-        if (params.latTs != null && params.latTs != 0.0) {
+        // Latitude of true scale (Mercator variant B, CEA, EQC, and Polar
+        // Stereographic variant B). Suppressed for Polar Stereographic variant A,
+        // which is defined by the scale factor below — emitting both a pole-latitude
+        // lat_ts and a k_0 is contradictory and breaks the round trip.
+        boolean polarStereoVariantA = isPolarStereographic(normProj, params)
+                && !isPolarStereographicVariantB(normProj, params);
+        if (params.latTs != null && params.latTs != 0.0 && !polarStereoVariantA) {
             sb.append(" +lat_ts=").append(formatAngle(params.latTs * RAD_TO_DEG));
         }
 
@@ -1964,11 +1969,9 @@ public final class CRSSerializer {
      */
     private static String getWktMethodName(String proj, ProjectionParams params) {
         if (isPolarStereographic(proj, params)) {
-            // Polar Stereographic: use variant B when latTs is present, variant A otherwise
-            if (params.latTs != null && params.latTs != 0.0) {
-                return "Polar Stereographic (variant B)";
-            }
-            return "Polar Stereographic (variant A)";
+            return isPolarStereographicVariantB(proj, params)
+                ? "Polar Stereographic (variant B)"
+                : "Polar Stereographic (variant A)";
         }
         if ("merc".equals(proj) && params.latTs != null && params.latTs != 0.0) {
             return "Mercator (variant B)";
@@ -2025,7 +2028,35 @@ public final class CRSSerializer {
         if ("merc".equals(proj) || "cea".equals(proj) || "eqc".equals(proj)) {
             return true;
         }
-        return isPolarStereographic(proj, params);
+        // Polar Stereographic carries latTs as the standard parallel only in variant B;
+        // variant A is defined by the scale factor and emits no standard parallel.
+        return isPolarStereographicVariantB(proj, params);
+    }
+
+    /**
+     * Whether a Polar Stereographic CRS is variant B (defined by a standard parallel
+     * / latitude of true scale) rather than variant A (defined by a scale factor).
+     *
+     * <p>Variant B requires a real standard parallel: latTs present, not zero, and not
+     * at the pole (a "standard parallel" coincident with the origin pole is degenerate
+     * and equivalent to variant A with k=1). A meaningful scale factor (k0 != 1) means
+     * the CRS is scale-defined — variant A — so the two never both apply. Keeping the
+     * variant label and the emitted parameters (scale_factor vs standard_parallel, and
+     * +k_0 vs +lat_ts) consistent is what makes the round trip stable: a CRS that
+     * arrives with both latTs and k0 (e.g. GeoTools adds latTs=90 to a variant-A polar
+     * CRS) is serialized as variant A and re-imports unchanged (apache/sedona#3103).</p>
+     */
+    private static boolean isPolarStereographicVariantB(String proj, ProjectionParams params) {
+        if (!isPolarStereographic(proj, params)) {
+            return false;
+        }
+        if (params.latTs == null || params.latTs == 0.0) {
+            return false;
+        }
+        if (params.k0 != 1.0) {
+            return false;
+        }
+        return Math.abs(Math.abs(params.latTs) - Math.PI / 2) >= 1e-10;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -2056,7 +2056,11 @@ public final class CRSSerializer {
         if (params.k0 != 1.0) {
             return false;
         }
-        return Math.abs(Math.abs(params.latTs) - Math.PI / 2) >= 1e-10;
+        // Degenerate (drop latTs) only when the standard parallel coincides with the
+        // origin pole (lat0), where the derived scale is 1. A standard parallel at the
+        // opposite pole derives a different scale (lat_0=90, lat_ts=-90 gives k=0), so
+        // it must stay variant B — dropping it would silently change the transform.
+        return params.lat0 == null || Math.abs(params.latTs - params.lat0) >= 1e-10;
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -3,6 +3,7 @@ package org.datasyslab.proj4sedona.parser;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+import org.datasyslab.proj4sedona.Proj4;
 import org.datasyslab.proj4sedona.core.Point;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
@@ -1784,6 +1785,25 @@ class CRSSerializerTest {
         assertFalse(wkt1.contains("standard_parallel"), wkt1);
         // Full WKT1 -> re-parse -> proj string keeps k_0.
         assertTrue(CRSSerializer.toProjString(new Proj(wkt1)).contains("+k_0=0.994"));
+    }
+
+    @Test
+    @DisplayName("Opposite-pole spherical lat_ts is preserved (derives a different scale)")
+    void testPolarStereoOppositePoleLatTsPreserved() {
+        // +proj=stere +lat_0=90 +lat_ts=-90 derives k=0 (degenerate zero-scale), unlike
+        // lat_ts=+90 which derives k=1. Dropping lat_ts here (treating it as the
+        // same-pole degenerate case) would silently change the transform — so it must
+        // stay variant B with lat_ts preserved. Regression compares the forward result
+        // before and after a proj-string round trip.
+        String src = "+proj=longlat +R=6371000 +no_defs";
+        String def = "+proj=stere +lat_0=90 +lat_ts=-90 +R=6371000 +no_defs";
+        String serialized = CRSSerializer.toProjString(new Proj(def));
+        assertTrue(serialized.contains("+lat_ts=-90"), "opposite-pole lat_ts kept: " + serialized);
+
+        Point before = Proj4.proj4(src, def).forward(new Point(10, 80));
+        Point after = Proj4.proj4(src, serialized).forward(new Point(10, 80));
+        assertEquals(before.x, after.x, 1e-6, "x unchanged by serialization");
+        assertEquals(before.y, after.y, 1e-6, "y unchanged by serialization");
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1761,6 +1761,49 @@ class CRSSerializerTest {
         assertTrue(projStr.contains("+lat_2=45"), "second parallel: " + projStr);
     }
 
+    // ========== Polar Stereographic variant consistency (apache/sedona#3103) ==========
+
+    @Test
+    @DisplayName("Polar stereographic with both lat_ts (at pole) and k_0 serializes as stable variant A")
+    void testPolarStereoVariantABothPresent() {
+        // GeoTools adds a redundant lat_ts=90 to a variant-A polar CRS (k_0 at the
+        // pole). The scale factor defines the CRS, so it must serialize as variant A:
+        // +k_0 kept, the degenerate lat_ts dropped, and idempotent on re-export.
+        Proj p = new Proj("+proj=stere +lat_0=90 +lat_ts=90 +k_0=0.994 "
+            + "+x_0=2000000 +y_0=2000000 +ellps=WGS84 +no_defs");
+        String proj1 = CRSSerializer.toProjString(p);
+        assertTrue(proj1.contains("+k_0=0.994"), proj1);
+        assertFalse(proj1.contains("+lat_ts="), "degenerate lat_ts dropped: " + proj1);
+        assertEquals(proj1, CRSSerializer.toProjString(new Proj(proj1)), "proj string idempotent");
+
+        // WKT1 is internally consistent: variant A carries a scale_factor and no
+        // standard parallel, so a strict consumer cannot drop the scale.
+        String wkt1 = CRSSerializer.toWkt1(p);
+        assertTrue(wkt1.contains("Polar Stereographic (variant A)"), wkt1);
+        assertTrue(wkt1.contains("scale_factor"), wkt1);
+        assertFalse(wkt1.contains("standard_parallel"), wkt1);
+        // Full WKT1 -> re-parse -> proj string keeps k_0.
+        assertTrue(CRSSerializer.toProjString(new Proj(wkt1)).contains("+k_0=0.994"));
+    }
+
+    @Test
+    @DisplayName("Polar stereographic variant B (real standard parallel) is preserved")
+    void testPolarStereoVariantBPreserved() {
+        // Antarctic Polar Stereographic (EPSG:3031-style): defined by a standard
+        // parallel at -71, k=1. Must stay variant B — lat_ts kept, no k_0, WKT carries
+        // a standard parallel and no scale factor.
+        Proj p = new Proj("+proj=stere +lat_0=-90 +lat_ts=-71 +x_0=0 +y_0=0 "
+            + "+ellps=WGS84 +no_defs");
+        String proj = CRSSerializer.toProjString(p);
+        assertTrue(proj.contains("+lat_ts=-71"), proj);
+        assertFalse(proj.contains("+k_0="), "variant B has no scale factor: " + proj);
+
+        String wkt1 = CRSSerializer.toWkt1(p);
+        assertTrue(wkt1.contains("Polar Stereographic (variant B)"), wkt1);
+        assertTrue(wkt1.contains("standard_parallel"), wkt1);
+        assertFalse(wkt1.contains("scale_factor"), wkt1);
+    }
+
     // ========== Datum token normalization (issue #98) ==========
 
     @Test


### PR DESCRIPTION
Fixes the last blocker for apache/sedona#3103: a Polar Stereographic variant-selection inconsistency in `CRSSerializer`.

## Problem

The variant (A vs B) was chosen purely on `latTs != null`, so a polar CRS carrying **both** `latTs` and `k0` was labelled "variant B" while still emitting a `scale_factor` — an internally contradictory WKT, since variant B is defined by a standard parallel and has no scale factor. A strict consumer honours the label and drops the scale: in Sedona's raster CRS round trip, GeoTools adds a redundant `lat_ts=90` to a variant-A polar CRS (EPSG:32661), and the next export then lost `+k_0` (`export2 != export3`).

This surfaced only after #108's (correct) method-name normalization started emitting `+proj=stere` instead of the raw, PROJ-invalid `+proj=Polar_Stereographic` that 0.1.0 produced — so #108 replaced *stable-but-invalid* output with *valid-but-unstable*, and this change completes it to *valid and stable*.

## Fix

The variant is now one coherent decision (`isPolarStereographicVariantB`): variant B only when it is a real standard parallel — `latTs` present, non-zero, **not at the pole** — with no meaningful scale (`k0 == 1`); a meaningful `k0` means the CRS is scale-defined, i.e. variant A. The method-name label, `usesLatTsAsStandardParallel` (standard-parallel emission), and the `+lat_ts` suppression in the proj string all key off this, so `scale_factor`↔`standard_parallel` and `+k_0`↔`+lat_ts` stay consistent across proj/WKT1/WKT2/PROJJSON. The both-present CRS now serializes as stable variant A (`k_0` kept, degenerate `lat_ts` dropped).

`CRSSerializer` is proj4sedona-original (proj4js has no WKT export), so there is no upstream variant-labelling to match; the fix is against the WKT/PROJ spec (variant A = scale factor, variant B = standard parallel).

## Verification

- 891 proj4sedona tests, plus two new ones pinning the both-present→variant-A stability and variant-B preservation.
- Adversarial review (correctness + regression) found no defects: non-target CRSs byte-identical before/after; the shapes that flip B→A verified semantically equivalent by forward transform (input matches k-only to <1e-6); the `k0==1.0` gate misclassifies no real variant B.
- End to end against Sedona's raster bridge (proj4sedona built as a local snapshot): all `CrsRoundTripComplianceTest` cases pass — EPSG:32661 (variant A) and the five previously deferred to #3103 — with EPSG:3031/3413 (variant B) unchanged, plus `FunctionsProj4Test`/`RasterEditorsTest`/`RasterAccessorsTest` (188 total).

Once released, the Sedona bump un-`@Ignore`s all those cases and closes #3103.
