### PR TITLE
Correct inverted proj4js note in Krovak scale-factor handling

### DIFF
--- a/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
@@ -51,9 +51,9 @@ public class Krovak implements Projection {
         // Persist the resolved central meridian (like UTM's zone-derived long0), so
         // wrappers such as ob_tran can compensate for it.
         params.long0 = this.long0;
-        // Krovak's scale factor is 0.9999 when +k is omitted (per PROJ). proj4js gets this
-        // wrong: its global `k0 = k0 || 1.0` default in Proj.js shadows krovak's own 0.9999
-        // fallback, so proj4js projects with 1.0. ProjectionParams likewise cannot distinguish
+        // Krovak's scale factor is 0.9999 when +k is omitted (per PROJ). In proj4js 2.20.9,
+        // the global `k0 = k0 || 1.0` default in Proj.js shadows krovak's own 0.9999 fallback,
+        // so an omitted +k projects with k0=1.0. ProjectionParams likewise cannot distinguish
         // "omitted" from "k=1" (both surface as the 1.0 default), and k=1 is not a real Krovak
         // definition, so treat 1.0/0 as unset (matching PROJ).
         this.k0 = params.k0;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Krovak.java
@@ -51,9 +51,11 @@ public class Krovak implements Projection {
         // Persist the resolved central meridian (like UTM's zone-derived long0), so
         // wrappers such as ob_tran can compensate for it.
         params.long0 = this.long0;
-        // Krovak's scale factor is 0.9999. proj4js defaults it when +k is omitted;
-        // ProjectionParams cannot distinguish "omitted" from "k=1" (both surface as the
-        // 1.0 default), and k=1 is not a real Krovak definition, so treat 1.0/0 as unset.
+        // Krovak's scale factor is 0.9999 when +k is omitted (per PROJ). proj4js gets this
+        // wrong: its global `k0 = k0 || 1.0` default in Proj.js shadows krovak's own 0.9999
+        // fallback, so proj4js projects with 1.0. ProjectionParams likewise cannot distinguish
+        // "omitted" from "k=1" (both surface as the 1.0 default), and k=1 is not a real Krovak
+        // definition, so treat 1.0/0 as unset (matching PROJ).
         this.k0 = params.k0;
         if (this.k0 == 0 || this.k0 == 1.0) {
             this.k0 = 0.9999;

--- a/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
@@ -87,8 +87,9 @@ class KrovakTest {
 
     @Test
     void testDefaultScaleFactor() {
-        // With +k omitted, Krovak's 0.9999 scale factor must be used (as in proj4js),
-        // not the generic 1.0 default.
+        // With +k omitted, Krovak's 0.9999 scale factor must be used (as PROJ does), not the
+        // generic 1.0 default. (proj4js gets this wrong and projects with 1.0; the expected
+        // values below are PROJ's, matching an explicit +k=0.9999.)
         Converter conv = Proj4.proj4(BESSEL_LL,
             "+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +ellps=bessel "
                 + "+pm=greenwich +units=m +no_defs");

--- a/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/KrovakTest.java
@@ -88,8 +88,8 @@ class KrovakTest {
     @Test
     void testDefaultScaleFactor() {
         // With +k omitted, Krovak's 0.9999 scale factor must be used (as PROJ does), not the
-        // generic 1.0 default. (proj4js gets this wrong and projects with 1.0; the expected
-        // values below are PROJ's, matching an explicit +k=0.9999.)
+        // generic 1.0 default. (proj4js 2.20.9 uses k0=1.0 here; the expected values below match
+        // an explicit +k=0.9999, as in testKnownValues.)
         Converter conv = Proj4.proj4(BESSEL_LL,
             "+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +ellps=bessel "
                 + "+pm=greenwich +units=m +no_defs");


### PR DESCRIPTION
## Summary

Corrects an **inverted** description of proj4js behavior in Krovak's scale-factor handling. The comments claimed proj4js applies Krovak's `0.9999` scale factor when `+k` is omitted — it does not.

Verified against **proj4js 2.20.9** and **PROJ 9.5.1 / pyproj 3.7.2**: proj4js's global `k0 = k0 || 1.0` default in `Proj.js` shadows krovak's own `0.9999` fallback, so proj4js projects an S-JTSK/Krovak definition without `+k` using `k0 = 1.0` (a ~128 m positional error vs PROJ). Concretely, for `+proj=krovak ... +ellps=bessel` without `+k`, forward of `(14.42, 50.08)`:
- proj4js → `[-743175.33, -1044003.06]` (k0 = 1.0)
- PROJ / this library → `[-743101.01, -1043898.66]` (k0 = 0.9999)

This library's code is **already correct** (it treats `1.0`/`0` as unset → `0.9999`, matching PROJ); only the explanatory comments in `Krovak.java` and `KrovakTest.java` were wrong. Comment-only change — no behavior change, `KrovakTest` unchanged and green (6/6).
