### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,14 +12,14 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'org.datasyslab:proj4sedona:0.1.0'
+implementation 'org.datasyslab:proj4sedona:0.1.1'
 ```
 
 ### Building from Source

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <name>Proj4Sedona</name>


### PR DESCRIPTION
## Summary

Patch release **0.1.0 → 0.1.1**, carrying the CRS-serialization interop fixes that unblock the round-trip export path in downstream consumers (apache/sedona#3103).

### What changed since 0.1.0
- **WKT1 export** now emits `TOWGS84` in human units (arc-seconds / ppm) and normalizes WKT/GeoTools method names to PROJ short codes (e.g. `Polar_Stereographic` → `stere`) on export (#108).
- **Canonical PROJ short codes** are owned by `ProjectionRegistry`, resolved through the new `resolveProjCode` / `isValidProjCode` API (#108).
- **Polar Stereographic** variant A/B selection is now consistent across proj-string, WKT1 and WKT2, with the opposite-pole standard parallel (`lat_ts` at the pole opposite the origin) correctly preserved (#110).

### Compatibility
Backward compatible — the only public-surface change is additive (`ProjectionRegistry.resolveProjCode` / `isValidProjCode`). No behavioral change to transforms.

### Verification
- proj4sedona: full test suite green.
- Downstream (Apache Sedona `common` + Spark CRS path) built against this version: 1182 tests pass, including the 5 previously-blocked round-trip cases and `CRSTransformProj4Test` (36).

Contents:
- `pom.xml`: `0.1.0` → `0.1.1`
- `docs/getting-started.md`: dependency version pins bumped to `0.1.1`
