### PR TITLE
Add CF grid mapping to CRS translation (apache/sedona#3121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,41 @@ CompletableFuture<GridData> future = GridCdnFetcher.fetchAndLoadAsync("ca_nrc_nt
 - **Azimuthal**: Lambert Azimuthal Equal Area, Stereographic, Oblique Stereographic Alternative, Azimuthal Equidistant, Orthographic, Gnomonic, Tilted Perspective
 - **Other**: Geostationary Satellite, New Zealand Map Grid, Geocentric (ECEF), Quadrilateralized Spherical Cube, General Oblique Transformation (rotated pole), Identity (longlat)
 
+## NetCDF CF Grid Mappings
+
+`CfGridMapping` translates CF (Climate and Forecast) convention grid mapping attributes —
+the parameter form used by netCDF files that carry no `crs_wkt` — into a PROJ string or
+`Proj`, following CF conventions Appendix F:
+
+```java
+import org.datasyslab.proj4sedona.cf.CfGridMapping;
+
+Map<String, Object> cf = new HashMap<>();
+cf.put("grid_mapping_name", "lambert_conformal_conic");
+cf.put("standard_parallel", new double[]{33.0, 45.0});
+cf.put("longitude_of_central_meridian", -97.0);
+cf.put("latitude_of_projection_origin", 40.0);
+
+String projString = CfGridMapping.toProjString(cf);
+// "+proj=lcc +lat_1=33 +lat_2=45 +lat_0=40 +lon_0=-97 +datum=WGS84 +no_defs"
+Proj proj = CfGridMapping.toProj(cf);
+String wkt = proj.toWkt2();
+```
+
+Supported grid mappings: `latitude_longitude`, `albers_conical_equal_area`,
+`azimuthal_equidistant`, `geostationary`, `lambert_azimuthal_equal_area`,
+`lambert_conformal_conic` (1SP/2SP), `lambert_cylindrical_equal_area`, `mercator`,
+`orthographic`, `polar_stereographic`, `sinusoidal`, `stereographic`,
+`transverse_mercator`, and netCDF-Java's `universal_transverse_mercator`. Ellipsoid and
+datum attributes (`semi_major_axis`, `inverse_flattening`, `earth_radius`,
+`reference_ellipsoid_name`, `horizontal_datum_name`, ...), prime meridians, `towgs84`,
+and non-metre coordinate units (`toProjString(cf, "km")`) are handled; with no
+identifying figure parameters, WGS 84 is assumed, as GDAL and pyproj do.
+
+This module is a Proj4Sedona extension with no proj4js counterpart; its behavior is
+validated against pyproj's `CRS.from_cf` and GDAL's `importFromCF1` (divergences between
+those two are resolved case by case and documented in the Javadoc).
+
 ## Upstream Sync Status
 
 Proj4Sedona tracks three upstream code bases. The port is complete and audited as of the

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2</version>
     <packaging>jar</packaging>
 
     <name>Proj4Sedona</name>

--- a/src/main/java/org/datasyslab/proj4sedona/cf/CfGridMapping.java
+++ b/src/main/java/org/datasyslab/proj4sedona/cf/CfGridMapping.java
@@ -145,7 +145,8 @@ public final class CfGridMapping {
      *
      * <p>A projected CRS has one linear coordinate unit. CF records the false easting in the
      * x-coordinate unit and the false northing in the y-coordinate unit, so equivalent unit
-     * spellings are accepted but incompatible x/y units are rejected rather than silently
+     * spellings are accepted. When only one axis declares a unit, that unit is used for the
+     * projected CRS; two explicitly incompatible units are rejected rather than silently
      * misscaling one axis.</p>
      *
      * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
@@ -482,32 +483,30 @@ public final class CfGridMapping {
         falseOrigin(cf, unit, parts);
     }
 
-    /** CF {@code stereographic} — PROJ {@code stere} (oblique/equatorial, EPSG 9809). */
+    /**
+     * CF {@code stereographic} — PROJ {@code stere} (oblique/equatorial, EPSG 9809).
+     * Missing origins and scale use the GDAL/pyproj defaults of 0 and 1.
+     */
     private static void stereographic(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
         Double scale = optionalPositiveDouble(cf, "scale_factor_at_projection_origin");
-        if (scale == null) {
-            throw new IllegalArgumentException(
-                "CF stereographic mapping missing 'scale_factor_at_projection_origin'");
-        }
         parts.add("+proj=stere");
         parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
         parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
-        parts.add("+k_0=" + num(scale));
+        parts.add("+k_0=" + num(scale != null ? scale : 1.0));
         falseOrigin(cf, unit, parts);
     }
 
-    /** CF {@code transverse_mercator} — PROJ {@code tmerc}. */
+    /**
+     * CF {@code transverse_mercator} — PROJ {@code tmerc}. Missing origins and scale
+     * use the GDAL/pyproj defaults of 0 and 1.
+     */
     private static void transverseMercator(
             Map<String, ?> cf, LinearUnit unit, List<String> parts) {
         Double scale = optionalPositiveDouble(cf, "scale_factor_at_central_meridian");
-        if (scale == null) {
-            throw new IllegalArgumentException(
-                "CF transverse_mercator mapping missing 'scale_factor_at_central_meridian'");
-        }
         parts.add("+proj=tmerc");
         parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
         parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_central_meridian", 0.0)));
-        parts.add("+k_0=" + num(scale));
+        parts.add("+k_0=" + num(scale != null ? scale : 1.0));
         falseOrigin(cf, unit, parts);
     }
 
@@ -613,6 +612,9 @@ public final class CfGridMapping {
      * @throws IllegalArgumentException if a figure attribute is present but malformed
      */
     public static boolean identifiesEarthShape(Map<String, ?> cfAttributes) {
+        if (cfAttributes == null) {
+            throw new IllegalArgumentException("CF grid mapping attributes cannot be null");
+        }
         return resolveIdentifiedEarthShape(cfAttributes) != null;
     }
 
@@ -650,6 +652,9 @@ public final class CfGridMapping {
      */
     private static EarthShape resolveIdentifiedEarthShape(Map<String, ?> cf) {
         boolean hasTowgs84 = cf.containsKey("towgs84");
+        if (hasTowgs84) {
+            towgs84Values(cf);
+        }
         Datum datum = lookupDatum(stringAttr(cf, "horizontal_datum_name"));
         if (datum != null && figureConsistentWithDatum(cf, datum)) {
             return EarthShape.ofDatum(datum, hasTowgs84);
@@ -664,13 +669,39 @@ public final class CfGridMapping {
         }
         if (semiMajor != null || semiMinor != null || inverseFlattening != null
                 || radius != null) {
+            if (semiMajor != null && semiMajor <= 0) {
+                throw new IllegalArgumentException(
+                    "CF attribute 'semi_major_axis' must be greater than zero, got: " + semiMajor);
+            }
+            if (radius != null && radius <= 0) {
+                throw new IllegalArgumentException(
+                    "CF Earth radius must be greater than zero, got: " + radius);
+            }
+            if (semiMinor != null && semiMinor <= 0) {
+                throw new IllegalArgumentException(
+                    "CF attribute 'semi_minor_axis' must be greater than zero, got: " + semiMinor);
+            }
+            if (inverseFlattening != null && inverseFlattening != 0
+                    && inverseFlattening <= 1) {
+                throw new IllegalArgumentException(
+                    "CF attribute 'inverse_flattening' must be zero or greater than one, got: "
+                        + inverseFlattening);
+            }
             double a = semiMajor != null ? semiMajor : (radius != null ? radius : 0);
             if (a <= 0) {
                 throw new IllegalArgumentException(
                     "CF grid mapping has a semi_minor_axis or inverse_flattening but no "
                         + "semi_major_axis or earth_radius");
             }
-            if (inverseFlattening != null && inverseFlattening != 0) {
+            if (semiMinor != null && semiMinor > a) {
+                throw new IllegalArgumentException(
+                    "CF attribute 'semi_minor_axis' cannot exceed semi_major_axis or earth_radius: "
+                        + semiMinor + " > " + a);
+            }
+            if (inverseFlattening != null) {
+                if (inverseFlattening == 0) {
+                    return new EarthShape(List.of("+R=" + num(a)), 0);
+                }
                 double b = a * (1 - 1 / inverseFlattening);
                 return new EarthShape(
                     List.of("+a=" + num(a), "+rf=" + num(inverseFlattening)),
@@ -829,11 +860,7 @@ public final class CfGridMapping {
         if (!cf.containsKey("towgs84")) {
             return;
         }
-        double[] values = doubleListAttr(cf, "towgs84");
-        if (values.length != 3 && values.length != 6 && values.length != 7) {
-            throw new IllegalArgumentException(
-                "CF grid mapping 'towgs84' must have 3, 6, or 7 values, got " + values.length);
-        }
+        double[] values = towgs84Values(cf);
         StringBuilder joined = new StringBuilder("+towgs84=");
         for (int i = 0; i < values.length; i++) {
             if (i > 0) {
@@ -845,6 +872,15 @@ public final class CfGridMapping {
             joined.append(",0");
         }
         parts.add(joined.toString());
+    }
+
+    private static double[] towgs84Values(Map<String, ?> cf) {
+        double[] values = doubleListAttr(cf, "towgs84");
+        if (values.length != 3 && values.length != 6 && values.length != 7) {
+            throw new IllegalArgumentException(
+                "CF grid mapping 'towgs84' must have 3, 6, or 7 values, got " + values.length);
+        }
+        return values;
     }
 
     // ==================== Linear units ====================
@@ -897,8 +933,16 @@ public final class CfGridMapping {
         }
 
         static LinearUnit resolveCompatible(String xUnits, String yUnits) {
-            LinearUnit x = resolve(xUnits);
-            LinearUnit y = resolve(yUnits);
+            boolean xMissing = xUnits == null || xUnits.trim().isEmpty();
+            boolean yMissing = yUnits == null || yUnits.trim().isEmpty();
+            LinearUnit x = xMissing ? null : resolve(xUnits);
+            LinearUnit y = yMissing ? null : resolve(yUnits);
+            if (x == null) {
+                return y != null ? y : METRE;
+            }
+            if (y == null) {
+                return x;
+            }
             if (x.projCode == null ? y.projCode != null : !x.projCode.equals(y.projCode)) {
                 throw new IllegalArgumentException(
                     "Projection coordinate units differ: x='" + xUnits + "', y='" + yUnits + "'");

--- a/src/main/java/org/datasyslab/proj4sedona/cf/CfGridMapping.java
+++ b/src/main/java/org/datasyslab/proj4sedona/cf/CfGridMapping.java
@@ -90,7 +90,20 @@ public final class CfGridMapping {
      * @throws IllegalArgumentException if the grid mapping is unsupported or malformed
      */
     public static Proj toProj(Map<String, ?> cfAttributes, String xyUnits) {
-        return new Proj(toProjString(cfAttributes, xyUnits));
+        return toProj(cfAttributes, xyUnits, xyUnits);
+    }
+
+    /**
+     * Translate CF grid mapping attributes to a {@link Proj}.
+     *
+     * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
+     * @param xUnits The {@code units} attribute of the projection x coordinate variable
+     * @param yUnits The {@code units} attribute of the projection y coordinate variable
+     * @return The corresponding projection
+     * @throws IllegalArgumentException if the mapping is malformed or the coordinate units differ
+     */
+    public static Proj toProj(Map<String, ?> cfAttributes, String xUnits, String yUnits) {
+        return new Proj(toProjString(cfAttributes, xUnits, yUnits));
     }
 
     /**
@@ -123,6 +136,26 @@ public final class CfGridMapping {
      * @throws IllegalArgumentException if the grid mapping is unsupported or malformed
      */
     public static String toProjString(Map<String, ?> cfAttributes, String xyUnits) {
+        return toProjString(cfAttributes, xyUnits, xyUnits);
+    }
+
+    /**
+     * Translate CF grid mapping attributes to a PROJ string, validating the units of both
+     * projection coordinate axes.
+     *
+     * <p>A projected CRS has one linear coordinate unit. CF records the false easting in the
+     * x-coordinate unit and the false northing in the y-coordinate unit, so equivalent unit
+     * spellings are accepted but incompatible x/y units are rejected rather than silently
+     * misscaling one axis.</p>
+     *
+     * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
+     * @param xUnits The {@code units} attribute of the projection x coordinate variable
+     * @param yUnits The {@code units} attribute of the projection y coordinate variable
+     * @return The corresponding PROJ string
+     * @throws IllegalArgumentException if the mapping is malformed or the coordinate units differ
+     */
+    public static String toProjString(
+            Map<String, ?> cfAttributes, String xUnits, String yUnits) {
         if (cfAttributes == null) {
             throw new IllegalArgumentException("CF grid mapping attributes cannot be null");
         }
@@ -137,7 +170,8 @@ public final class CfGridMapping {
         EarthShape earth = resolveEarthShape(cfAttributes);
         // A geographic grid has angular coordinates; its units say nothing about a
         // false origin, so they are not interpreted (or validated) as linear units.
-        LinearUnit unit = geographic ? LinearUnit.METRE : LinearUnit.resolve(xyUnits);
+        LinearUnit unit = geographic
+            ? LinearUnit.METRE : LinearUnit.resolveCompatible(xUnits, yUnits);
 
         List<String> parts = new ArrayList<>();
         switch (gridMappingName) {
@@ -306,7 +340,7 @@ public final class CfGridMapping {
             parts.add("+lat_2=" + num(parallels[1]));
             parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
         } else {
-            Double scale = optionalDouble(cf, "scale_factor_at_projection_origin");
+            Double scale = optionalPositiveDouble(cf, "scale_factor_at_projection_origin");
             double lat0;
             if (scale == null) {
                 if (parallels == null) {
@@ -337,10 +371,10 @@ public final class CfGridMapping {
      */
     private static void lambertCylindricalEqualArea(
             Map<String, ?> cf, LinearUnit unit, EarthShape earth, List<String> parts) {
-        Double scale = optionalDouble(cf, "scale_factor_at_projection_origin");
+        Double scale = optionalPositiveDouble(cf, "scale_factor_at_projection_origin");
         double latTs;
         if (scale != null) {
-            if (scale <= 0 || scale > 1) {
+            if (scale > 1) {
                 throw new IllegalArgumentException(
                     "CF lambert_cylindrical_equal_area mapping has invalid "
                         + "scale_factor_at_projection_origin: " + scale);
@@ -348,8 +382,13 @@ public final class CfGridMapping {
             double sinSq = (1 - scale * scale) / (1 - scale * scale * earth.es);
             latTs = Math.toDegrees(Math.asin(Math.sqrt(sinSq)));
         } else {
-            double[] parallels = optionalParallels(cf);
-            latTs = parallels != null ? parallels[0] : 0.0;
+            Double parallel = optionalSingleParallel(cf, "lambert_cylindrical_equal_area");
+            if (parallel == null) {
+                throw new IllegalArgumentException(
+                    "CF lambert_cylindrical_equal_area mapping needs 'standard_parallel' or"
+                        + " 'scale_factor_at_projection_origin'");
+            }
+            latTs = parallel;
         }
         parts.add("+proj=cea");
         parts.add("+lat_ts=" + num(latTs));
@@ -368,12 +407,17 @@ public final class CfGridMapping {
      */
     private static void mercator(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
         parts.add("+proj=merc");
-        Double scale = optionalDouble(cf, "scale_factor_at_projection_origin");
+        Double scale = optionalPositiveDouble(cf, "scale_factor_at_projection_origin");
         if (scale != null) {
             parts.add("+k_0=" + num(scale));
         } else {
-            double[] parallels = optionalParallels(cf);
-            parts.add("+lat_ts=" + num(parallels != null ? parallels[0] : 0.0));
+            Double parallel = optionalSingleParallel(cf, "mercator");
+            if (parallel == null) {
+                throw new IllegalArgumentException(
+                    "CF mercator mapping needs 'standard_parallel' or"
+                        + " 'scale_factor_at_projection_origin'");
+            }
+            parts.add("+lat_ts=" + num(parallel));
         }
         parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
         falseOrigin(cf, unit, parts);
@@ -387,24 +431,27 @@ public final class CfGridMapping {
      * it to be ±90) and otherwise from the standard parallel's hemisphere, as pyproj
      * derives it. Without a standard parallel, variant A applies:
      * {@code latitude_of_projection_origin} must be ±90 and
-     * {@code scale_factor_at_projection_origin} (default 1) becomes {@code +k_0}.
-     * {@code straight_vertical_longitude_from_pole} defaults to 0 as in GDAL (pyproj
-     * requires it).</p>
+     * {@code scale_factor_at_projection_origin} becomes {@code +k_0}. The current
+     * {@code longitude_of_projection_origin} name takes precedence over the deprecated
+     * {@code straight_vertical_longitude_from_pole}; either defaults to 0 as in GDAL
+     * when absent (pyproj requires it).</p>
      */
     private static void polarStereographic(
             Map<String, ?> cf, LinearUnit unit, List<String> parts) {
-        double lon0 = doubleAttr(cf, "straight_vertical_longitude_from_pole", 0.0);
+        Double longitude = optionalDouble(cf, "longitude_of_projection_origin");
+        double lon0 = longitude != null
+            ? longitude : doubleAttr(cf, "straight_vertical_longitude_from_pole", 0.0);
         Double latProjOrigin = optionalDouble(cf, "latitude_of_projection_origin");
         if (latProjOrigin != null && latProjOrigin != 90.0 && latProjOrigin != -90.0) {
             throw new IllegalArgumentException(
                 "CF polar_stereographic mapping requires latitude_of_projection_origin"
                     + " = +90 or -90, got: " + latProjOrigin);
         }
-        double[] parallels = optionalParallels(cf);
+        Double parallel = optionalSingleParallel(cf, "polar_stereographic");
         parts.add("+proj=stere");
-        if (parallels != null) {
+        if (parallel != null) {
             // Variant B: standard parallel, k = 1
-            double latTs = parallels[0];
+            double latTs = parallel;
             double pole = latProjOrigin != null ? latProjOrigin : (latTs < 0 ? -90.0 : 90.0);
             parts.add("+lat_0=" + num(pole));
             parts.add("+lat_ts=" + num(latTs));
@@ -416,8 +463,13 @@ public final class CfGridMapping {
                         + " 'latitude_of_projection_origin'");
             }
             parts.add("+lat_0=" + num(latProjOrigin));
-            parts.add("+k_0="
-                + num(doubleAttr(cf, "scale_factor_at_projection_origin", 1.0)));
+            Double scale = optionalPositiveDouble(cf, "scale_factor_at_projection_origin");
+            if (scale == null) {
+                throw new IllegalArgumentException(
+                    "CF polar_stereographic mapping needs 'standard_parallel' or"
+                        + " 'scale_factor_at_projection_origin'");
+            }
+            parts.add("+k_0=" + num(scale));
         }
         parts.add("+lon_0=" + num(lon0));
         falseOrigin(cf, unit, parts);
@@ -432,20 +484,30 @@ public final class CfGridMapping {
 
     /** CF {@code stereographic} — PROJ {@code stere} (oblique/equatorial, EPSG 9809). */
     private static void stereographic(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        Double scale = optionalPositiveDouble(cf, "scale_factor_at_projection_origin");
+        if (scale == null) {
+            throw new IllegalArgumentException(
+                "CF stereographic mapping missing 'scale_factor_at_projection_origin'");
+        }
         parts.add("+proj=stere");
         parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
         parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
-        parts.add("+k_0=" + num(doubleAttr(cf, "scale_factor_at_projection_origin", 1.0)));
+        parts.add("+k_0=" + num(scale));
         falseOrigin(cf, unit, parts);
     }
 
     /** CF {@code transverse_mercator} — PROJ {@code tmerc}. */
     private static void transverseMercator(
             Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        Double scale = optionalPositiveDouble(cf, "scale_factor_at_central_meridian");
+        if (scale == null) {
+            throw new IllegalArgumentException(
+                "CF transverse_mercator mapping missing 'scale_factor_at_central_meridian'");
+        }
         parts.add("+proj=tmerc");
         parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
         parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_central_meridian", 0.0)));
-        parts.add("+k_0=" + num(doubleAttr(cf, "scale_factor_at_central_meridian", 1.0)));
+        parts.add("+k_0=" + num(scale));
         falseOrigin(cf, unit, parts);
     }
 
@@ -465,7 +527,12 @@ public final class CfGridMapping {
             throw new IllegalArgumentException(
                 "CF universal_transverse_mercator mapping missing 'utm_zone_number'");
         }
-        int zone = (int) (double) zoneValue;
+        if (zoneValue != Math.rint(zoneValue)) {
+            throw new IllegalArgumentException(
+                "CF universal_transverse_mercator mapping requires an integer "
+                    + "utm_zone_number, got: " + num(zoneValue));
+        }
+        int zone = (int) Math.rint(zoneValue);
         boolean south = zone < 0;
         zone = Math.abs(zone);
         if (zone < 1 || zone > 60) {
@@ -754,17 +821,18 @@ public final class CfGridMapping {
     }
 
     /**
-     * The {@code towgs84} attribute (3 or 7 Helmert parameters) is not CF but is written
-     * by some producers and read by pyproj's {@code from_cf}.
+     * The CF {@code towgs84} attribute: 3, 6, or 7 Helmert parameters. CF defines a
+     * missing seventh value in the six-parameter form as zero, while PROJ accepts only
+     * 3- or 7-value lists, so the six-parameter form is padded during translation.
      */
     private static void towgs84(Map<String, ?> cf, List<String> parts) {
         if (!cf.containsKey("towgs84")) {
             return;
         }
         double[] values = doubleListAttr(cf, "towgs84");
-        if (values.length != 3 && values.length != 7) {
+        if (values.length != 3 && values.length != 6 && values.length != 7) {
             throw new IllegalArgumentException(
-                "CF grid mapping 'towgs84' must have 3 or 7 values, got " + values.length);
+                "CF grid mapping 'towgs84' must have 3, 6, or 7 values, got " + values.length);
         }
         StringBuilder joined = new StringBuilder("+towgs84=");
         for (int i = 0; i < values.length; i++) {
@@ -772,6 +840,9 @@ public final class CfGridMapping {
                 joined.append(',');
             }
             joined.append(num(values[i]));
+        }
+        if (values.length == 6) {
+            joined.append(",0");
         }
         parts.add(joined.toString());
     }
@@ -824,6 +895,16 @@ public final class CfGridMapping {
                         "Unsupported projection coordinate unit: " + units);
             }
         }
+
+        static LinearUnit resolveCompatible(String xUnits, String yUnits) {
+            LinearUnit x = resolve(xUnits);
+            LinearUnit y = resolve(yUnits);
+            if (x.projCode == null ? y.projCode != null : !x.projCode.equals(y.projCode)) {
+                throw new IllegalArgumentException(
+                    "Projection coordinate units differ: x='" + xUnits + "', y='" + yUnits + "'");
+            }
+            return x;
+        }
     }
 
     // ==================== Attribute coercion ====================
@@ -840,7 +921,16 @@ public final class CfGridMapping {
                 "CF attribute '" + key + "' must be a single number, got "
                     + values.length + " values");
         }
-        return values[0];
+        return finite(values[0], key);
+    }
+
+    private static Double optionalPositiveDouble(Map<String, ?> cf, String key) {
+        Double value = optionalDouble(cf, key);
+        if (value != null && value <= 0) {
+            throw new IllegalArgumentException(
+                "CF attribute '" + key + "' must be greater than zero, got: " + value);
+        }
+        return value;
     }
 
     private static double doubleAttr(Map<String, ?> cf, String key, double defaultValue) {
@@ -867,6 +957,20 @@ public final class CfGridMapping {
         return values;
     }
 
+    /** A standard parallel for mappings which permit exactly one value. */
+    private static Double optionalSingleParallel(Map<String, ?> cf, String gridMappingName) {
+        double[] parallels = optionalParallels(cf);
+        if (parallels == null) {
+            return null;
+        }
+        if (parallels.length != 1) {
+            throw new IllegalArgumentException(
+                "CF " + gridMappingName + " mapping requires exactly one 'standard_parallel', got "
+                    + parallels.length);
+        }
+        return parallels[0];
+    }
+
     private static double[] requireParallels(Map<String, ?> cf, String gridMappingName) {
         double[] parallels = optionalParallels(cf);
         if (parallels == null) {
@@ -881,7 +985,11 @@ public final class CfGridMapping {
         if (value == null) {
             throw new IllegalArgumentException("CF attribute '" + key + "' is missing");
         }
-        return coerceDoubles(value, key);
+        double[] values = coerceDoubles(value, key);
+        for (int i = 0; i < values.length; i++) {
+            values[i] = finite(values[i], key);
+        }
+        return values;
     }
 
     /**
@@ -970,8 +1078,20 @@ public final class CfGridMapping {
         }
     }
 
+    private static double finite(double value, String key) {
+        if (!Double.isFinite(value)) {
+            throw new IllegalArgumentException(
+                "CF attribute '" + key + "' must be finite, got: " + value);
+        }
+        return value;
+    }
+
     /** Plain decimal rendering: integral values without ".0", never scientific notation. */
     private static String num(double value) {
+        if (!Double.isFinite(value)) {
+            throw new IllegalArgumentException(
+                "CF grid mapping produced a non-finite numeric value: " + value);
+        }
         if (value == Math.rint(value) && Math.abs(value) < 1e15) {
             return Long.toString((long) value);
         }

--- a/src/main/java/org/datasyslab/proj4sedona/cf/CfGridMapping.java
+++ b/src/main/java/org/datasyslab/proj4sedona/cf/CfGridMapping.java
@@ -1,0 +1,980 @@
+package org.datasyslab.proj4sedona.cf;
+
+import org.datasyslab.proj4sedona.constants.Datum;
+import org.datasyslab.proj4sedona.constants.Ellipsoid;
+import org.datasyslab.proj4sedona.constants.PrimeMeridian;
+import org.datasyslab.proj4sedona.core.Proj;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Translates NetCDF CF (Climate and Forecast) convention grid mapping attributes to a CRS.
+ *
+ * <p>CF metadata defines a coordinate reference system through a <i>grid mapping variable</i>:
+ * a {@code grid_mapping_name} attribute naming the projection method plus projection and
+ * ellipsoid parameters ({@code standard_parallel}, {@code longitude_of_central_meridian},
+ * {@code semi_major_axis}, ...). The optional {@code crs_wkt} attribute carries a full WKT
+ * string, but many files define the CRS only through the parameter attributes. This class
+ * converts the parameter form to a PROJ string (and from there to a {@link Proj}), following
+ * CF conventions Appendix F.</p>
+ *
+ * <p>This is a proj4sedona extension with no proj4js upstream counterpart. The translation
+ * table follows the two reference implementations, which were used as oracles for the unit
+ * tests: pyproj's {@code CRS.from_cf} ({@code pyproj/crs/_cf1x8.py}, pyproj 3.7.2 / PROJ
+ * 9.5.1) and GDAL's {@code OGRSpatialReference::importFromCF1} ({@code ogr/ogr_srs_cf1.cpp}).
+ * Where the two disagree, the choice is documented on the relevant method.</p>
+ *
+ * <p>Supported {@code grid_mapping_name} values:</p>
+ * <ul>
+ *   <li>{@code latitude_longitude} (geographic CRS)</li>
+ *   <li>{@code albers_conical_equal_area}, {@code azimuthal_equidistant},
+ *       {@code geostationary}, {@code lambert_azimuthal_equal_area},
+ *       {@code lambert_conformal_conic} (1SP and 2SP),
+ *       {@code lambert_cylindrical_equal_area} (and the pre-CF-1.0 alias
+ *       {@code cylindrical_equal_area}), {@code mercator} (variants A and B),
+ *       {@code orthographic}, {@code polar_stereographic} (variants A and B),
+ *       {@code sinusoidal}, {@code stereographic}, {@code transverse_mercator}</li>
+ *   <li>{@code universal_transverse_mercator} — not a CF Appendix F mapping but the
+ *       netCDF-Java (CDM) convention: {@code utm_zone_number} (alias {@code UTM_zone}),
+ *       negative zone numbers meaning the southern hemisphere</li>
+ * </ul>
+ *
+ * <p>Attribute values may be any {@link Number}, numeric {@link String}, primitive numeric
+ * array, {@code Number[]}, or {@code List} of either — whatever a netCDF attribute reader
+ * produces. Multi-valued attributes ({@code standard_parallel}, {@code towgs84}) additionally
+ * accept comma- or whitespace-separated strings.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * Map&lt;String, Object&gt; cf = new HashMap&lt;&gt;();
+ * cf.put("grid_mapping_name", "lambert_conformal_conic");
+ * cf.put("standard_parallel", new double[]{33.0, 45.0});
+ * cf.put("longitude_of_central_meridian", -97.0);
+ * cf.put("latitude_of_projection_origin", 40.0);
+ *
+ * String projString = CfGridMapping.toProjString(cf);
+ * // "+proj=lcc +lat_1=33 +lat_2=45 +lat_0=40 +lon_0=-97 +datum=WGS84 +no_defs"
+ * Proj proj = CfGridMapping.toProj(cf);
+ * </pre>
+ */
+public final class CfGridMapping {
+
+    private CfGridMapping() {
+        // Utility class
+    }
+
+    /**
+     * Translate CF grid mapping attributes to a {@link Proj}, with projection coordinates
+     * in metres.
+     *
+     * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
+     * @return The corresponding projection
+     * @throws IllegalArgumentException if the grid mapping is unsupported or malformed
+     */
+    public static Proj toProj(Map<String, ?> cfAttributes) {
+        return new Proj(toProjString(cfAttributes));
+    }
+
+    /**
+     * Translate CF grid mapping attributes to a {@link Proj}.
+     *
+     * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
+     * @param xyUnits The {@code units} attribute of the projection x/y coordinate
+     *                variables (e.g. {@code "km"}), or null for metres
+     * @return The corresponding projection
+     * @throws IllegalArgumentException if the grid mapping is unsupported or malformed
+     */
+    public static Proj toProj(Map<String, ?> cfAttributes, String xyUnits) {
+        return new Proj(toProjString(cfAttributes, xyUnits));
+    }
+
+    /**
+     * Translate CF grid mapping attributes to a PROJ string, with projection coordinates
+     * in metres.
+     *
+     * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
+     * @return The corresponding PROJ string
+     * @throws IllegalArgumentException if the grid mapping is unsupported or malformed
+     */
+    public static String toProjString(Map<String, ?> cfAttributes) {
+        return toProjString(cfAttributes, null);
+    }
+
+    /**
+     * Translate CF grid mapping attributes to a PROJ string.
+     *
+     * <p>CF requires {@code false_easting}/{@code false_northing} to be in the same units
+     * as the projection coordinates, while PROJ {@code +x_0}/{@code +y_0} are always in
+     * metres — so when {@code xyUnits} names a non-metre linear unit, the false origin is
+     * converted to metres and the unit is emitted as {@code +units=} for the coordinates
+     * (the same split GDAL performs via the PROJCS linear unit). An unrecognized unit
+     * throws rather than silently misscaling the false origin.</p>
+     *
+     * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
+     * @param xyUnits The {@code units} attribute of the projection x/y coordinate
+     *                variables (e.g. {@code "km"}), or null for metres; ignored for
+     *                {@code latitude_longitude} (angular coordinates)
+     * @return The corresponding PROJ string
+     * @throws IllegalArgumentException if the grid mapping is unsupported or malformed
+     */
+    public static String toProjString(Map<String, ?> cfAttributes, String xyUnits) {
+        if (cfAttributes == null) {
+            throw new IllegalArgumentException("CF grid mapping attributes cannot be null");
+        }
+        String name = stringAttr(cfAttributes, "grid_mapping_name");
+        if (name == null) {
+            throw new IllegalArgumentException(
+                "CF grid mapping attributes missing 'grid_mapping_name'");
+        }
+        String gridMappingName = name.trim().toLowerCase(Locale.ROOT);
+        boolean geographic = "latitude_longitude".equals(gridMappingName);
+
+        EarthShape earth = resolveEarthShape(cfAttributes);
+        // A geographic grid has angular coordinates; its units say nothing about a
+        // false origin, so they are not interpreted (or validated) as linear units.
+        LinearUnit unit = geographic ? LinearUnit.METRE : LinearUnit.resolve(xyUnits);
+
+        List<String> parts = new ArrayList<>();
+        switch (gridMappingName) {
+            case "latitude_longitude":
+                parts.add("+proj=longlat");
+                break;
+            case "albers_conical_equal_area":
+                albersConicalEqualArea(cfAttributes, unit, parts);
+                break;
+            case "azimuthal_equidistant":
+                azimuthalProjection("aeqd", cfAttributes, unit, parts);
+                break;
+            case "geostationary":
+                geostationary(cfAttributes, unit, parts);
+                break;
+            case "lambert_azimuthal_equal_area":
+                azimuthalProjection("laea", cfAttributes, unit, parts);
+                break;
+            case "lambert_conformal_conic":
+                lambertConformalConic(cfAttributes, unit, parts);
+                break;
+            case "lambert_cylindrical_equal_area":
+            case "cylindrical_equal_area": // pre-CF-1.0 name, still read by GDAL
+                lambertCylindricalEqualArea(cfAttributes, unit, earth, parts);
+                break;
+            case "mercator":
+                mercator(cfAttributes, unit, parts);
+                break;
+            case "orthographic":
+                azimuthalProjection("ortho", cfAttributes, unit, parts);
+                break;
+            case "polar_stereographic":
+                polarStereographic(cfAttributes, unit, parts);
+                break;
+            case "sinusoidal":
+                sinusoidal(cfAttributes, unit, parts);
+                break;
+            case "stereographic":
+                stereographic(cfAttributes, unit, parts);
+                break;
+            case "transverse_mercator":
+                transverseMercator(cfAttributes, unit, parts);
+                break;
+            case "universal_transverse_mercator":
+                universalTransverseMercator(cfAttributes, parts);
+                break;
+            default:
+                throw new IllegalArgumentException(
+                    "Unsupported CF grid_mapping_name: " + gridMappingName);
+        }
+
+        parts.addAll(earth.tokens);
+        primeMeridian(cfAttributes, parts);
+        towgs84(cfAttributes, parts);
+        if (!geographic && unit.projCode != null) {
+            parts.add("+units=" + unit.projCode);
+        }
+        parts.add("+no_defs");
+        return String.join(" ", parts);
+    }
+
+    // ==================== Per-projection translations ====================
+
+    /**
+     * CF {@code albers_conical_equal_area} — PROJ {@code aea}.
+     *
+     * <p>With a single standard parallel the second is set equal to the first, as GDAL
+     * does; pyproj instead defaults the second parallel to 0, which changes the cone
+     * (an apparent bug in {@code _cf1x8.py}: {@code second_parallel or 0.0}).</p>
+     */
+    private static void albersConicalEqualArea(
+            Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        double[] parallels = requireParallels(cf, "albers_conical_equal_area");
+        double lat1 = parallels[0];
+        double lat2 = parallels.length > 1 ? parallels[1] : parallels[0];
+        parts.add("+proj=aea");
+        parts.add("+lat_1=" + num(lat1));
+        parts.add("+lat_2=" + num(lat2));
+        parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_central_meridian", 0.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /**
+     * The shared azimuthal shape: CF {@code azimuthal_equidistant} / {@code
+     * lambert_azimuthal_equal_area} / {@code orthographic} — PROJ {@code aeqd} /
+     * {@code laea} / {@code ortho}: latitude/longitude of projection origin plus
+     * false origin.
+     */
+    private static void azimuthalProjection(
+            String projCode, Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        parts.add("+proj=" + projCode);
+        parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /**
+     * CF {@code geostationary} — PROJ {@code geos}.
+     *
+     * <p>The sweep angle axis comes from {@code sweep_angle_axis}, or the inverse of
+     * {@code fixed_angle_axis} (CF defines them as perpendicular), defaulting to
+     * {@code y} (the PROJ default, and GDAL's behavior when the attribute is absent;
+     * pyproj instead raises). A non-zero {@code latitude_of_projection_origin} is
+     * rejected — the projection is defined for equatorial orbits only, which PROJ
+     * enforces at setup.</p>
+     */
+    private static void geostationary(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        Double height = optionalDouble(cf, "perspective_point_height");
+        if (height == null) {
+            throw new IllegalArgumentException(
+                "CF geostationary mapping missing 'perspective_point_height'");
+        }
+        double lat0 = doubleAttr(cf, "latitude_of_projection_origin", 0.0);
+        if (lat0 != 0.0) {
+            throw new IllegalArgumentException(
+                "CF geostationary mapping requires latitude_of_projection_origin = 0, got: "
+                    + lat0);
+        }
+        String sweep = stringAttr(cf, "sweep_angle_axis");
+        if (sweep == null) {
+            String fixed = stringAttr(cf, "fixed_angle_axis");
+            if (fixed != null) {
+                sweep = invertAxis(fixed, "fixed_angle_axis");
+            }
+        } else {
+            // Validate through the same x/y check
+            invertAxis(sweep, "sweep_angle_axis");
+        }
+        parts.add("+proj=geos");
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
+        parts.add("+h=" + num(height));
+        parts.add("+sweep=" + (sweep == null ? "y" : sweep.trim().toLowerCase(Locale.ROOT)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    private static String invertAxis(String axis, String attrName) {
+        String normalized = axis.trim().toLowerCase(Locale.ROOT);
+        if ("x".equals(normalized)) {
+            return "y";
+        }
+        if ("y".equals(normalized)) {
+            return "x";
+        }
+        throw new IllegalArgumentException(
+            "CF geostationary mapping has invalid " + attrName + ": " + axis);
+    }
+
+    /**
+     * CF {@code lambert_conformal_conic} — PROJ {@code lcc}.
+     *
+     * <p>Two standard parallels select the 2SP form. With one, the parallel is the
+     * natural origin of the EPSG 1SP method (scale factor 1), as pyproj translates it;
+     * a {@code latitude_of_projection_origin} different from the standard parallel is
+     * ignored, matching pyproj (GDAL instead derives a scale factor via Snyder eq. 15-4,
+     * a conversion it labels experimental). A {@code scale_factor_at_projection_origin}
+     * attribute — not CF, but written by some producers for the 1SP form and read by
+     * GDAL — selects the 1SP method anchored at {@code latitude_of_projection_origin}.</p>
+     */
+    private static void lambertConformalConic(
+            Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        double[] parallels = optionalParallels(cf);
+        parts.add("+proj=lcc");
+        if (parallels != null && parallels.length == 2) {
+            parts.add("+lat_1=" + num(parallels[0]));
+            parts.add("+lat_2=" + num(parallels[1]));
+            parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
+        } else {
+            Double scale = optionalDouble(cf, "scale_factor_at_projection_origin");
+            double lat0;
+            if (scale == null) {
+                if (parallels == null) {
+                    throw new IllegalArgumentException(
+                        "CF lambert_conformal_conic mapping missing 'standard_parallel'");
+                }
+                lat0 = parallels[0];
+                scale = 1.0;
+            } else {
+                lat0 = doubleAttr(cf, "latitude_of_projection_origin", 0.0);
+            }
+            parts.add("+lat_1=" + num(lat0));
+            parts.add("+lat_0=" + num(lat0));
+            parts.add("+k_0=" + num(scale));
+        }
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_central_meridian", 0.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /**
+     * CF {@code lambert_cylindrical_equal_area} — PROJ {@code cea}.
+     *
+     * <p>The scale-factor form is normalized to a standard parallel with the inverse of
+     * the EPSG 9835 scale relation k₀ = cos φ / √(1 − e² sin² φ), i.e.
+     * sin² φ = (1 − k₀²)/(1 − k₀² e²), exactly as PROJ normalizes the EPSG method
+     * (verified against pyproj: k₀ = 0.9 on WGS 84 → φ = 25.9174996918105°). GDAL does
+     * not read the scale-factor form at all.</p>
+     */
+    private static void lambertCylindricalEqualArea(
+            Map<String, ?> cf, LinearUnit unit, EarthShape earth, List<String> parts) {
+        Double scale = optionalDouble(cf, "scale_factor_at_projection_origin");
+        double latTs;
+        if (scale != null) {
+            if (scale <= 0 || scale > 1) {
+                throw new IllegalArgumentException(
+                    "CF lambert_cylindrical_equal_area mapping has invalid "
+                        + "scale_factor_at_projection_origin: " + scale);
+            }
+            double sinSq = (1 - scale * scale) / (1 - scale * scale * earth.es);
+            latTs = Math.toDegrees(Math.asin(Math.sqrt(sinSq)));
+        } else {
+            double[] parallels = optionalParallels(cf);
+            latTs = parallels != null ? parallels[0] : 0.0;
+        }
+        parts.add("+proj=cea");
+        parts.add("+lat_ts=" + num(latTs));
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_central_meridian", 0.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /**
+     * CF {@code mercator} — PROJ {@code merc}.
+     *
+     * <p>CF defines the variants as mutually exclusive: {@code
+     * scale_factor_at_projection_origin} selects variant A ({@code +k_0}), otherwise
+     * {@code standard_parallel} selects variant B ({@code +lat_ts}). When both appear
+     * the scale factor wins, matching pyproj (GDAL checks the standard parallel
+     * first).</p>
+     */
+    private static void mercator(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        parts.add("+proj=merc");
+        Double scale = optionalDouble(cf, "scale_factor_at_projection_origin");
+        if (scale != null) {
+            parts.add("+k_0=" + num(scale));
+        } else {
+            double[] parallels = optionalParallels(cf);
+            parts.add("+lat_ts=" + num(parallels != null ? parallels[0] : 0.0));
+        }
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /**
+     * CF {@code polar_stereographic} — PROJ {@code stere} at a pole.
+     *
+     * <p>A {@code standard_parallel} selects EPSG variant B ({@code +lat_ts}, scale 1);
+     * the pole comes from {@code latitude_of_projection_origin} when present (CF requires
+     * it to be ±90) and otherwise from the standard parallel's hemisphere, as pyproj
+     * derives it. Without a standard parallel, variant A applies:
+     * {@code latitude_of_projection_origin} must be ±90 and
+     * {@code scale_factor_at_projection_origin} (default 1) becomes {@code +k_0}.
+     * {@code straight_vertical_longitude_from_pole} defaults to 0 as in GDAL (pyproj
+     * requires it).</p>
+     */
+    private static void polarStereographic(
+            Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        double lon0 = doubleAttr(cf, "straight_vertical_longitude_from_pole", 0.0);
+        Double latProjOrigin = optionalDouble(cf, "latitude_of_projection_origin");
+        if (latProjOrigin != null && latProjOrigin != 90.0 && latProjOrigin != -90.0) {
+            throw new IllegalArgumentException(
+                "CF polar_stereographic mapping requires latitude_of_projection_origin"
+                    + " = +90 or -90, got: " + latProjOrigin);
+        }
+        double[] parallels = optionalParallels(cf);
+        parts.add("+proj=stere");
+        if (parallels != null) {
+            // Variant B: standard parallel, k = 1
+            double latTs = parallels[0];
+            double pole = latProjOrigin != null ? latProjOrigin : (latTs < 0 ? -90.0 : 90.0);
+            parts.add("+lat_0=" + num(pole));
+            parts.add("+lat_ts=" + num(latTs));
+        } else {
+            // Variant A: scale factor at the pole
+            if (latProjOrigin == null) {
+                throw new IllegalArgumentException(
+                    "CF polar_stereographic mapping needs 'standard_parallel' or"
+                        + " 'latitude_of_projection_origin'");
+            }
+            parts.add("+lat_0=" + num(latProjOrigin));
+            parts.add("+k_0="
+                + num(doubleAttr(cf, "scale_factor_at_projection_origin", 1.0)));
+        }
+        parts.add("+lon_0=" + num(lon0));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /** CF {@code sinusoidal} — PROJ {@code sinu}. */
+    private static void sinusoidal(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        parts.add("+proj=sinu");
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /** CF {@code stereographic} — PROJ {@code stere} (oblique/equatorial, EPSG 9809). */
+    private static void stereographic(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        parts.add("+proj=stere");
+        parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_projection_origin", 0.0)));
+        parts.add("+k_0=" + num(doubleAttr(cf, "scale_factor_at_projection_origin", 1.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /** CF {@code transverse_mercator} — PROJ {@code tmerc}. */
+    private static void transverseMercator(
+            Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        parts.add("+proj=tmerc");
+        parts.add("+lat_0=" + num(doubleAttr(cf, "latitude_of_projection_origin", 0.0)));
+        parts.add("+lon_0=" + num(doubleAttr(cf, "longitude_of_central_meridian", 0.0)));
+        parts.add("+k_0=" + num(doubleAttr(cf, "scale_factor_at_central_meridian", 1.0)));
+        falseOrigin(cf, unit, parts);
+    }
+
+    /**
+     * CDM {@code universal_transverse_mercator} — PROJ {@code utm}.
+     *
+     * <p>Not a CF Appendix F grid mapping: netCDF-Java's {@code UtmProjection} defines it
+     * with a {@code utm_zone_number} attribute (legacy alias {@code UTM_zone}), whose sign
+     * carries the hemisphere — negative zones are south.</p>
+     */
+    private static void universalTransverseMercator(Map<String, ?> cf, List<String> parts) {
+        Double zoneValue = optionalDouble(cf, "utm_zone_number");
+        if (zoneValue == null) {
+            zoneValue = optionalDouble(cf, "UTM_zone");
+        }
+        if (zoneValue == null) {
+            throw new IllegalArgumentException(
+                "CF universal_transverse_mercator mapping missing 'utm_zone_number'");
+        }
+        int zone = (int) (double) zoneValue;
+        boolean south = zone < 0;
+        zone = Math.abs(zone);
+        if (zone < 1 || zone > 60) {
+            throw new IllegalArgumentException(
+                "CF universal_transverse_mercator mapping has invalid utm_zone_number: "
+                    + num(zoneValue));
+        }
+        parts.add("+proj=utm");
+        parts.add("+zone=" + zone);
+        if (south) {
+            parts.add("+south");
+        }
+    }
+
+    /**
+     * False easting/northing, converted from the coordinate unit to the metres PROJ
+     * {@code +x_0}/{@code +y_0} expect. Zero values are omitted.
+     */
+    private static void falseOrigin(Map<String, ?> cf, LinearUnit unit, List<String> parts) {
+        double falseEasting = doubleAttr(cf, "false_easting", 0.0);
+        double falseNorthing = doubleAttr(cf, "false_northing", 0.0);
+        if (falseEasting != 0.0) {
+            parts.add("+x_0=" + num(falseEasting * unit.toMeter));
+        }
+        if (falseNorthing != 0.0) {
+            parts.add("+y_0=" + num(falseNorthing * unit.toMeter));
+        }
+    }
+
+    // ==================== Datum / ellipsoid / prime meridian ====================
+
+    /** Resolved ellipsoid or datum: the PROJ tokens plus the eccentricity the shape implies. */
+    private static final class EarthShape {
+        final List<String> tokens;
+        /** First eccentricity squared, e² = 1 − (b/a)²; 0 for a sphere. */
+        final double es;
+
+        EarthShape(List<String> tokens, double es) {
+            this.tokens = tokens;
+            this.es = es;
+        }
+
+        static EarthShape ofDatum(Datum datum, boolean ellipsoidOnly) {
+            Ellipsoid ellipsoid = Ellipsoid.get(datum.getEllipse());
+            double es = ellipsoid != null
+                ? eccentricitySquared(ellipsoid.getA(), ellipsoid.getB()) : 0;
+            if (ellipsoidOnly) {
+                // An explicit towgs84 attribute carries the datum shift itself; a
+                // +datum= token would bring the registry datum's own (conflicting)
+                // shift parameters, so only the datum's ellipsoid is emitted — the
+                // shape pyproj exports for a CF mapping with towgs84.
+                String ellps = ellipsoid != null ? ellipsoid.getCode() : "WGS84";
+                return new EarthShape(List.of("+ellps=" + ellps), es);
+            }
+            // The registry keys datum codes lowercase; WGS84 keeps its conventional
+            // uppercase PROJ spelling.
+            String code = "wgs84".equalsIgnoreCase(datum.getCode())
+                ? "WGS84" : datum.getCode();
+            return new EarthShape(List.of("+datum=" + code), es);
+        }
+
+        static double eccentricitySquared(double a, double b) {
+            return 1 - (b / a) * (b / a);
+        }
+    }
+
+    /**
+     * Whether the attributes positively identify the Earth figure — a resolvable datum
+     * or ellipsoid name, explicit figure parameters, or Helmert parameters.
+     *
+     * <p>When this is false, {@link #toProjString} still translates the grid mapping but
+     * assumes WGS 84, as GDAL and pyproj do. Callers that must not guess a datum (e.g.
+     * reporting only CRS identities a file actually declares) can use this to decide
+     * whether the assumption would be doing the talking.</p>
+     *
+     * @param cfAttributes The grid mapping variable's attributes, keyed by attribute name
+     * @return true when the attributes identify the Earth figure without the WGS 84 default
+     * @throws IllegalArgumentException if a figure attribute is present but malformed
+     */
+    public static boolean identifiesEarthShape(Map<String, ?> cfAttributes) {
+        return resolveIdentifiedEarthShape(cfAttributes) != null;
+    }
+
+    /**
+     * Resolve the CF ellipsoid/datum attributes to PROJ tokens.
+     *
+     * <p>With nothing identifying the figure, WGS 84 is assumed, as both GDAL and
+     * pyproj do.</p>
+     */
+    private static EarthShape resolveEarthShape(Map<String, ?> cf) {
+        EarthShape identified = resolveIdentifiedEarthShape(cf);
+        return identified != null
+            ? identified
+            : EarthShape.ofDatum(Datum.get("wgs84"), cf.containsKey("towgs84"));
+    }
+
+    /**
+     * The Earth figure the attributes positively identify, or null when only the WGS 84
+     * assumption would remain.
+     *
+     * <p>Following pyproj's {@code _horizontal_datum_from_params}, a resolvable
+     * {@code horizontal_datum_name} wins first — but only when the explicit figure
+     * attributes are consistent with that datum's ellipsoid (pyproj lets the name win
+     * outright, silently discarding contradicting parameters; a file declaring
+     * {@code horizontal_datum_name = "WGS84"} on a GRS 1980 ellipsoid must not be
+     * reported as datum-identified WGS 84). Otherwise explicit figure parameters are
+     * used with GDAL's precedence: inverse flattening, then a semi-minor axis, then a
+     * sphere from {@code earth_radius} (or {@code spherical_earth_radius_meters}, the
+     * pre-CF spelling GDAL still reads) or a lone semi-major axis. Failing that, a
+     * resolvable {@code reference_ellipsoid_name} is used, then {@code
+     * geographic_crs_name} as a datum-name fallback (pyproj resolves it against the full
+     * EPSG database; the registry's datum aliases cover the common cases). Helmert
+     * parameters alone also identify the figure: {@code towgs84} pins the datum shift
+     * even though the ellipsoid stays the WGS 84 default.</p>
+     */
+    private static EarthShape resolveIdentifiedEarthShape(Map<String, ?> cf) {
+        boolean hasTowgs84 = cf.containsKey("towgs84");
+        Datum datum = lookupDatum(stringAttr(cf, "horizontal_datum_name"));
+        if (datum != null && figureConsistentWithDatum(cf, datum)) {
+            return EarthShape.ofDatum(datum, hasTowgs84);
+        }
+
+        Double semiMajor = optionalDouble(cf, "semi_major_axis");
+        Double semiMinor = optionalDouble(cf, "semi_minor_axis");
+        Double inverseFlattening = optionalDouble(cf, "inverse_flattening");
+        Double radius = optionalDouble(cf, "earth_radius");
+        if (radius == null) {
+            radius = optionalDouble(cf, "spherical_earth_radius_meters");
+        }
+        if (semiMajor != null || semiMinor != null || inverseFlattening != null
+                || radius != null) {
+            double a = semiMajor != null ? semiMajor : (radius != null ? radius : 0);
+            if (a <= 0) {
+                throw new IllegalArgumentException(
+                    "CF grid mapping has a semi_minor_axis or inverse_flattening but no "
+                        + "semi_major_axis or earth_radius");
+            }
+            if (inverseFlattening != null && inverseFlattening != 0) {
+                double b = a * (1 - 1 / inverseFlattening);
+                return new EarthShape(
+                    List.of("+a=" + num(a), "+rf=" + num(inverseFlattening)),
+                    EarthShape.eccentricitySquared(a, b));
+            }
+            if (semiMinor != null) {
+                return new EarthShape(
+                    List.of("+a=" + num(a), "+b=" + num(semiMinor)),
+                    EarthShape.eccentricitySquared(a, semiMinor));
+            }
+            return new EarthShape(List.of("+R=" + num(a)), 0);
+        }
+
+        String ellipsoidName = stringAttr(cf, "reference_ellipsoid_name");
+        Ellipsoid ellipsoid = lookupEllipsoid(ellipsoidName);
+        if (ellipsoid != null) {
+            return new EarthShape(
+                List.of("+ellps=" + ellipsoid.getCode()),
+                EarthShape.eccentricitySquared(ellipsoid.getA(), ellipsoid.getB()));
+        }
+
+        Datum crsDatum = lookupDatum(stringAttr(cf, "geographic_crs_name"));
+        if (crsDatum != null && figureConsistentWithDatum(cf, crsDatum)) {
+            return EarthShape.ofDatum(crsDatum, hasTowgs84);
+        }
+
+        if (hasTowgs84) {
+            // The shift parameters identify the datum relationship; the ellipsoid
+            // stays the WGS 84 default, and the +towgs84 token itself is appended
+            // by the caller.
+            return EarthShape.ofDatum(Datum.get("wgs84"), true);
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether the explicit figure attributes are consistent with a named datum's
+     * ellipsoid. Attributes can only veto, never qualify: absent attributes are
+     * consistent, but a present one must match the datum's ellipsoid within the axis
+     * (1 mm) and inverse-flattening (1e-6) tolerances. An {@code earth_radius} always
+     * contradicts (no registry datum is spherical), and a {@code
+     * reference_ellipsoid_name} must resolve to exactly the datum's ellipsoid.
+     */
+    private static boolean figureConsistentWithDatum(Map<String, ?> cf, Datum datum) {
+        Ellipsoid ellipsoid = Ellipsoid.get(datum.getEllipse());
+        String ellipsoidName = stringAttr(cf, "reference_ellipsoid_name");
+        Double semiMajor = optionalDouble(cf, "semi_major_axis");
+        Double semiMinor = optionalDouble(cf, "semi_minor_axis");
+        Double inverseFlattening = optionalDouble(cf, "inverse_flattening");
+        boolean hasRadius = cf.containsKey("earth_radius")
+            || cf.containsKey("spherical_earth_radius_meters");
+        if (ellipsoid == null) {
+            // Datums registered without an ellipsoid reference cannot vouch for any
+            // declared figure attribute
+            return isUnknown(ellipsoidName) && semiMajor == null && semiMinor == null
+                && inverseFlattening == null && !hasRadius;
+        }
+        if (hasRadius) {
+            return false;
+        }
+        if (!isUnknown(ellipsoidName) && lookupEllipsoid(ellipsoidName) != ellipsoid) {
+            return false;
+        }
+        if (semiMajor != null && Math.abs(semiMajor - ellipsoid.getA()) >= 1e-3) {
+            return false;
+        }
+        if (semiMinor != null && Math.abs(semiMinor - ellipsoid.getB()) >= 1e-3) {
+            return false;
+        }
+        return inverseFlattening == null
+            || Math.abs(inverseFlattening - ellipsoid.getRf()) < 1e-6;
+    }
+
+    private static boolean isUnknown(String name) {
+        if (name == null) {
+            return true;
+        }
+        String normalized = name.trim().toLowerCase(Locale.ROOT);
+        return normalized.isEmpty() || "unknown".equals(normalized)
+            || "undefined".equals(normalized);
+    }
+
+    private static Datum lookupDatum(String name) {
+        return isUnknown(name) ? null : Datum.get(name.trim());
+    }
+
+    /**
+     * EPSG ellipsoid names for entries whose registry name (inherited from proj4js's
+     * table) is spelled too differently for normalized matching to find, e.g.
+     * "GRS 1980" vs the registry's "GRS 1980(IUGG, 1980)".
+     */
+    private static final Map<String, Ellipsoid> ELLIPSOID_NAME_ALIASES = new HashMap<>();
+    static {
+        ELLIPSOID_NAME_ALIASES.put("grs1980", Ellipsoid.GRS80);
+        ELLIPSOID_NAME_ALIASES.put("international1924", Ellipsoid.INTL);
+        ELLIPSOID_NAME_ALIASES.put("krassowsky1940", Ellipsoid.KRASS);
+        ELLIPSOID_NAME_ALIASES.put("clarke1880rgs", Ellipsoid.CLRK80);
+        ELLIPSOID_NAME_ALIASES.put("clarke1880", Ellipsoid.CLRK80);
+    }
+
+    /**
+     * Resolve {@code reference_ellipsoid_name} to a registry ellipsoid: by PROJ code
+     * (with the registry's own fuzzy matching, so "WGS 84" and "GRS 80" resolve), then
+     * by normalized ellipsoid name ("Clarke 1866", "Bessel 1841", "Airy 1830", ...),
+     * then through {@link #ELLIPSOID_NAME_ALIASES}.
+     */
+    private static Ellipsoid lookupEllipsoid(String name) {
+        if (isUnknown(name)) {
+            return null;
+        }
+        Ellipsoid byCode = Ellipsoid.get(name.trim());
+        if (byCode != null) {
+            return byCode;
+        }
+        String normalized = normalizeName(name);
+        for (Ellipsoid candidate : Ellipsoid.getAll().values()) {
+            if (candidate.getEllipseName() != null
+                    && normalizeName(candidate.getEllipseName()).equals(normalized)) {
+                return candidate;
+            }
+        }
+        return ELLIPSOID_NAME_ALIASES.get(normalized);
+    }
+
+    private static String normalizeName(String name) {
+        return name.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+    }
+
+    /**
+     * Prime meridian: a non-zero {@code longitude_of_prime_meridian} (degrees east of
+     * Greenwich) is emitted numerically; otherwise a resolvable, non-Greenwich
+     * {@code prime_meridian_name} is emitted by name.
+     */
+    private static void primeMeridian(Map<String, ?> cf, List<String> parts) {
+        Double longitude = optionalDouble(cf, "longitude_of_prime_meridian");
+        if (longitude != null && longitude != 0.0) {
+            parts.add("+pm=" + num(longitude));
+            return;
+        }
+        String name = stringAttr(cf, "prime_meridian_name");
+        if (longitude == null && !isUnknown(name)) {
+            String normalized = name.trim().toLowerCase(Locale.ROOT);
+            if (!"greenwich".equals(normalized) && PrimeMeridian.get(normalized) != null) {
+                parts.add("+pm=" + normalized);
+            }
+        }
+    }
+
+    /**
+     * The {@code towgs84} attribute (3 or 7 Helmert parameters) is not CF but is written
+     * by some producers and read by pyproj's {@code from_cf}.
+     */
+    private static void towgs84(Map<String, ?> cf, List<String> parts) {
+        if (!cf.containsKey("towgs84")) {
+            return;
+        }
+        double[] values = doubleListAttr(cf, "towgs84");
+        if (values.length != 3 && values.length != 7) {
+            throw new IllegalArgumentException(
+                "CF grid mapping 'towgs84' must have 3 or 7 values, got " + values.length);
+        }
+        StringBuilder joined = new StringBuilder("+towgs84=");
+        for (int i = 0; i < values.length; i++) {
+            if (i > 0) {
+                joined.append(',');
+            }
+            joined.append(num(values[i]));
+        }
+        parts.add(joined.toString());
+    }
+
+    // ==================== Linear units ====================
+
+    /**
+     * The linear unit of the projection coordinate variables. CF/UDUNITS spellings are
+     * normalized to PROJ unit codes; metre variants collapse to the PROJ default (no
+     * {@code +units=} emitted).
+     */
+    private static final class LinearUnit {
+        static final LinearUnit METRE = new LinearUnit(null, 1.0);
+
+        /** PROJ {@code +units=} code, or null for metres. */
+        final String projCode;
+        final double toMeter;
+
+        private LinearUnit(String projCode, double toMeter) {
+            this.projCode = projCode;
+            this.toMeter = toMeter;
+        }
+
+        static LinearUnit resolve(String units) {
+            if (units == null || units.trim().isEmpty()) {
+                return METRE;
+            }
+            switch (units.trim().toLowerCase(Locale.ROOT)) {
+                case "m":
+                case "meter":
+                case "meters":
+                case "metre":
+                case "metres":
+                    return METRE;
+                case "km":
+                case "kilometer":
+                case "kilometers":
+                case "kilometre":
+                case "kilometres":
+                    return new LinearUnit("km", 1000.0);
+                case "ft":
+                case "foot":
+                case "feet":
+                    return new LinearUnit("ft", 0.3048);
+                case "us_survey_foot":
+                case "us_survey_feet":
+                    return new LinearUnit("us-ft", 1200.0 / 3937.0);
+                default:
+                    throw new IllegalArgumentException(
+                        "Unsupported projection coordinate unit: " + units);
+            }
+        }
+    }
+
+    // ==================== Attribute coercion ====================
+
+    /** A single numeric attribute; null when absent. Rejects multi-valued attributes. */
+    private static Double optionalDouble(Map<String, ?> cf, String key) {
+        Object value = cf.get(key);
+        if (value == null) {
+            return null;
+        }
+        double[] values = coerceDoubles(value, key);
+        if (values.length != 1) {
+            throw new IllegalArgumentException(
+                "CF attribute '" + key + "' must be a single number, got "
+                    + values.length + " values");
+        }
+        return values[0];
+    }
+
+    private static double doubleAttr(Map<String, ?> cf, String key, double defaultValue) {
+        Double value = optionalDouble(cf, key);
+        return value != null ? value : defaultValue;
+    }
+
+    private static String stringAttr(Map<String, ?> cf, String key) {
+        Object value = cf.get(key);
+        return value instanceof String ? (String) value : null;
+    }
+
+    /** {@code standard_parallel}: 1 or 2 values; null when absent. */
+    private static double[] optionalParallels(Map<String, ?> cf) {
+        if (!cf.containsKey("standard_parallel")) {
+            return null;
+        }
+        double[] values = doubleListAttr(cf, "standard_parallel");
+        if (values.length < 1 || values.length > 2) {
+            throw new IllegalArgumentException(
+                "CF attribute 'standard_parallel' must have 1 or 2 values, got "
+                    + values.length);
+        }
+        return values;
+    }
+
+    private static double[] requireParallels(Map<String, ?> cf, String gridMappingName) {
+        double[] parallels = optionalParallels(cf);
+        if (parallels == null) {
+            throw new IllegalArgumentException(
+                "CF " + gridMappingName + " mapping missing 'standard_parallel'");
+        }
+        return parallels;
+    }
+
+    private static double[] doubleListAttr(Map<String, ?> cf, String key) {
+        Object value = cf.get(key);
+        if (value == null) {
+            throw new IllegalArgumentException("CF attribute '" + key + "' is missing");
+        }
+        return coerceDoubles(value, key);
+    }
+
+    /**
+     * Coerce an attribute value as produced by netCDF readers — a {@link Number}, a
+     * numeric or comma/whitespace-separated {@link String}, a primitive numeric array,
+     * a {@code Number[]}, or a {@link List} of any of these element types.
+     */
+    private static double[] coerceDoubles(Object value, String key) {
+        if (value instanceof Number) {
+            return new double[]{((Number) value).doubleValue()};
+        }
+        if (value instanceof String) {
+            String[] tokens = ((String) value).trim().split("[,\\s]+");
+            double[] result = new double[tokens.length];
+            for (int i = 0; i < tokens.length; i++) {
+                result[i] = parseDouble(tokens[i], key);
+            }
+            return result;
+        }
+        if (value instanceof double[]) {
+            return ((double[]) value).clone();
+        }
+        if (value instanceof float[]) {
+            float[] floats = (float[]) value;
+            double[] result = new double[floats.length];
+            for (int i = 0; i < floats.length; i++) {
+                result[i] = floats[i];
+            }
+            return result;
+        }
+        if (value instanceof int[]) {
+            int[] ints = (int[]) value;
+            double[] result = new double[ints.length];
+            for (int i = 0; i < ints.length; i++) {
+                result[i] = ints[i];
+            }
+            return result;
+        }
+        if (value instanceof long[]) {
+            long[] longs = (long[]) value;
+            double[] result = new double[longs.length];
+            for (int i = 0; i < longs.length; i++) {
+                result[i] = longs[i];
+            }
+            return result;
+        }
+        if (value instanceof Object[]) {
+            Object[] objects = (Object[]) value;
+            double[] result = new double[objects.length];
+            for (int i = 0; i < objects.length; i++) {
+                result[i] = coerceScalar(objects[i], key);
+            }
+            return result;
+        }
+        if (value instanceof List) {
+            List<?> list = (List<?>) value;
+            double[] result = new double[list.size()];
+            for (int i = 0; i < list.size(); i++) {
+                result[i] = coerceScalar(list.get(i), key);
+            }
+            return result;
+        }
+        throw new IllegalArgumentException(
+            "CF attribute '" + key + "' has unsupported value type: "
+                + value.getClass().getName());
+    }
+
+    private static double coerceScalar(Object value, String key) {
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        if (value instanceof String) {
+            return parseDouble((String) value, key);
+        }
+        throw new IllegalArgumentException(
+            "CF attribute '" + key + "' has unsupported element type: "
+                + (value == null ? "null" : value.getClass().getName()));
+    }
+
+    private static double parseDouble(String value, String key) {
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                "CF attribute '" + key + "' has non-numeric value: " + value, e);
+        }
+    }
+
+    /** Plain decimal rendering: integral values without ".0", never scientific notation. */
+    private static String num(double value) {
+        if (value == Math.rint(value) && Math.abs(value) < 1e15) {
+            return Long.toString((long) value);
+        }
+        return BigDecimal.valueOf(value).stripTrailingZeros().toPlainString();
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -661,18 +661,8 @@ public final class CRSSerializer {
     }
 
     private static void appendWkt1Unit(StringBuilder sb, ProjectionParams params) {
-        String unitName = "metre";
-        double toMeter = 1.0;
-
-        if (params.units != null) {
-            unitName = getUnitName(params.units);
-            Double tm = Units.getToMeter(params.units);
-            if (tm != null) {
-                toMeter = tm;
-            }
-        } else if (params.toMeter != null) {
-            toMeter = params.toMeter;
-        }
+        String unitName = params.units != null ? getUnitName(params.units) : "metre";
+        double toMeter = linearUnitToMeter(params);
 
         sb.append(",UNIT[\"").append(unitName).append("\",").append(toMeter).append("]");
     }
@@ -882,36 +872,16 @@ public final class CRSSerializer {
     }
 
     private static void appendWkt2Unit(StringBuilder sb, ProjectionParams params) {
-        String unitName = "metre";
-        double toMeter = 1.0;
-
-        if (params.units != null) {
-            unitName = getUnitName(params.units);
-            Double tm = Units.getToMeter(params.units);
-            if (tm != null) {
-                toMeter = tm;
-            }
-        } else if (params.toMeter != null) {
-            toMeter = params.toMeter;
-        }
+        String unitName = params.units != null ? getUnitName(params.units) : "metre";
+        double toMeter = linearUnitToMeter(params);
 
         sb.append("LENGTHUNIT[\"").append(unitName).append("\",").append(toMeter).append("]");
     }
 
     private static void appendWkt2LengthUnit(StringBuilder sb, ProjectionParams params) {
-        double toMeter = 1.0;
-        String unitName = "metre";
-        
-        if (params.units != null) {
-            unitName = getUnitName(params.units);
-            Double tm = Units.getToMeter(params.units);
-            if (tm != null) {
-                toMeter = tm;
-            }
-        } else if (params.toMeter != null) {
-            toMeter = params.toMeter;
-        }
-        
+        String unitName = params.units != null ? getUnitName(params.units) : "metre";
+        double toMeter = linearUnitToMeter(params);
+
         sb.append(",LENGTHUNIT[\"").append(unitName).append("\",").append(toMeter).append("]");
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -609,13 +609,31 @@ public final class CRSSerializer {
             sb.append(",PARAMETER[\"scale_factor\",").append(params.k0).append("]");
         }
 
-        // False easting/northing
+        // False easting/northing. The internal values are metres; WKT1 linear
+        // parameters are expressed in the PROJCS UNIT, and parsers (including our
+        // own WktProcessor, following wkt-parser) scale them back by that unit.
+        double unitToMeter = linearUnitToMeter(params);
         if (params.x0 != 0.0) {
-            sb.append(",PARAMETER[\"false_easting\",").append(params.x0).append("]");
+            sb.append(",PARAMETER[\"false_easting\",").append(params.x0 / unitToMeter).append("]");
         }
         if (params.y0 != 0.0) {
-            sb.append(",PARAMETER[\"false_northing\",").append(params.y0).append("]");
+            sb.append(",PARAMETER[\"false_northing\",").append(params.y0 / unitToMeter).append("]");
         }
+    }
+
+    /**
+     * The metre factor of the CRS's linear unit, with the same precedence the unit
+     * emitters use: a named unit's registry factor first, then an explicit to_meter,
+     * else metres.
+     */
+    private static double linearUnitToMeter(ProjectionParams params) {
+        if (params.units != null) {
+            Double tm = Units.getToMeter(params.units);
+            if (tm != null) {
+                return tm;
+            }
+        }
+        return params.toMeter != null ? params.toMeter : 1.0;
     }
 
     private static void appendWkt1OmercParams(StringBuilder sb, ProjectionParams params) {
@@ -835,16 +853,20 @@ public final class CRSSerializer {
             sb.append(params.k0).append(",SCALEUNIT[\"unity\",1]]");
         }
 
-        // False easting/northing
+        // False easting/northing. The internal values are metres; a WKT2 parameter
+        // value is expressed in the LENGTHUNIT it is tagged with, and parsers
+        // (including our own WktProcessor, following wkt-parser) scale it back by
+        // that unit's factor.
+        double unitToMeter = linearUnitToMeter(params);
         if (params.x0 != 0.0) {
             sb.append(",PARAMETER[\"False easting\",");
-            sb.append(params.x0);
+            sb.append(params.x0 / unitToMeter);
             appendWkt2LengthUnit(sb, params);
             sb.append("]");
         }
         if (params.y0 != 0.0) {
             sb.append(",PARAMETER[\"False northing\",");
-            sb.append(params.y0);
+            sb.append(params.y0 / unitToMeter);
             appendWkt2LengthUnit(sb, params);
             sb.append("]");
         }
@@ -1343,6 +1365,13 @@ public final class CRSSerializer {
             return null;
         }
 
+        // Every mapped EPSG geographic CRS uses the Greenwich prime meridian, so a
+        // non-zero offset (e.g. +datum=WGS84 +pm=paris) disqualifies the datum-name
+        // shortcut outright.
+        if (params.fromGreenwich != null && params.fromGreenwich != 0.0) {
+            return null;
+        }
+
         // Try datumCode (set from PROJJSON datum.name or PROJ +datum flag).
         // The name alone is not enough: explicit +a/+b (or +ellps=) override the
         // datum's ellipsoid at parse, so +datum=WGS84 +a=6378137 +b=6300000 must
@@ -1571,6 +1600,15 @@ public final class CRSSerializer {
                 return false;
             }
             if (!closeEnough(params.long0, refParams.long0, 1e-9)) {
+                return false;
+            }
+
+            // Check the prime meridian: a null offset means Greenwich (0), and a
+            // non-Greenwich meridian (+pm=paris) must not match a Greenwich-based
+            // definition even when every other parameter agrees.
+            double pmOffset = params.fromGreenwich != null ? params.fromGreenwich : 0.0;
+            double refPmOffset = refParams.fromGreenwich != null ? refParams.fromGreenwich : 0.0;
+            if (Math.abs(pmOffset - refPmOffset) > 1e-9) {
                 return false;
             }
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -627,13 +627,22 @@ public final class CRSSerializer {
      * else metres.
      */
     private static double linearUnitToMeter(ProjectionParams params) {
+        double toMeter;
         if (params.units != null) {
             Double tm = Units.getToMeter(params.units);
             if (tm != null) {
-                return tm;
+                toMeter = tm;
+            } else {
+                toMeter = params.toMeter != null ? params.toMeter : 1.0;
             }
+        } else {
+            toMeter = params.toMeter != null ? params.toMeter : 1.0;
         }
-        return params.toMeter != null ? params.toMeter : 1.0;
+        if (!Double.isFinite(toMeter) || toMeter <= 0) {
+            throw new IllegalArgumentException(
+                "Linear unit conversion factor must be finite and greater than zero: " + toMeter);
+        }
+        return toMeter;
     }
 
     private static void appendWkt1OmercParams(StringBuilder sb, ProjectionParams params) {

--- a/src/test/java/org/datasyslab/proj4sedona/cf/CfGridMappingTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/cf/CfGridMappingTest.java
@@ -1,0 +1,875 @@
+package org.datasyslab.proj4sedona.cf;
+
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for the CF grid mapping translator.
+ *
+ * <p>Expected coordinates come from pyproj 3.7.2 / PROJ 9.5.1 as the oracle: each CF
+ * attribute map was fed to {@code pyproj.CRS.from_cf} and a sample geographic point
+ * transformed from EPSG:4326 with {@code always_xy=True}. Cases where the translation
+ * deliberately diverges from pyproj (single-parallel Albers, GDAL-style leniency) note
+ * the oracle used instead.</p>
+ */
+class CfGridMappingTest {
+
+    private static final String WGS84 = "+proj=longlat +datum=WGS84";
+
+    @BeforeAll
+    static void setup() {
+        ProjectionRegistry.start();
+    }
+
+    private static Map<String, Object> cf(Object... keyValues) {
+        Map<String, Object> attrs = new HashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            attrs.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return attrs;
+    }
+
+    /** Transform a WGS 84 lon/lat with the translated CRS and compare to the oracle. */
+    private static void assertProjects(
+            Map<String, Object> cfAttrs, String xyUnits,
+            double lon, double lat, double expectedX, double expectedY, double tolerance) {
+        String projString = CfGridMapping.toProjString(cfAttrs, xyUnits);
+        double[] result = Proj4.proj4(WGS84, projString, new double[]{lon, lat});
+        assertEquals(expectedX, result[0], tolerance, "x for " + projString);
+        assertEquals(expectedY, result[1], tolerance, "y for " + projString);
+    }
+
+    // ==================== latitude_longitude ====================
+
+    @Test
+    @DisplayName("latitude_longitude: bare mapping assumes WGS 84 like GDAL and pyproj")
+    void testLatitudeLongitudeBare() {
+        Map<String, Object> attrs = cf("grid_mapping_name", "latitude_longitude");
+        assertEquals("+proj=longlat +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        assertEquals("EPSG:4326", CfGridMapping.toProj(attrs).toEpsgCode());
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: verbose WGS 84 datum name resolves to +datum")
+    void testLatitudeLongitudeDatumName() {
+        assertEquals("+proj=longlat +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "horizontal_datum_name", "World Geodetic System 1984")));
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: NAD83 datum name identifies EPSG:4269")
+    void testLatitudeLongitudeNad83() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "latitude_longitude",
+            "horizontal_datum_name", "North American Datum 1983");
+        assertEquals("+proj=longlat +datum=nad83 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        assertEquals("EPSG:4269", CfGridMapping.toProj(attrs).toEpsgCode());
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: earth_radius builds a sphere")
+    void testLatitudeLongitudeSphere() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "latitude_longitude",
+            "earth_radius", 6371000.0);
+        assertEquals("+proj=longlat +R=6371000 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: identity for the geographic coordinates themselves
+        assertProjects(attrs, null, -100.0, 35.0, -100.0, 35.0, 1e-9);
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: semi-major axis with inverse flattening")
+    void testLatitudeLongitudeAxisAndFlattening() {
+        assertEquals("+proj=longlat +a=6378137 +rf=298.257222101 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "semi_major_axis", 6378137.0,
+                "inverse_flattening", 298.257222101)));
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: semi-major with semi-minor axis")
+    void testLatitudeLongitudeAxes() {
+        assertEquals("+proj=longlat +a=6378137 +b=6356752.314245 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "semi_major_axis", 6378137.0,
+                "semi_minor_axis", 6356752.314245)));
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: EPSG ellipsoid names resolve to +ellps codes")
+    void testLatitudeLongitudeEllipsoidNames() {
+        assertEquals("+proj=longlat +ellps=GRS80 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "reference_ellipsoid_name", "GRS 1980")));
+        assertEquals("+proj=longlat +ellps=clrk66 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "reference_ellipsoid_name", "Clarke 1866")));
+        assertEquals("+proj=longlat +ellps=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "reference_ellipsoid_name", "WGS 84")));
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: geographic_crs_name is a datum-name fallback")
+    void testLatitudeLongitudeGeographicCrsName() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "latitude_longitude",
+            "geographic_crs_name", "WGS 84");
+        assertEquals("+proj=longlat +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: explicit figure parameters beat the datum-name fallback order")
+    void testUnknownDatumNameFallsToParameters() {
+        assertEquals("+proj=longlat +a=6378137 +rf=298.257223563 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "horizontal_datum_name", "unknown",
+                "semi_major_axis", 6378137.0,
+                "inverse_flattening", 298.257223563)));
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: non-Greenwich prime meridian shifts longitudes")
+    void testLatitudeLongitudePrimeMeridian() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "latitude_longitude",
+            "semi_major_axis", 6378137.0,
+            "inverse_flattening", 298.257223563,
+            "longitude_of_prime_meridian", 2.5969213,
+            "prime_meridian_name", "Paris");
+        String projString = CfGridMapping.toProjString(attrs);
+        assertTrue(projString.contains("+pm=2.5969213"), projString);
+        // pyproj: (-100, 35) -> (-102.5969213, 35)
+        assertProjects(attrs, null, -100.0, 35.0, -102.5969213, 35.0, 1e-9);
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: named prime meridian without a longitude value")
+    void testLatitudeLongitudeNamedPrimeMeridian() {
+        String projString = CfGridMapping.toProjString(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "prime_meridian_name", "Paris"));
+        assertTrue(projString.contains("+pm=paris"), projString);
+    }
+
+    @Test
+    @DisplayName("latitude_longitude: angular coordinate units are not linear-validated")
+    void testLatitudeLongitudeIgnoresAngularUnits() {
+        assertEquals("+proj=longlat +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(
+                cf("grid_mapping_name", "latitude_longitude"), "degrees_east"));
+    }
+
+    // ==================== mercator ====================
+
+    @Test
+    @DisplayName("mercator: standard parallel selects variant B (+lat_ts)")
+    void testMercatorVariantB() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "mercator",
+            "standard_parallel", 20.0,
+            "longitude_of_projection_origin", -80.5,
+            "false_easting", 1000.0,
+            "false_northing", 2000.0);
+        assertEquals(
+            "+proj=merc +lat_ts=20 +lon_0=-80.5 +x_0=1000 +y_0=2000 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-75, 25) -> (576558.9747042408, 2688404.7184919477)
+        assertProjects(attrs, null, -75.0, 25.0, 576558.9747042408, 2688404.7184919477, 1e-3);
+    }
+
+    @Test
+    @DisplayName("mercator: scale factor selects variant A (+k_0)")
+    void testMercatorVariantA() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "mercator",
+            "scale_factor_at_projection_origin", 0.9996,
+            "longitude_of_projection_origin", -80.5);
+        assertEquals("+proj=merc +k_0=0.9996 +lon_0=-80.5 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-75, 25) -> (612012.2964832595, 2856549.534116069)
+        assertProjects(attrs, null, -75.0, 25.0, 612012.2964832595, 2856549.534116069, 1e-3);
+    }
+
+    // ==================== transverse_mercator / UTM ====================
+
+    @Test
+    @DisplayName("transverse_mercator: full parameter set")
+    void testTransverseMercator() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "transverse_mercator",
+            "latitude_of_projection_origin", 0.0,
+            "longitude_of_central_meridian", -123.0,
+            "scale_factor_at_central_meridian", 0.9996,
+            "false_easting", 500000.0,
+            "false_northing", 0.0);
+        assertEquals(
+            "+proj=tmerc +lat_0=0 +lon_0=-123 +k_0=0.9996 +x_0=500000 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-122, 47.6) -> (575169.9645693353, 5272327.878876387)
+        assertProjects(attrs, null, -122.0, 47.6, 575169.9645693353, 5272327.878876387, 1e-3);
+    }
+
+    @Test
+    @DisplayName("universal_transverse_mercator: positive zone is north")
+    void testUtmNorth() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "universal_transverse_mercator",
+            "utm_zone_number", 33);
+        assertEquals("+proj=utm +zone=33 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: EPSG:32633, (15.5, 52) -> (534325.167454962, 5761156.235698992)
+        assertProjects(attrs, null, 15.5, 52.0, 534325.167454962, 5761156.235698992, 1e-3);
+    }
+
+    @Test
+    @DisplayName("universal_transverse_mercator: negative zone is south (CDM convention)")
+    void testUtmSouth() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "universal_transverse_mercator",
+            "utm_zone_number", -33);
+        assertEquals("+proj=utm +zone=33 +south +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: EPSG:32733, (15.5, -30) -> (548224.1512265288, 6681109.436954567)
+        assertProjects(attrs, null, 15.5, -30.0, 548224.1512265288, 6681109.436954567, 1e-3);
+    }
+
+    @Test
+    @DisplayName("universal_transverse_mercator: legacy UTM_zone alias")
+    void testUtmZoneAlias() {
+        assertEquals("+proj=utm +zone=17 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "universal_transverse_mercator",
+                "UTM_zone", 17)));
+    }
+
+    // ==================== lambert_conformal_conic ====================
+
+    @Test
+    @DisplayName("lambert_conformal_conic: two standard parallels select the 2SP form")
+    void testLambertConformalConic2SP() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "lambert_conformal_conic",
+            "standard_parallel", new double[]{33.0, 45.0},
+            "longitude_of_central_meridian", -97.0,
+            "latitude_of_projection_origin", 40.0);
+        assertEquals("+proj=lcc +lat_1=33 +lat_2=45 +lat_0=40 +lon_0=-97 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-100, 35) -> (-272997.97662925394, -547779.5422659346)
+        assertProjects(attrs, null, -100.0, 35.0,
+            -272997.97662925394, -547779.5422659346, 1e-3);
+    }
+
+    @Test
+    @DisplayName("lambert_conformal_conic: one standard parallel is the 1SP natural origin")
+    void testLambertConformalConic1SP() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "lambert_conformal_conic",
+            "standard_parallel", 25.0,
+            "longitude_of_central_meridian", -95.0,
+            "latitude_of_projection_origin", 25.0);
+        assertEquals("+proj=lcc +lat_1=25 +lat_0=25 +k_0=1 +lon_0=-95 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-100, 35) -> (-463549.29671087995, 1122854.9752173377)
+        assertProjects(attrs, null, -100.0, 35.0,
+            -463549.29671087995, 1122854.9752173377, 1e-3);
+    }
+
+    @Test
+    @DisplayName("lambert_conformal_conic 1SP: a differing projection origin is ignored, as pyproj")
+    void testLambertConformalConic1SPDifferingOrigin() {
+        // pyproj anchors the 1SP natural origin at the standard parallel and ignores
+        // latitude_of_projection_origin; GDAL instead derives a scale factor via
+        // Snyder eq. 15-4 (flagged experimental there, bug #3324).
+        assertEquals("+proj=lcc +lat_1=25 +lat_0=25 +k_0=1 +lon_0=-95 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "lambert_conformal_conic",
+                "standard_parallel", 25.0,
+                "longitude_of_central_meridian", -95.0,
+                "latitude_of_projection_origin", 26.0)));
+    }
+
+    @Test
+    @DisplayName("lambert_conformal_conic 1SP: non-CF scale factor form, as GDAL reads it")
+    void testLambertConformalConic1SPScaleFactor() {
+        assertEquals(
+            "+proj=lcc +lat_1=36 +lat_0=36 +k_0=0.9986 +lon_0=-95 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "lambert_conformal_conic",
+                "scale_factor_at_projection_origin", 0.9986,
+                "longitude_of_central_meridian", -95.0,
+                "latitude_of_projection_origin", 36.0)));
+    }
+
+    // ==================== polar_stereographic ====================
+
+    @Test
+    @DisplayName("polar_stereographic: standard parallel selects variant B")
+    void testPolarStereographicVariantB() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "polar_stereographic",
+            "standard_parallel", 70.0,
+            "straight_vertical_longitude_from_pole", -45.0,
+            "latitude_of_projection_origin", 90.0);
+        assertEquals("+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-30, 75) -> (422879.13134797517, -1578206.403651236)
+        assertProjects(attrs, null, -30.0, 75.0, 422879.13134797517, -1578206.403651236, 1e-3);
+    }
+
+    @Test
+    @DisplayName("polar_stereographic variant B: pole derived from the parallel's hemisphere")
+    void testPolarStereographicVariantBSouth() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "polar_stereographic",
+            "standard_parallel", -71.0,
+            "straight_vertical_longitude_from_pole", 0.0);
+        assertEquals("+proj=stere +lat_0=-90 +lat_ts=-71 +lon_0=0 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (45, -75) -> (1158794.7407726075, 1158794.7407726077)
+        assertProjects(attrs, null, 45.0, -75.0, 1158794.7407726075, 1158794.7407726077, 1e-3);
+    }
+
+    @Test
+    @DisplayName("polar_stereographic: scale factor selects variant A")
+    void testPolarStereographicVariantA() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "polar_stereographic",
+            "latitude_of_projection_origin", -90.0,
+            "straight_vertical_longitude_from_pole", 0.0,
+            "scale_factor_at_projection_origin", 0.994);
+        assertEquals("+proj=stere +lat_0=-90 +k_0=0.994 +lon_0=0 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (45, -75) -> (1184085.7974123128, 1184085.7974123128)
+        assertProjects(attrs, null, 45.0, -75.0, 1184085.7974123128, 1184085.7974123128, 1e-3);
+    }
+
+    @Test
+    @DisplayName("polar_stereographic: the projection origin must be a pole")
+    void testPolarStereographicRequiresPole() {
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "polar_stereographic",
+                "latitude_of_projection_origin", 45.0,
+                "straight_vertical_longitude_from_pole", 0.0)));
+        // Variant A without any latitude_of_projection_origin
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "polar_stereographic",
+                "scale_factor_at_projection_origin", 0.994)));
+    }
+
+    // ==================== stereographic ====================
+
+    @Test
+    @DisplayName("stereographic: oblique case on Bessel 1841 (RD-style parameters)")
+    void testStereographicOblique() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "stereographic",
+            "latitude_of_projection_origin", 52.15616055555555,
+            "longitude_of_projection_origin", 5.38763888888889,
+            "scale_factor_at_projection_origin", 0.9999079,
+            "false_easting", 155000.0,
+            "false_northing", 463000.0,
+            "semi_major_axis", 6377397.155,
+            "inverse_flattening", 299.1528128);
+        // pyproj: (5, 52) -> (128383.70882521641, 445698.7003830712)
+        assertProjects(attrs, null, 5.0, 52.0, 128383.70882521641, 445698.7003830712, 1e-3);
+    }
+
+    // ==================== albers_conical_equal_area ====================
+
+    @Test
+    @DisplayName("albers_conical_equal_area: two standard parallels")
+    void testAlbers2SP() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "albers_conical_equal_area",
+            "standard_parallel", List.of(29.5, 45.5),
+            "longitude_of_central_meridian", -96.0,
+            "latitude_of_projection_origin", 23.0);
+        assertEquals(
+            "+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-100, 35) -> (-361961.77654349455, 1334419.5069948842)
+        assertProjects(attrs, null, -100.0, 35.0, -361961.77654349455, 1334419.5069948842, 1e-3);
+    }
+
+    @Test
+    @DisplayName("albers_conical_equal_area: a single parallel is duplicated, as GDAL")
+    void testAlbers1SPDuplicatesParallel() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "albers_conical_equal_area",
+            "standard_parallel", 29.5,
+            "longitude_of_central_meridian", -96.0,
+            "latitude_of_projection_origin", 23.0);
+        // GDAL duplicates the first parallel; pyproj defaults the second parallel to 0,
+        // which silently changes the cone. Expected value from PROJ 9.5.1 for
+        // +proj=aea +lat_1=29.5 +lat_2=29.5 +lat_0=23 +lon_0=-96 +datum=WGS84:
+        assertEquals(
+            "+proj=aea +lat_1=29.5 +lat_2=29.5 +lat_0=23 +lon_0=-96 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        assertProjects(attrs, null, -100.0, 35.0,
+            -366859.23139493144, 1333923.9009652464, 1e-3);
+    }
+
+    // ==================== other projections ====================
+
+    @Test
+    @DisplayName("lambert_azimuthal_equal_area on GRS 80 (ETRS89-LAEA-style parameters)")
+    void testLambertAzimuthalEqualArea() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "lambert_azimuthal_equal_area",
+            "latitude_of_projection_origin", 52.0,
+            "longitude_of_projection_origin", 10.0,
+            "false_easting", 4321000.0,
+            "false_northing", 3210000.0,
+            "semi_major_axis", 6378137.0,
+            "inverse_flattening", 298.257222101);
+        // pyproj: (5, 52) -> (3977921.1759082996, 3221773.634434365)
+        assertProjects(attrs, null, 5.0, 52.0, 3977921.1759082996, 3221773.634434365, 1e-3);
+    }
+
+    @Test
+    @DisplayName("azimuthal_equidistant")
+    void testAzimuthalEquidistant() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "azimuthal_equidistant",
+            "latitude_of_projection_origin", 40.0,
+            "longitude_of_projection_origin", -100.0);
+        // pyproj: (-95, 35) -> (456802.6959157313, -542560.7336703506)
+        assertProjects(attrs, null, -95.0, 35.0, 456802.6959157313, -542560.7336703506, 1e-3);
+    }
+
+    @Test
+    @DisplayName("orthographic")
+    void testOrthographic() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "orthographic",
+            "latitude_of_projection_origin", 40.0,
+            "longitude_of_projection_origin", -100.0);
+        // The translation matches pyproj; the expected values are PROJ 9.5.1 for
+        // +proj=ortho +lat_0=40 +lon_0=-100 +R=6378137 because proj4js (and this
+        // port) implements the spherical orthographic evaluated on the semi-major
+        // axis, while PROJ computes the ellipsoidal form on an ellipsoidal CRS
+        // (which puts (-95, 35) at x=455861.736, ~500 m away).
+        assertProjects(attrs, null, -95.0, 35.0, 455359.46824163693, -543111.7347346254, 1e-3);
+    }
+
+    @Test
+    @DisplayName("sinusoidal on the MODIS sphere")
+    void testSinusoidal() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "sinusoidal",
+            "longitude_of_projection_origin", 0.0,
+            "earth_radius", 6371007.181);
+        assertEquals("+proj=sinu +lon_0=0 +R=6371007.181 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-100, 35) -> (-9108565.414149545, 3891826.819182831)
+        assertProjects(attrs, null, -100.0, 35.0, -9108565.414149545, 3891826.819182831, 1e-3);
+    }
+
+    @Test
+    @DisplayName("lambert_cylindrical_equal_area: standard parallel form")
+    void testCylindricalEqualArea() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "lambert_cylindrical_equal_area",
+            "standard_parallel", 30.0,
+            "longitude_of_central_meridian", -75.0);
+        assertEquals("+proj=cea +lat_ts=30 +lon_0=-75 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+        // pyproj: (-70, 35) -> (482431.4012544832, 4198673.820940024)
+        assertProjects(attrs, null, -70.0, 35.0, 482431.4012544832, 4198673.820940024, 1e-3);
+    }
+
+    @Test
+    @DisplayName("lambert_cylindrical_equal_area: scale factor normalized to a parallel")
+    void testCylindricalEqualAreaScaleFactor() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "lambert_cylindrical_equal_area",
+            "scale_factor_at_projection_origin", 0.9,
+            "longitude_of_central_meridian", -75.0);
+        // pyproj normalizes k0=0.9 on WGS 84 to lat_ts=25.9174996918105 and gives
+        // (-70, 35) -> (500937.70856973197, 4043560.8264148985)
+        assertProjects(attrs, null, -70.0, 35.0, 500937.70856973197, 4043560.8264148985, 1e-3);
+    }
+
+    @Test
+    @DisplayName("cylindrical_equal_area: the pre-CF-1.0 name is accepted")
+    void testCylindricalEqualAreaLegacyName() {
+        assertEquals("+proj=cea +lat_ts=30 +lon_0=-75 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "cylindrical_equal_area",
+                "standard_parallel", 30.0,
+                "longitude_of_central_meridian", -75.0)));
+    }
+
+    @Test
+    @DisplayName("geostationary: sweep_angle_axis (GOES-R ABI-style parameters)")
+    void testGeostationarySweepX() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "geostationary",
+            "perspective_point_height", 35786023.0,
+            "longitude_of_projection_origin", -75.0,
+            "latitude_of_projection_origin", 0.0,
+            "sweep_angle_axis", "x",
+            "semi_major_axis", 6378137.0,
+            "inverse_flattening", 298.257222096);
+        String projString = CfGridMapping.toProjString(attrs);
+        assertTrue(projString.contains("+sweep=x"), projString);
+        // pyproj: (-80, 30) -> (-468595.77315508184, 3087367.476236351)
+        assertProjects(attrs, null, -80.0, 30.0, -468595.77315508184, 3087367.476236351, 1e-2);
+    }
+
+    @Test
+    @DisplayName("geostationary: fixed_angle_axis is the perpendicular of the sweep axis")
+    void testGeostationaryFixedAngleAxis() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "geostationary",
+            "perspective_point_height", 35786023.0,
+            "longitude_of_projection_origin", -75.0,
+            "fixed_angle_axis", "y");
+        String projString = CfGridMapping.toProjString(attrs);
+        assertTrue(projString.contains("+sweep=x"), projString);
+        // pyproj: (-80, 30) -> (-468595.7731527729, 3087367.476323175)
+        assertProjects(attrs, null, -80.0, 30.0, -468595.7731527729, 3087367.476323175, 1e-2);
+    }
+
+    @Test
+    @DisplayName("geostationary: sweep defaults to y and the orbit must be equatorial")
+    void testGeostationaryDefaultsAndValidation() {
+        String projString = CfGridMapping.toProjString(cf(
+            "grid_mapping_name", "geostationary",
+            "perspective_point_height", 35786023.0));
+        assertTrue(projString.contains("+sweep=y"), projString);
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "geostationary",
+                "perspective_point_height", 35786023.0,
+                "latitude_of_projection_origin", 10.0)));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf("grid_mapping_name", "geostationary")));
+    }
+
+    // ==================== towgs84 / units ====================
+
+    @Test
+    @DisplayName("towgs84: Helmert parameters carried into the datum shift")
+    void testTowgs84() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "transverse_mercator",
+            "latitude_of_projection_origin", 0.0,
+            "longitude_of_central_meridian", 15.0,
+            "scale_factor_at_central_meridian", 0.9996,
+            "false_easting", 500000.0,
+            "towgs84", new double[]{674.374, 15.056, 405.346},
+            "semi_major_axis", 6377397.155,
+            "inverse_flattening", 299.1528128);
+        String projString = CfGridMapping.toProjString(attrs);
+        assertTrue(projString.contains("+towgs84=674.374,15.056,405.346"), projString);
+        // pyproj: (16, 48) -> (574755.4738060532, 5316391.412676798)
+        assertProjects(attrs, null, 16.0, 48.0, 574755.4738060532, 5316391.412676798, 1e-3);
+    }
+
+    @Test
+    @DisplayName("towgs84: a resolvable datum name degrades to its ellipsoid, keeping the shift")
+    void testTowgs84WithDatumName() {
+        // +datum= would bring the registry datum's own shift parameters alongside the
+        // explicit +towgs84; the datum's ellipsoid alone must be emitted instead.
+        assertEquals("+proj=longlat +ellps=WGS84 +towgs84=1,2,3 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "horizontal_datum_name", "WGS84",
+                "towgs84", new double[]{1, 2, 3})));
+    }
+
+    @Test
+    @DisplayName("towgs84 alone identifies the shift on the default WGS 84 ellipsoid")
+    void testTowgs84WithoutFigureParameters() {
+        assertEquals("+proj=longlat +ellps=WGS84 +towgs84=1,2,3 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "towgs84", new double[]{1, 2, 3})));
+    }
+
+    @Test
+    @DisplayName("datum name vetoed by a contradicting ellipsoid name or figure parameters")
+    void testDatumNameVeto() {
+        // horizontal_datum_name = WGS84 on an explicitly GRS 1980 ellipsoid: the name
+        // must not win (pyproj would let it; the declared figure would be discarded).
+        // The resolvable ellipsoid name takes over.
+        assertEquals("+proj=longlat +ellps=GRS80 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "horizontal_datum_name", "WGS84",
+                "reference_ellipsoid_name", "GRS_1980")));
+        // Contradicting numeric parameters win over the name (GDAL's precedence)
+        assertEquals("+proj=longlat +a=6378137 +rf=298.257222101 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "horizontal_datum_name", "WGS84",
+                "semi_major_axis", 6378137.0,
+                "inverse_flattening", 298.257222101)));
+        // Consistent parameters keep the datum identification
+        assertEquals("+proj=longlat +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "horizontal_datum_name", "WGS84",
+                "semi_major_axis", 6378137.0,
+                "inverse_flattening", 298.257223563,
+                "reference_ellipsoid_name", "WGS 84")));
+        // An earth_radius contradicts any registry datum's ellipsoid
+        assertEquals("+proj=longlat +R=6371000 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "horizontal_datum_name", "WGS84",
+                "earth_radius", 6371000.0)));
+    }
+
+    @Test
+    @DisplayName("a WGS 84 CRS on a non-Greenwich prime meridian is not EPSG:4326")
+    void testPrimeMeridianBlocksEpsgIdentification() {
+        Proj paris = CfGridMapping.toProj(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "geographic_crs_name", "WGS 84",
+            "prime_meridian_name", "Paris"));
+        assertEquals(null, paris.toEpsgCode());
+    }
+
+    @Test
+    @DisplayName("identifiesEarthShape: positive identification vs the WGS 84 assumption")
+    void testIdentifiesEarthShape() {
+        assertFalse(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude")));
+        assertFalse(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "horizontal_datum_name", "unknown")));
+        // An unresolvable datum name is not identification — the translation would
+        // fall through to the WGS 84 default
+        assertFalse(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "horizontal_datum_name", "Costa Rica 2005")));
+        assertTrue(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "horizontal_datum_name", "World Geodetic System 1984")));
+        assertTrue(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "semi_major_axis", 6378137.0,
+            "inverse_flattening", 298.257223563)));
+        assertTrue(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "earth_radius", 6371000.0)));
+        assertTrue(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "reference_ellipsoid_name", "GRS 1980")));
+        assertTrue(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "geographic_crs_name", "WGS 84")));
+        assertTrue(CfGridMapping.identifiesEarthShape(cf(
+            "grid_mapping_name", "latitude_longitude",
+            "towgs84", new double[]{1, 2, 3})));
+    }
+
+    @Test
+    @DisplayName("towgs84: only 3 or 7 parameters are meaningful")
+    void testTowgs84Validation() {
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "towgs84", new double[]{1, 2, 3, 4, 5})));
+    }
+
+    @Test
+    @DisplayName("km coordinates: false origin converted to metres, +units=km emitted")
+    void testKilometreUnits() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "polar_stereographic",
+            "standard_parallel", 70.0,
+            "straight_vertical_longitude_from_pole", -45.0,
+            "false_easting", 2000.0,
+            "false_northing", 2000.0);
+        assertEquals(
+            "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +x_0=2000000 +y_0=2000000"
+                + " +datum=WGS84 +units=km +no_defs",
+            CfGridMapping.toProjString(attrs, "km"));
+        // PROJ 9.5.1 for the equivalent proj string: (-30, 75) -> km coordinates
+        assertProjects(attrs, "km", -30.0, 75.0, 2422.879131347975, 421.7935963487639, 1e-6);
+    }
+
+    @Test
+    @DisplayName("km false origin survives the WKT round trip in the declared unit")
+    void testKilometreUnitsWktRoundTrip() {
+        // Regression: WKT emission used to write the internal metre value under a
+        // kilometre LENGTHUNIT tag, so parsing the emitted WKT scaled the false
+        // origin by the unit factor a second time (x_0 = 2e9).
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "polar_stereographic",
+            "standard_parallel", 70.0,
+            "straight_vertical_longitude_from_pole", -45.0,
+            "false_easting", 2000.0,
+            "false_northing", 2000.0);
+        Proj original = CfGridMapping.toProj(attrs, "km");
+        for (String wkt : new String[]{original.toWkt1(), original.toWkt2()}) {
+            double[] viaWkt = Proj4.proj4(WGS84, wkt, new double[]{-30.0, 75.0});
+            assertEquals(2422.879131347975, viaWkt[0], 1e-6, "x via " + wkt);
+            assertEquals(421.7935963487639, viaWkt[1], 1e-6, "y via " + wkt);
+        }
+    }
+
+    @Test
+    @DisplayName("unit spellings: metre variants collapse, feet map to PROJ codes")
+    void testUnitSpellings() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "transverse_mercator",
+            "longitude_of_central_meridian", -123.0);
+        assertFalse(CfGridMapping.toProjString(attrs, "meters").contains("+units="));
+        assertTrue(CfGridMapping.toProjString(attrs, "US_survey_foot").contains("+units=us-ft"));
+        assertTrue(CfGridMapping.toProjString(attrs, "foot").contains("+units=ft"));
+        assertThrows(IllegalArgumentException.class,
+            () -> CfGridMapping.toProjString(attrs, "furlongs"));
+    }
+
+    // ==================== attribute value coercion ====================
+
+    @Test
+    @DisplayName("standard_parallel accepts arrays, lists, and separated strings")
+    void testStandardParallelForms() {
+        String expected =
+            "+proj=aea +lat_1=29.5 +lat_2=45.5 +lat_0=23 +lon_0=-96 +datum=WGS84 +no_defs";
+        for (Object form : new Object[]{
+                new double[]{29.5, 45.5},
+                new float[]{29.5f, 45.5f},
+                List.of(29.5, 45.5),
+                "29.5,45.5",
+                "29.5 45.5"}) {
+            assertEquals(expected, CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "albers_conical_equal_area",
+                "standard_parallel", form,
+                "longitude_of_central_meridian", -96.0,
+                "latitude_of_projection_origin", 23.0)), "form: " + form.getClass());
+        }
+    }
+
+    @Test
+    @DisplayName("numeric attributes accept Number and numeric String values")
+    void testScalarForms() {
+        String expected = "+proj=merc +lat_ts=20 +lon_0=-80.5 +datum=WGS84 +no_defs";
+        assertEquals(expected, CfGridMapping.toProjString(cf(
+            "grid_mapping_name", "mercator",
+            "standard_parallel", "20",
+            "longitude_of_projection_origin", "-80.5")));
+        assertEquals(expected, CfGridMapping.toProjString(cf(
+            "grid_mapping_name", "mercator",
+            "standard_parallel", 20,
+            "longitude_of_projection_origin", -80.5f)));
+    }
+
+    // ==================== errors ====================
+
+    @Test
+    @DisplayName("missing or unsupported grid mappings are rejected with clear messages")
+    void testUnsupportedMappings() {
+        assertThrows(IllegalArgumentException.class,
+            () -> CfGridMapping.toProjString(cf("standard_parallel", 30.0)));
+        assertThrows(IllegalArgumentException.class, () -> CfGridMapping.toProjString(null));
+        for (String unsupported : new String[]{
+                "rotated_latitude_longitude", "oblique_mercator", "vertical_perspective",
+                "made_up_projection"}) {
+            IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> CfGridMapping.toProjString(cf("grid_mapping_name", unsupported)));
+            assertTrue(e.getMessage().contains(unsupported), e.getMessage());
+        }
+    }
+
+    @Test
+    @DisplayName("malformed attributes are rejected")
+    void testMalformedAttributes() {
+        // Albers without its required standard_parallel
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "albers_conical_equal_area",
+                "longitude_of_central_meridian", -96.0)));
+        // LCC with neither standard_parallel nor scale factor
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "lambert_conformal_conic",
+                "longitude_of_central_meridian", -95.0)));
+        // Three standard parallels
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "albers_conical_equal_area",
+                "standard_parallel", new double[]{1, 2, 3})));
+        // Non-numeric value
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "mercator",
+                "standard_parallel", "twenty")));
+        // Multi-valued scalar
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "mercator",
+                "longitude_of_projection_origin", new double[]{1, 2})));
+        // UTM zone missing or out of range
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "universal_transverse_mercator")));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "universal_transverse_mercator",
+                "utm_zone_number", 61)));
+    }
+
+    // ==================== downstream serialization ====================
+
+    @Test
+    @DisplayName("translated CRS serializes to WKT2 that parses back to the same projection")
+    void testWktRoundTrip() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "lambert_conformal_conic",
+            "standard_parallel", new double[]{33.0, 45.0},
+            "longitude_of_central_meridian", -97.0,
+            "latitude_of_projection_origin", 40.0);
+        Proj original = CfGridMapping.toProj(attrs);
+        String wkt2 = original.toWkt2();
+        assertNotNull(wkt2);
+        double[] viaWkt = Proj4.proj4(WGS84, wkt2, new double[]{-100.0, 35.0});
+        assertEquals(-272997.97662925394, viaWkt[0], 1e-3);
+        assertEquals(-547779.5422659346, viaWkt[1], 1e-3);
+    }
+
+    @Test
+    @DisplayName("translated UTM identifies its EPSG code")
+    void testUtmEpsgIdentification() {
+        assertEquals("EPSG:32633", CfGridMapping.toProj(cf(
+            "grid_mapping_name", "universal_transverse_mercator",
+            "utm_zone_number", 33)).toEpsgCode());
+        assertEquals("EPSG:32733", CfGridMapping.toProj(cf(
+            "grid_mapping_name", "universal_transverse_mercator",
+            "utm_zone_number", -33)).toEpsgCode());
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/cf/CfGridMappingTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/cf/CfGridMappingTest.java
@@ -237,6 +237,13 @@ class CfGridMappingTest {
     }
 
     @Test
+    @DisplayName("transverse_mercator: omitted origins and scale use oracle defaults")
+    void testTransverseMercatorDefaults() {
+        assertEquals("+proj=tmerc +lat_0=0 +lon_0=0 +k_0=1 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf("grid_mapping_name", "transverse_mercator")));
+    }
+
+    @Test
     @DisplayName("universal_transverse_mercator: positive zone is north")
     void testUtmNorth() {
         Map<String, Object> attrs = cf(
@@ -344,6 +351,17 @@ class CfGridMappingTest {
     }
 
     @Test
+    @DisplayName("polar_stereographic: current longitude attribute without legacy alias")
+    void testPolarStereographicCurrentLongitudeOnly() {
+        assertEquals("+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "polar_stereographic",
+                "standard_parallel", 70.0,
+                "longitude_of_projection_origin", -45.0,
+                "latitude_of_projection_origin", 90.0)));
+    }
+
+    @Test
     @DisplayName("polar_stereographic: current longitude attribute takes precedence over legacy")
     void testPolarStereographicCurrentLongitudeAttribute() {
         Map<String, Object> attrs = cf(
@@ -414,6 +432,13 @@ class CfGridMappingTest {
             "inverse_flattening", 299.1528128);
         // pyproj: (5, 52) -> (128383.70882521641, 445698.7003830712)
         assertProjects(attrs, null, 5.0, 52.0, 128383.70882521641, 445698.7003830712, 1e-3);
+    }
+
+    @Test
+    @DisplayName("stereographic: omitted origins and scale use oracle defaults")
+    void testStereographicDefaults() {
+        assertEquals("+proj=stere +lat_0=0 +lon_0=0 +k_0=1 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(cf("grid_mapping_name", "stereographic")));
     }
 
     // ==================== albers_conical_equal_area ====================
@@ -706,10 +731,16 @@ class CfGridMappingTest {
         assertTrue(CfGridMapping.identifiesEarthShape(cf(
             "grid_mapping_name", "latitude_longitude",
             "towgs84", new double[]{1, 2, 3})));
+        assertThrows(IllegalArgumentException.class,
+            () -> CfGridMapping.identifiesEarthShape(null));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.identifiesEarthShape(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "towgs84", new double[]{1, 2, 3, 4, 5})));
     }
 
     @Test
-    @DisplayName("towgs84: only 3 or 7 parameters are meaningful")
+    @DisplayName("towgs84: only 3, 6, or 7 parameters are meaningful")
     void testTowgs84Validation() {
         assertThrows(IllegalArgumentException.class, () ->
             CfGridMapping.toProjString(cf(
@@ -785,8 +816,52 @@ class CfGridMappingTest {
             "longitude_of_central_meridian", -123.0,
             "scale_factor_at_central_meridian", 1.0);
         assertTrue(CfGridMapping.toProjString(attrs, "km", "kilometres").contains("+units=km"));
+        assertTrue(CfGridMapping.toProjString(attrs, "km", null).contains("+units=km"));
+        assertTrue(CfGridMapping.toProjString(attrs, null, "kilometres").contains("+units=km"));
         assertThrows(IllegalArgumentException.class,
             () -> CfGridMapping.toProjString(attrs, "km", "m"));
+    }
+
+    @Test
+    @DisplayName("single-parallel mappings reject two standard parallels")
+    void testSingleParallelMappingsRejectTwoParallels() {
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "mercator",
+                "standard_parallel", new double[]{10, 20})));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "lambert_cylindrical_equal_area",
+                "standard_parallel", new double[]{10, 20})));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "polar_stereographic",
+                "standard_parallel", new double[]{70, 71},
+                "latitude_of_projection_origin", 90.0)));
+    }
+
+    @Test
+    @DisplayName("non-physical ellipsoid parameters are rejected")
+    void testInvalidEarthShapeParameters() {
+        for (double inverseFlattening : new double[]{-298.0, 0.5, 1.0}) {
+            assertThrows(IllegalArgumentException.class, () ->
+                CfGridMapping.toProjString(cf(
+                    "grid_mapping_name", "latitude_longitude",
+                    "semi_major_axis", 6378137.0,
+                    "inverse_flattening", inverseFlattening)));
+        }
+        for (double semiMinor : new double[]{0.0, -1.0, 6378138.0}) {
+            assertThrows(IllegalArgumentException.class, () ->
+                CfGridMapping.toProjString(cf(
+                    "grid_mapping_name", "latitude_longitude",
+                    "semi_major_axis", 6378137.0,
+                    "semi_minor_axis", semiMinor)));
+        }
+        assertEquals("+proj=longlat +R=6378137 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "semi_major_axis", 6378137.0,
+                "inverse_flattening", 0.0)));
     }
 
     // ==================== attribute value coercion ====================
@@ -881,19 +956,20 @@ class CfGridMappingTest {
             CfGridMapping.toProjString(cf(
                 "grid_mapping_name", "universal_transverse_mercator",
                 "utm_zone_number", 33.7)));
-        // Variant-defining scale/parallel parameters are required
+        // Mercator's variant-defining scale/parallel parameter is required
         assertThrows(IllegalArgumentException.class, () ->
             CfGridMapping.toProjString(cf(
                 "grid_mapping_name", "mercator",
                 "longitude_of_projection_origin", 0.0)));
+        // Explicit scale factors must remain positive even when omission defaults to one
         assertThrows(IllegalArgumentException.class, () ->
             CfGridMapping.toProjString(cf(
                 "grid_mapping_name", "transverse_mercator",
-                "longitude_of_central_meridian", 0.0)));
+                "scale_factor_at_central_meridian", 0.0)));
         assertThrows(IllegalArgumentException.class, () ->
             CfGridMapping.toProjString(cf(
                 "grid_mapping_name", "stereographic",
-                "latitude_of_projection_origin", 45.0)));
+                "scale_factor_at_projection_origin", -1.0)));
         // Non-finite numeric metadata is rejected at coercion
         assertThrows(IllegalArgumentException.class, () ->
             CfGridMapping.toProjString(cf(

--- a/src/test/java/org/datasyslab/proj4sedona/cf/CfGridMappingTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/cf/CfGridMappingTest.java
@@ -344,6 +344,19 @@ class CfGridMappingTest {
     }
 
     @Test
+    @DisplayName("polar_stereographic: current longitude attribute takes precedence over legacy")
+    void testPolarStereographicCurrentLongitudeAttribute() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "polar_stereographic",
+            "standard_parallel", 70.0,
+            "longitude_of_projection_origin", -45.0,
+            "straight_vertical_longitude_from_pole", 10.0,
+            "latitude_of_projection_origin", 90.0);
+        assertEquals("+proj=stere +lat_0=90 +lat_ts=70 +lon_0=-45 +datum=WGS84 +no_defs",
+            CfGridMapping.toProjString(attrs));
+    }
+
+    @Test
     @DisplayName("polar_stereographic variant B: pole derived from the parallel's hemisphere")
     void testPolarStereographicVariantBSouth() {
         Map<String, Object> attrs = cf(
@@ -705,6 +718,15 @@ class CfGridMappingTest {
     }
 
     @Test
+    @DisplayName("towgs84: CF six-parameter form is padded to PROJ's seven values")
+    void testTowgs84SixParameters() {
+        assertEquals("+proj=longlat +ellps=WGS84 +towgs84=1,2,3,4,5,6,0 +no_defs",
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "latitude_longitude",
+                "towgs84", new double[]{1, 2, 3, 4, 5, 6})));
+    }
+
+    @Test
     @DisplayName("km coordinates: false origin converted to metres, +units=km emitted")
     void testKilometreUnits() {
         Map<String, Object> attrs = cf(
@@ -746,12 +768,25 @@ class CfGridMappingTest {
     void testUnitSpellings() {
         Map<String, Object> attrs = cf(
             "grid_mapping_name", "transverse_mercator",
-            "longitude_of_central_meridian", -123.0);
+            "longitude_of_central_meridian", -123.0,
+            "scale_factor_at_central_meridian", 1.0);
         assertFalse(CfGridMapping.toProjString(attrs, "meters").contains("+units="));
         assertTrue(CfGridMapping.toProjString(attrs, "US_survey_foot").contains("+units=us-ft"));
         assertTrue(CfGridMapping.toProjString(attrs, "foot").contains("+units=ft"));
         assertThrows(IllegalArgumentException.class,
             () -> CfGridMapping.toProjString(attrs, "furlongs"));
+    }
+
+    @Test
+    @DisplayName("projection coordinate axes must use compatible linear units")
+    void testCoordinateUnitCompatibility() {
+        Map<String, Object> attrs = cf(
+            "grid_mapping_name", "transverse_mercator",
+            "longitude_of_central_meridian", -123.0,
+            "scale_factor_at_central_meridian", 1.0);
+        assertTrue(CfGridMapping.toProjString(attrs, "km", "kilometres").contains("+units=km"));
+        assertThrows(IllegalArgumentException.class,
+            () -> CfGridMapping.toProjString(attrs, "km", "m"));
     }
 
     // ==================== attribute value coercion ====================
@@ -842,6 +877,34 @@ class CfGridMappingTest {
             CfGridMapping.toProjString(cf(
                 "grid_mapping_name", "universal_transverse_mercator",
                 "utm_zone_number", 61)));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "universal_transverse_mercator",
+                "utm_zone_number", 33.7)));
+        // Variant-defining scale/parallel parameters are required
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "mercator",
+                "longitude_of_projection_origin", 0.0)));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "transverse_mercator",
+                "longitude_of_central_meridian", 0.0)));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "stereographic",
+                "latitude_of_projection_origin", 45.0)));
+        // Non-finite numeric metadata is rejected at coercion
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "mercator",
+                "standard_parallel", Double.NaN,
+                "longitude_of_projection_origin", 0.0)));
+        assertThrows(IllegalArgumentException.class, () ->
+            CfGridMapping.toProjString(cf(
+                "grid_mapping_name", "mercator",
+                "standard_parallel", "Infinity",
+                "longitude_of_projection_origin", 0.0)));
     }
 
     // ==================== downstream serialization ====================

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -173,6 +173,14 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("WKT export rejects a zero linear-unit conversion factor")
+    void testWktRejectsZeroToMeter() {
+        Proj proj = new Proj("+proj=tmerc +x_0=100 +to_meter=0");
+        assertThrows(IllegalArgumentException.class, () -> CRSSerializer.toWkt1(proj));
+        assertThrows(IllegalArgumentException.class, () -> CRSSerializer.toWkt2(proj));
+    }
+
+    @Test
     @DisplayName("toProjString: geographic CRS with any angular unit emits no unit token")
     void testToProjStringGeographicAngularUnitNoToken() {
         // PROJ branches on the unit's kind, not its name — a geographic CRS's unit is

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -181,6 +181,26 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("WKT export uses explicit to_meter for an unknown named unit")
+    void testWktUnknownUnitUsesExplicitToMeter() {
+        Proj proj = new Proj("+proj=tmerc +x_0=100 +units=widget +to_meter=0.5");
+        String wkt1 = CRSSerializer.toWkt1(proj);
+        assertTrue(wkt1.contains("PARAMETER[\"false_easting\",200.0]"), wkt1);
+        assertTrue(wkt1.contains("UNIT[\"widget\",0.5]"), wkt1);
+
+        String wkt2 = CRSSerializer.toWkt2(proj);
+        assertTrue(wkt2.contains(
+            "PARAMETER[\"False easting\",200.0,LENGTHUNIT[\"widget\",0.5]]"), wkt2);
+        assertTrue(wkt2.contains("LENGTHUNIT[\"widget\",0.5]"), wkt2);
+
+        for (String wkt : new String[]{wkt1, wkt2}) {
+            Proj reimported = new Proj(wkt);
+            assertEquals(100.0, reimported.getParams().x0, 1e-9, wkt);
+            assertEquals(0.5, reimported.getParams().toMeter, 0, wkt);
+        }
+    }
+
+    @Test
     @DisplayName("toProjString: geographic CRS with any angular unit emits no unit token")
     void testToProjStringGeographicAngularUnitNoToken() {
         // PROJ branches on the unit's kind, not its name — a geographic CRS's unit is


### PR DESCRIPTION
## What

New `org.datasyslab.proj4sedona.cf.CfGridMapping`: translates NetCDF CF convention grid mapping attributes (`grid_mapping_name` plus projection/ellipsoid parameters, per CF conventions Appendix F) to PROJ strings and `Proj` objects, for files that define their CRS without a `crs_wkt` attribute. Groundwork for apache/sedona#3121 (`netcdf.metadata` reporting CRS/SRID for parameter-defined grid mappings) and reusable for `RS_FromNetCDF` georeferencing later.

Supported mappings: `latitude_longitude`, `albers_conical_equal_area`, `azimuthal_equidistant`, `geostationary`, `lambert_azimuthal_equal_area`, `lambert_conformal_conic` (1SP/2SP), `lambert_cylindrical_equal_area` (+ pre-CF-1.0 alias `cylindrical_equal_area`), `mercator` (variants A/B), `orthographic`, `polar_stereographic` (variants A/B), `sinusoidal`, `stereographic`, `transverse_mercator`, and netCDF-Java's `universal_transverse_mercator` (`utm_zone_number`, negative = southern hemisphere).

Also handled:

- Ellipsoid/datum resolution: `horizontal_datum_name`/`geographic_crs_name` through the datum registry, `reference_ellipsoid_name` through the ellipsoid registry (with EPSG-name aliases), explicit figure parameters (`semi_major_axis`, `semi_minor_axis`, `inverse_flattening`, `earth_radius`, GDAL's legacy `spherical_earth_radius_meters` spelling), `towgs84`, prime meridians (numeric and named). With nothing identifying the figure, WGS 84 is assumed (GDAL/pyproj behavior); `identifiesEarthShape` lets callers that must not report that assumption detect it.
- Non-metre projection coordinate units: CF puts `false_easting`/`false_northing` in the x/y coordinate units, PROJ `+x_0`/`+y_0` are metres — `toProjString(cf, "km")` converts the false origin and emits `+units=km`.
- Attribute values as netCDF readers produce them: `Number`, numeric/comma-separated `String`, primitive arrays, `Number[]`, `List`.

## Oracles

Behavior follows pyproj's `CRS.from_cf` (`pyproj/crs/_cf1x8.py`) and GDAL's `OGRSpatialReference::importFromCF1` (`ogr/ogr_srs_cf1.cpp`). Expected test coordinates were generated with pyproj 3.7.2 / PROJ 9.5.1 (each fixture's provenance is in a comment). Where the two oracles disagree, the choice is documented in the Javadoc:

- Single-parallel Albers duplicates the first parallel (GDAL); pyproj defaults the second parallel to 0, which changes the cone.
- LCC 1SP anchors the natural origin at the standard parallel with k=1 and ignores a differing `latitude_of_projection_origin` (pyproj); GDAL derives a scale factor via Snyder eq. 15-4 and labels it experimental.
- A datum name contradicted by explicit figure attributes (e.g. `horizontal_datum_name = "WGS84"` with `reference_ellipsoid_name = "GRS_1980"`) is vetoed and the declared figure wins; pyproj lets the name win outright and silently discards the contradiction.
- The CEA scale-factor form is normalized to a standard parallel with the inverse of the EPSG 9835 relation, matching pyproj to full precision.

## Bug fixes surfaced by the new path (each pinned by a regression test)

- EPSG identification accepted a non-Greenwich prime meridian: `+proj=longlat +datum=WGS84 +pm=paris` identified as EPSG:4326 through both the datum-name shortcut and parameter matching in `CRSSerializer`.
- WKT1/WKT2 export wrote false easting/northing as the internal metre values while tagging them with the CRS's linear unit, so re-parsing a non-metre CRS scaled the false origin twice (x_0 = 2e9 for a 2000 km false easting).

## Testing

- 55 new tests in `CfGridMappingTest`: per-projection numeric transforms against the pyproj/PROJ oracle values, token assertions, coercion forms, error cases, WKT1/WKT2 round trips, EPSG identification (UTM zones, 4326/4269).
- Full suite green (`mvn test`), no changes to existing test expectations.

This module is a proj4sedona extension with no proj4js upstream counterpart; README documents it and its oracle-based validation.
