### PR TITLE
Align MGRS behavior with upstream 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ import org.datasyslab.proj4sedona.Proj4;
 import org.datasyslab.proj4sedona.mgrs.MGRS;
 
 // Convert lon/lat to MGRS
-String mgrs = Proj4.toMGRS(-77.0369, 38.9072);  // "18SUJ2338308451"
+String mgrs = Proj4.toMGRS(-77.0369, 38.9072);  // "18SUJ2338308450"
 
-// With custom accuracy (1=10km, 2=1km, 3=100m, 4=10m, 5=1m)
+// With custom accuracy (0=100km, 1=10km, 2=1km, 3=100m, 4=10m, 5=1m)
 String mgrs1km = Proj4.toMGRS(-77.0369, 38.9072, 2);  // "18SUJ2308"
 
 // Convert MGRS to lon/lat
-double[] lonLat = Proj4.fromMGRS("18SUJ2338308451");  // [-77.0369, 38.9072]
+double[] lonLat = Proj4.fromMGRS("18SUJ2338308450");  // [-77.0369, 38.9072]
 
 // Or use the MGRS class directly
 String mgrs2 = MGRS.forward(new double[]{-77.0369, 38.9072}, 5);
-double[] point = MGRS.toPoint("18SUJ2338308451");
+double[] point = MGRS.toPoint("18SUJ2338308450");
 double[] bbox = MGRS.inverse("18SUJ23");  // [left, bottom, right, top]
 ```
 
@@ -263,7 +263,7 @@ known to be wrong; each is noted in the relevant Javadoc and pinned by a test):
 |---|---|---|
 | [proj4js](https://github.com/proj4js/proj4js) | commit `695c191` | 2026-07-05 |
 | [wkt-parser](https://github.com/proj4js/wkt-parser) | v1.5.5 | 2026-07-13 (audit) |
-| [mgrs](https://github.com/proj4js/mgrs) | v1.0.0 | — |
+| [mgrs](https://github.com/proj4js/mgrs) | v2.2.0 | 2026-07-21 |
 
 To find upstream changes that may need porting since the last sync:
 
@@ -273,6 +273,9 @@ git log 695c191..origin/master -- lib/
 
 # For wkt-parser, diff the published packages:
 npm pack wkt-parser@1.5.5 && npm pack wkt-parser@latest
+
+# For MGRS, diff the published packages:
+npm pack mgrs@2.2.0 && npm pack mgrs@latest
 ```
 
 When updating this table, audit each new commit/diff hunk as ported, not applicable,

--- a/docs/mgrs.md
+++ b/docs/mgrs.md
@@ -112,9 +112,11 @@ UTM zone number (1-60)
 MGRS follows the UTM zone system with two exceptions for Norway and Svalbard:
 
 - Zone 32V is widened to cover southwestern Norway (normally zone 31V)
-- Zones 32X, 34X, and 36X do not exist; they are merged into zones 31X, 33X, 35X, and 37X for Svalbard
+- From 72°N up to, but not including, 84°N, zones 32X, 34X, and 36X are merged into zones 31X, 33X, 35X, and 37X for Svalbard
 
-Proj4Sedona handles these special zones automatically.
+Proj4Sedona handles these special zones automatically. At exactly 84°N, matching
+mgrs 2.2.0, ordinary zone selection applies; references in 32X, 34X, and 36X can
+therefore occur at that supported northern boundary and are accepted on decode.
 
 ## UPS (Universal Polar Stereographic)
 
@@ -164,6 +166,13 @@ for (double[] city : cities) {
 ## Error Handling
 
 MGRS input is case-insensitive and may contain whitespace, so `4QFJ 12345 67890` and `4QFJ1234567890` decode identically. Invalid coordinates, accuracies, and MGRS strings throw an `IllegalArgumentException`. Longitude must be finite and between -180 and 180, latitude must be finite and between -80 and 84, accuracy must be between 0 and 5, UTM zones must be between 1 and 60, and each decoded axis may contain at most five digits.
+
+Two input-handling differences from mgrs 2.2.0 are intentional. Proj4Sedona
+rejects a 100km easting letter that belongs to the wrong grid set for the numeric
+zone; upstream accepts it and may return a coordinate outside that zone.
+Proj4Sedona also removes all Java whitespace, including tabs and line breaks,
+whereas upstream removes ASCII spaces only. These behaviors are pinned by the
+MGRS regression tests.
 
 ```java
 try {

--- a/docs/mgrs.md
+++ b/docs/mgrs.md
@@ -1,6 +1,6 @@
 # MGRS Coordinates
 
-Proj4Sedona supports conversion between geographic coordinates (longitude/latitude) and Military Grid Reference System (MGRS) strings. MGRS is widely used in military and emergency services for unambiguous location references.
+Proj4Sedona supports conversion between geographic coordinates (longitude/latitude) and Military Grid Reference System (MGRS) strings in the UTM latitude bands from 80°S through 84°N. MGRS is widely used in military and emergency services for unambiguous location references. This implementation tracks [proj4js/mgrs v2.2.0](https://github.com/proj4js/mgrs/releases/tag/v2.2.0).
 
 ## Converting to MGRS
 
@@ -12,14 +12,15 @@ import org.datasyslab.proj4sedona.core.Point;
 
 // Default accuracy (5 = 1-meter precision)
 String mgrs = Proj4.toMGRS(-77.0369, 38.9072);
-// "18SUJ2338308451"
+// "18SUJ2338308450"
 
 // With explicit accuracy
-String mgrs5 = Proj4.toMGRS(-77.0369, 38.9072, 5);  // "18SUJ2338308451" (1m)
+String mgrs5 = Proj4.toMGRS(-77.0369, 38.9072, 5);  // "18SUJ2338308450" (1m)
 String mgrs4 = Proj4.toMGRS(-77.0369, 38.9072, 4);  // "18SUJ23380845"  (10m)
 String mgrs3 = Proj4.toMGRS(-77.0369, 38.9072, 3);  // "18SUJ233084"    (100m)
 String mgrs2 = Proj4.toMGRS(-77.0369, 38.9072, 2);  // "18SUJ2308"      (1km)
 String mgrs1 = Proj4.toMGRS(-77.0369, 38.9072, 1);  // "18SUJ20"        (10km)
+String mgrs0 = Proj4.toMGRS(-77.0369, 38.9072, 0);  // "18SUJ"          (100km)
 ```
 
 ### From Array
@@ -35,11 +36,11 @@ String mgrs2 = Proj4.toMGRS(new double[]{-77.0369, 38.9072}, 3);
 
 ```java
 // Returns [longitude, latitude]
-double[] lonLat = Proj4.fromMGRS("18SUJ2338308451");
+double[] lonLat = Proj4.fromMGRS("18SUJ2338308450");
 // [-77.0369, 38.9072] (approximately)
 
 // Using Point object
-Point p = Proj4.mgrsToPoint("18SUJ2338308451");
+Point p = Proj4.mgrsToPoint("18SUJ2338308450");
 // p.x = longitude, p.y = latitude
 ```
 
@@ -59,11 +60,12 @@ The accuracy parameter controls the precision of the MGRS string:
 
 | Accuracy | Grid Size | Digits per Axis | Example |
 |----------|----------|-----------------|---------|
+| 0 | 100 km | 0 | `18SUJ` |
 | 1 | 10 km | 1 | `18SUJ20` |
 | 2 | 1 km | 2 | `18SUJ2308` |
 | 3 | 100 m | 3 | `18SUJ233084` |
 | 4 | 10 m | 4 | `18SUJ23380845` |
-| 5 | 1 m | 5 | `18SUJ2338308451` |
+| 5 | 1 m | 5 | `18SUJ2338308450` |
 
 ## Using the MGRS Class Directly
 
@@ -74,16 +76,16 @@ import org.datasyslab.proj4sedona.mgrs.MGRS;
 
 // Forward: lon/lat to MGRS string
 String mgrs = MGRS.forward(new double[]{-77.0369, 38.9072}, 5);
-// "18SUJ2338308451"
+// "18SUJ2338308450"
 
 // Default accuracy (5)
 String mgrsDefault = MGRS.forward(new double[]{-77.0369, 38.9072});
 
 // Inverse: MGRS to bounding box [left, bottom, right, top]
-double[] bbox = MGRS.inverse("18SUJ2338308451");
+double[] bbox = MGRS.inverse("18SUJ2338308450");
 
 // To center point [longitude, latitude]
-double[] center = MGRS.toPoint("18SUJ2338308451");
+double[] center = MGRS.toPoint("18SUJ2338308450");
 ```
 
 ## MGRS String Format
@@ -91,7 +93,7 @@ double[] center = MGRS.toPoint("18SUJ2338308451");
 An MGRS string has three parts:
 
 ```
-18 S UJ 23383 08451
+18 S UJ 23383 08450
 ^  ^ ^  ^     ^
 |  | |  |     Northing digits
 |  | |  Easting digits
@@ -111,7 +113,7 @@ Proj4Sedona handles these special zones automatically.
 
 ## UPS (Universal Polar Stereographic)
 
-For polar regions (above 84N or below 80S), MGRS uses the Universal Polar Stereographic (UPS) projection instead of UTM.
+`MGRS.forward` intentionally rejects polar regions above 84°N or below 80°S, matching proj4js/mgrs. Proj4Sedona also provides a separate local Universal Polar Stereographic (UPS) API for those coordinates; it is not invoked automatically by `MGRS`.
 
 ```java
 import org.datasyslab.proj4sedona.mgrs.UPS;
@@ -156,7 +158,7 @@ for (double[] city : cities) {
 
 ## Error Handling
 
-Invalid MGRS strings throw an `IllegalArgumentException`:
+MGRS input is case-insensitive and may contain whitespace, so `4QFJ 12345 67890` and `4QFJ1234567890` decode identically. Invalid coordinates, accuracies, and MGRS strings throw an `IllegalArgumentException`. Longitude must be finite and between -180 and 180, latitude must be finite and between -80 and 84, accuracy must be between 0 and 5, UTM zones must be between 1 and 60, and each decoded axis may contain at most five digits.
 
 ```java
 try {

--- a/docs/mgrs.md
+++ b/docs/mgrs.md
@@ -54,6 +54,11 @@ double[] bbox = Proj4.mgrsInverse("18SUJ23");
 // Bounding box of the 10km grid square
 ```
 
+The returned box and center describe the complete UTM grid cell. As in upstream
+`mgrs`, a coarse cell that straddles an antimeridian or latitude-band boundary is
+not clipped to that boundary, so its center can lie outside the nominal grid-zone
+designation and its longitude can be outside `-180..180`.
+
 ## Accuracy Levels
 
 The accuracy parameter controls the precision of the MGRS string:

--- a/src/main/java/org/datasyslab/proj4sedona/Proj4.java
+++ b/src/main/java/org/datasyslab/proj4sedona/Proj4.java
@@ -358,7 +358,8 @@ public final class Proj4 {
      * Convert longitude/latitude to MGRS string.
      * 
      * @param lonLat Array with [longitude, latitude] in degrees (WGS84)
-     * @param accuracy Accuracy in digits (1-5): 5=1m, 4=10m, 3=100m, 2=1km, 1=10km
+     * @param accuracy Accuracy in digits (0-5): 5=1m, 4=10m, 3=100m, 2=1km,
+     *                 1=10km, 0=100km
      * @return MGRS string for the given location
      */
     public static String toMGRS(double[] lonLat, int accuracy) {
@@ -380,7 +381,7 @@ public final class Proj4 {
      * 
      * @param lon Longitude in degrees (WGS84)
      * @param lat Latitude in degrees (WGS84)
-     * @param accuracy Accuracy in digits (1-5)
+     * @param accuracy Accuracy in digits (0-5)
      * @return MGRS string for the given location
      */
     public static String toMGRS(double lon, double lat, int accuracy) {

--- a/src/main/java/org/datasyslab/proj4sedona/mgrs/MGRS.java
+++ b/src/main/java/org/datasyslab/proj4sedona/mgrs/MGRS.java
@@ -1,11 +1,14 @@
 package org.datasyslab.proj4sedona.mgrs;
 
+import java.util.Locale;
+
 /**
  * Military Grid Reference System (MGRS) coordinate converter.
- * Mirrors: node_modules/mgrs/mgrs.js
+ * Mirrors: proj4js/mgrs v2.2.0 {@code mgrs.js}
  * 
  * MGRS is a geocoordinate standard used by NATO militaries for locating points
- * on Earth. It is derived from the UTM system, but uses a different notation.
+ * on Earth. This converter covers the UTM latitude bands from 80°S through 84°N;
+ * the separate {@link UPS} API covers polar coordinates.
  * 
  * An MGRS coordinate consists of:
  * - Zone number (1-60)
@@ -18,15 +21,15 @@ package org.datasyslab.proj4sedona.mgrs;
  * Usage:
  * <pre>
  * // Convert lat/lon to MGRS
- * String mgrs = MGRS.forward(new double[]{-77.0, 38.9}, 5);
+ * String mgrs = MGRS.forward(new double[]{-77.0369, 38.9072}, 5);
  * // Returns: "18SUJ2338308450"
  * 
  * // Convert MGRS to lat/lon
  * double[] point = MGRS.toPoint("18SUJ2338308450");
- * // Returns: [-77.0, 38.9]
+ * // Returns approximately: [-77.0369, 38.9072]
  * 
  * // Get bounding box for MGRS reference
- * double[] bbox = MGRS.inverse("18SUJ23384");
+ * double[] bbox = MGRS.inverse("18SUJ2308");
  * // Returns: [left, bottom, right, top]
  * </pre>
  */
@@ -83,15 +86,36 @@ public final class MGRS {
      * Convert latitude/longitude to MGRS string.
      * 
      * @param lonLat Array with [longitude, latitude] in degrees (WGS84)
-     * @param accuracy Accuracy in digits (1-5): 5=1m, 4=10m, 3=100m, 2=1km, 1=10km
+     * @param accuracy Accuracy in digits (0-5): 5=1m, 4=10m, 3=100m, 2=1km,
+     *                 1=10km, 0=100km
      * @return MGRS string for the given location
-     * @throws IllegalArgumentException if coordinates are outside MGRS bounds
+     * @throws IllegalArgumentException if the coordinate array, values, or accuracy are invalid
      */
     public static String forward(double[] lonLat, int accuracy) {
-        if (accuracy < 1 || accuracy > 5) {
-            accuracy = 5; // Default to 1m accuracy
+        if (lonLat == null) {
+            throw new IllegalArgumentException("MGRS forward coordinate cannot be null");
         }
-        UTMCoordinate utm = llToUTM(lonLat[1], lonLat[0]);
+        if (lonLat.length < 2) {
+            throw new IllegalArgumentException("MGRS forward coordinate must contain [longitude, latitude]");
+        }
+
+        double lon = lonLat[0];
+        double lat = lonLat[1];
+        if (!Double.isFinite(lon) || lon < -180.0 || lon > 180.0) {
+            throw new IllegalArgumentException("Invalid longitude: " + lon);
+        }
+        if (!Double.isFinite(lat) || lat < -90.0 || lat > 90.0) {
+            throw new IllegalArgumentException("Invalid latitude: " + lat);
+        }
+        if (lat < -80.0 || lat > 84.0) {
+            throw new IllegalArgumentException(
+                "MGRS does not support polar latitudes below 80°S or above 84°N: " + lat);
+        }
+
+        if (accuracy < 0 || accuracy > 5) {
+            throw new IllegalArgumentException("MGRS accuracy must be between 0 and 5: " + accuracy);
+        }
+        UTMCoordinate utm = llToUTM(lat, lon);
         return encode(utm, accuracy);
     }
 
@@ -113,7 +137,7 @@ public final class MGRS {
      * @throws IllegalArgumentException if MGRS string is invalid
      */
     public static double[] inverse(String mgrs) {
-        UTMCoordinate utm = decode(mgrs.toUpperCase());
+        UTMCoordinate utm = decode(mgrs);
         LatLonResult result = utmToLL(utm);
         
         if (result.isPoint) {
@@ -130,7 +154,7 @@ public final class MGRS {
      * @throws IllegalArgumentException if MGRS string is invalid
      */
     public static double[] toPoint(String mgrs) {
-        UTMCoordinate utm = decode(mgrs.toUpperCase());
+        UTMCoordinate utm = decode(mgrs);
         LatLonResult result = utmToLL(utm);
         
         if (result.isPoint) {
@@ -214,8 +238,8 @@ public final class MGRS {
         }
 
         return new UTMCoordinate(
-            Math.round(northing),
-            Math.round(easting),
+            (long) northing,
+            (long) easting,
             zoneNumber,
             getLetterDesignator(lat),
             0 // No accuracy for forward conversion
@@ -226,7 +250,7 @@ public final class MGRS {
      * Convert UTM coordinates to lat/lon using WGS84.
      */
     private static LatLonResult utmToLL(UTMCoordinate utm) {
-        if (utm.zoneNumber < 0 || utm.zoneNumber > 60) {
+        if (utm.zoneNumber < 1 || utm.zoneNumber > 60) {
             throw new IllegalArgumentException("Invalid UTM zone number: " + utm.zoneNumber);
         }
 
@@ -298,8 +322,8 @@ public final class MGRS {
      * Encode UTM coordinates as MGRS string.
      */
     private static String encode(UTMCoordinate utm, int accuracy) {
-        String seasting = String.format("%05d", (int) utm.easting);
-        String snorthing = String.format("%05d", (int) utm.northing);
+        String seasting = "00000" + (long) utm.easting;
+        String snorthing = "00000" + (long) utm.northing;
 
         return String.valueOf(utm.zoneNumber) 
             + utm.zoneLetter 
@@ -312,8 +336,20 @@ public final class MGRS {
      * Decode MGRS string to UTM coordinates.
      */
     private static UTMCoordinate decode(String mgrsString) {
-        if (mgrsString == null || mgrsString.isEmpty()) {
-            throw new IllegalArgumentException("MGRS string cannot be empty");
+        if (mgrsString == null) {
+            throw new IllegalArgumentException("MGRS string cannot be null");
+        }
+
+        StringBuilder normalized = new StringBuilder(mgrsString.length());
+        for (int index = 0; index < mgrsString.length(); index++) {
+            char character = mgrsString.charAt(index);
+            if (!Character.isWhitespace(character)) {
+                normalized.append(character);
+            }
+        }
+        mgrsString = normalized.toString().toUpperCase(Locale.ROOT);
+        if (mgrsString.isEmpty()) {
+            throw new IllegalArgumentException("MGRS string cannot be blank");
         }
 
         int length = mgrsString.length();
@@ -321,7 +357,7 @@ public final class MGRS {
         int i = 0;
 
         // Parse zone number
-        while (i < length && !Character.isLetter(mgrsString.charAt(i))) {
+        while (i < length && Character.isDigit(mgrsString.charAt(i))) {
             if (i >= 2) {
                 throw new IllegalArgumentException("Invalid MGRS string: " + mgrsString);
             }
@@ -329,10 +365,13 @@ public final class MGRS {
             i++;
         }
 
-        int zoneNumber = Integer.parseInt(sb.toString());
-
         if (i == 0 || i + 3 > length) {
             throw new IllegalArgumentException("Invalid MGRS string: " + mgrsString);
+        }
+
+        int zoneNumber = Integer.parseInt(sb.toString());
+        if (zoneNumber < 1 || zoneNumber > 60) {
+            throw new IllegalArgumentException("Invalid MGRS zone number: " + zoneNumber);
         }
 
         char zoneLetter = mgrsString.charAt(i++);
@@ -342,12 +381,19 @@ public final class MGRS {
             || zoneLetter == 'I' || zoneLetter == 'O') {
             throw new IllegalArgumentException("Invalid zone letter '" + zoneLetter + "' in: " + mgrsString);
         }
+        if (zoneLetter == 'X' && (zoneNumber == 32 || zoneNumber == 34 || zoneNumber == 36)) {
+            throw new IllegalArgumentException("Invalid Svalbard MGRS zone: " + zoneNumber + zoneLetter);
+        }
 
         // Parse 100km grid square
         String hunK = mgrsString.substring(i, i + 2);
         i += 2;
 
+        validateGridLetter(hunK.charAt(0), "easting");
+        validateGridLetter(hunK.charAt(1), "northing");
+
         int set = get100kSetForZone(zoneNumber);
+        validateEastingForSet(hunK.charAt(0), set);
         double east100k = getEastingFromChar(hunK.charAt(0), set);
         double north100k = getNorthingFromChar(hunK.charAt(1), set);
 
@@ -358,20 +404,22 @@ public final class MGRS {
 
         // Parse easting/northing digits
         int remainder = length - i;
-        if (remainder % 2 != 0) {
+        if (remainder % 2 != 0 || remainder > 10) {
             throw new IllegalArgumentException(
-                "MGRS string must have even number of digits after zone and grid square: " + mgrsString);
+                "MGRS string must have 0-5 digits per axis: " + mgrsString);
         }
 
         int sep = remainder / 2;
         double sepEasting = 0.0;
         double sepNorthing = 0.0;
-        double accuracyBonus = 0;
+        double accuracyBonus = 100000.0 / Math.pow(10, sep);
 
         if (sep > 0) {
-            accuracyBonus = 100000.0 / Math.pow(10, sep);
             String sepEastingString = mgrsString.substring(i, i + sep);
             String sepNorthingString = mgrsString.substring(i + sep);
+            if (!allDigits(sepEastingString) || !allDigits(sepNorthingString)) {
+                throw new IllegalArgumentException("Invalid MGRS numeric precision: " + mgrsString);
+            }
             sepEasting = Double.parseDouble(sepEastingString) * accuracyBonus;
             sepNorthing = Double.parseDouble(sepNorthingString) * accuracyBonus;
         }
@@ -384,11 +432,45 @@ public final class MGRS {
 
     // ========== Helper Methods ==========
 
+    private static void validateGridLetter(char letter, String component) {
+        if (letter < 'A' || letter > 'Z' || letter == 'I' || letter == 'O') {
+            throw new IllegalArgumentException("Invalid MGRS " + component + " grid letter: " + letter);
+        }
+    }
+
+    private static void validateEastingForSet(char letter, int set) {
+        String validLetters;
+        switch ((set - 1) % 3) {
+            case 0:
+                validLetters = "ABCDEFGH";
+                break;
+            case 1:
+                validLetters = "JKLMNPQR";
+                break;
+            default:
+                validLetters = "STUVWXYZ";
+                break;
+        }
+        if (validLetters.indexOf(letter) < 0) {
+            throw new IllegalArgumentException(
+                "Invalid MGRS easting grid letter " + letter + " for 100km set " + set);
+        }
+    }
+
+    private static boolean allDigits(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            if (!Character.isDigit(value.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Get the MGRS latitude band letter for a given latitude.
      */
     private static char getLetterDesignator(double lat) {
-        if (lat >= 84 || lat < -80) {
+        if (lat > 84 || lat < -80) {
             return 'Z'; // Outside MGRS bounds
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/mgrs/MGRS.java
+++ b/src/main/java/org/datasyslab/proj4sedona/mgrs/MGRS.java
@@ -15,6 +15,14 @@ package org.datasyslab.proj4sedona.mgrs;
  * - Easting and northing within the grid square (variable precision)
  * 
  * Example: "33UUP0500011950" represents a point in UTM zone 33U
+ *
+ * <p>Input validation intentionally differs from mgrs 2.2.0 in two places. This
+ * decoder rejects a 100km easting letter that does not belong to the numeric
+ * zone's grid set; upstream accepts such references and can return a coordinate
+ * outside the named zone. This decoder also ignores every character recognized
+ * by {@link Character#isWhitespace(char)}, while upstream removes ASCII spaces
+ * only. These stricter grid checks and broader whitespace normalization are
+ * deliberate Java API behavior.</p>
  * 
  * Usage:
  * <pre>
@@ -388,9 +396,6 @@ public final class MGRS {
         if (zoneLetter <= 'A' || zoneLetter == 'B' || zoneLetter == 'Y' || zoneLetter >= 'Z' 
             || zoneLetter == 'I' || zoneLetter == 'O') {
             throw new IllegalArgumentException("Invalid zone letter '" + zoneLetter + "' in: " + mgrsString);
-        }
-        if (zoneLetter == 'X' && (zoneNumber == 32 || zoneNumber == 34 || zoneNumber == 36)) {
-            throw new IllegalArgumentException("Invalid Svalbard MGRS zone: " + zoneNumber + zoneLetter);
         }
 
         // Parse 100km grid square

--- a/src/main/java/org/datasyslab/proj4sedona/mgrs/MGRS.java
+++ b/src/main/java/org/datasyslab/proj4sedona/mgrs/MGRS.java
@@ -1,7 +1,5 @@
 package org.datasyslab.proj4sedona.mgrs;
 
-import java.util.Locale;
-
 /**
  * Military Grid Reference System (MGRS) coordinate converter.
  * Mirrors: proj4js/mgrs v2.2.0 {@code mgrs.js}
@@ -343,11 +341,21 @@ public final class MGRS {
         StringBuilder normalized = new StringBuilder(mgrsString.length());
         for (int index = 0; index < mgrsString.length(); index++) {
             char character = mgrsString.charAt(index);
-            if (!Character.isWhitespace(character)) {
+            if (Character.isWhitespace(character)) {
+                continue;
+            }
+            if (character >= 'a' && character <= 'z') {
+                normalized.append((char) (character - ('a' - 'A')));
+            } else if (isAsciiDigit(character)
+                    || (character >= 'A' && character <= 'Z')) {
                 normalized.append(character);
+            } else {
+                throw new IllegalArgumentException(
+                    "MGRS strings may contain only ASCII letters, digits, and whitespace: "
+                        + mgrsString);
             }
         }
-        mgrsString = normalized.toString().toUpperCase(Locale.ROOT);
+        mgrsString = normalized.toString();
         if (mgrsString.isEmpty()) {
             throw new IllegalArgumentException("MGRS string cannot be blank");
         }
@@ -357,7 +365,7 @@ public final class MGRS {
         int i = 0;
 
         // Parse zone number
-        while (i < length && Character.isDigit(mgrsString.charAt(i))) {
+        while (i < length && isAsciiDigit(mgrsString.charAt(i))) {
             if (i >= 2) {
                 throw new IllegalArgumentException("Invalid MGRS string: " + mgrsString);
             }
@@ -459,11 +467,15 @@ public final class MGRS {
 
     private static boolean allDigits(String value) {
         for (int i = 0; i < value.length(); i++) {
-            if (!Character.isDigit(value.charAt(i))) {
+            if (!isAsciiDigit(value.charAt(i))) {
                 return false;
             }
         }
         return true;
+    }
+
+    private static boolean isAsciiDigit(char value) {
+        return value >= '0' && value <= '9';
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/mgrs/MGRSTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/mgrs/MGRSTest.java
@@ -160,10 +160,12 @@ public class MGRSTest {
     }
 
     @Test
-    void testWhitespaceTolerantDecoding() {
+    void testIntentionalWhitespaceNormalizationDivergenceFromUpstream() {
         double[] expectedPoint = MGRS.toPoint("4QFJ1234567890");
         double[] expectedBounds = MGRS.inverse("4QFJ1234567890");
 
+        // mgrs 2.2.0 strips ASCII spaces only. The Java API deliberately ignores
+        // every Character.isWhitespace character, including tabs and line breaks.
         assertArrayEquals(expectedPoint, MGRS.toPoint("4QFJ 12345 67890"), 0.0);
         assertArrayEquals(expectedPoint, MGRS.toPoint("\t4QFJ\n12345 67890\r"), 0.0);
         assertArrayEquals(expectedBounds, MGRS.inverse("4Q FJ 12345 67890"), 0.0);
@@ -245,6 +247,30 @@ public class MGRSTest {
         
         assertTrue(mgrs.startsWith("33X"), "Svalbard should use zone 33X");
         System.out.println("Longyearbyen, Svalbard: " + mgrs);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "8.9, 32XMU9883228094, 31X",
+        "20.9, 34XDU9883228094, 33X",
+        "32.9, 36XVU9883228094, 35X"
+    })
+    void testExactNorthernBoundaryUsesOrdinarySvalbardZones(
+            double lon, String expectedMgrs, String belowBoundaryZone) {
+        String mgrs = MGRS.forward(new double[]{lon, 84.0}, 5);
+
+        // The upstream Svalbard remap covers 72 <= latitude < 84. At exactly
+        // 84 degrees, ordinary zoning can therefore produce 32X, 34X, or 36X.
+        assertEquals(expectedMgrs, mgrs);
+        assertTrue(MGRS.forward(new double[]{lon, Math.nextDown(84.0)}, 5)
+            .startsWith(belowBoundaryZone));
+
+        double[] point = MGRS.toPoint(mgrs);
+        double[] bounds = MGRS.inverse(mgrs);
+        assertEquals(lon, point[0], TOLERANCE);
+        assertEquals(84.0, point[1], TOLERANCE);
+        assertEquals((bounds[0] + bounds[2]) / 2, point[0], 0.0);
+        assertEquals((bounds[1] + bounds[3]) / 2, point[1], 0.0);
     }
 
     // ========== Edge Case Tests ==========
@@ -380,7 +406,20 @@ public class MGRSTest {
         assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UIA"));
         assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UXZ"));
         assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UAP"));
-        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("32XNA"));
+    }
+
+    @Test
+    void testWrongSet100kmColumnIsRejectedUnlikeUpstream() {
+        // mgrs 2.2.0 accepts this zone-18 reference even though J belongs to the
+        // wrong 100km column set, then returns a coordinate outside the zone.
+        String wrongSet = "18SJJ2338308450";
+
+        IllegalArgumentException pointError = assertThrows(
+            IllegalArgumentException.class, () -> MGRS.toPoint(wrongSet));
+        IllegalArgumentException inverseError = assertThrows(
+            IllegalArgumentException.class, () -> MGRS.inverse(wrongSet));
+        assertTrue(pointError.getMessage().contains("for 100km set"));
+        assertTrue(inverseError.getMessage().contains("for 100km set"));
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/mgrs/MGRSTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/mgrs/MGRSTest.java
@@ -383,6 +383,14 @@ public class MGRSTest {
         assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("32XNA"));
     }
 
+    @Test
+    void testNonAsciiTokensAreRejectedBeforeNormalization() {
+        for (String invalid : new String[]{"٣٣UXP", "33Uß"}) {
+            assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint(invalid), invalid);
+            assertThrows(IllegalArgumentException.class, () -> MGRS.inverse(invalid), invalid);
+        }
+    }
+
     // ========== Known Coordinate Tests ==========
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/mgrs/MGRSTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/mgrs/MGRSTest.java
@@ -90,6 +90,7 @@ public class MGRSTest {
 
     @ParameterizedTest
     @CsvSource({
+        "0, 5",   // 100km accuracy: zone(2) + letter(1) + grid(2)
         "1, 7",   // 10km accuracy: zone(2) + letter(1) + grid(2) + easting(1) + northing(1)
         "2, 9",   // 1km accuracy: zone(2) + letter(1) + grid(2) + easting(2) + northing(2)
         "3, 11",  // 100m accuracy: zone(2) + letter(1) + grid(2) + easting(3) + northing(3)
@@ -102,6 +103,37 @@ public class MGRSTest {
         
         assertEquals(expectedLength, mgrs.length(), 
             "Accuracy " + accuracy + " should give " + expectedLength + " char MGRS");
+    }
+
+    @Test
+    void testUpstreamFirstSetRegressionVectors() {
+        double[] point = MGRS.toPoint("33UXP04");
+
+        assertEquals(16.41450040258237, point[0], 1e-9);
+        assertEquals(48.24949021548379, point[1], 1e-9);
+        assertEquals("33UXP0500444997", MGRS.forward(point));
+        assertEquals("33UXP04", MGRS.forward(point, 1));
+        assertEquals("33UXP", MGRS.forward(point, 0));
+    }
+
+    @Test
+    void testUpstreamZoneBorderRegressionVectors() {
+        double[] point = MGRS.toPoint("24XWT783908");
+
+        assertEquals(-32.664334461480315, point[0], 1e-9);
+        assertEquals(83.6277777848563, point[1], 1e-9);
+        assertEquals("25XEN041865", MGRS.forward(point, 3));
+        assertEquals("25XEN", MGRS.forward(point, 0));
+    }
+
+    @Test
+    void testUpstreamForwardRegressionVectors() {
+        assertEquals("31NAA6602100000", MGRS.forward(new double[]{0.0, 0.0}, 5));
+        assertEquals("31NAA6602100001", MGRS.forward(new double[]{0.0, 0.00001}, 5));
+        assertEquals(
+            "11SPA7234911844",
+            MGRS.forward(new double[]{-115.0820944, 36.2361322}, 5));
+        assertEquals("11SPA", MGRS.forward(new double[]{-115.0820944, 36.2361322}, 0));
     }
 
     // ========== Inverse Conversion Tests ==========
@@ -125,6 +157,16 @@ public class MGRSTest {
         
         assertNotNull(bbox);
         assertEquals(4, bbox.length);
+    }
+
+    @Test
+    void testWhitespaceTolerantDecoding() {
+        double[] expectedPoint = MGRS.toPoint("4QFJ1234567890");
+        double[] expectedBounds = MGRS.inverse("4QFJ1234567890");
+
+        assertArrayEquals(expectedPoint, MGRS.toPoint("4QFJ 12345 67890"), 0.0);
+        assertArrayEquals(expectedPoint, MGRS.toPoint("\t4QFJ\n12345 67890\r"), 0.0);
+        assertArrayEquals(expectedBounds, MGRS.inverse("4Q FJ 12345 67890"), 0.0);
     }
 
     // ========== toPoint Tests ==========
@@ -216,6 +258,29 @@ public class MGRSTest {
         assertTrue(mgrs.startsWith("60"), "Longitude 180 should be in zone 60");
     }
 
+    @ParameterizedTest
+    @CsvSource({
+        "-180.0, -80.0, 1CDM4186716915",
+        "180.0, -80.0, 60CWS5813216915",
+        "-180.0, 84.0, 1XDP6500529005",
+        "180.0, 84.0, 60XWU3499429005"
+    })
+    void testSupportedBoundaryCoordinates(double lon, double lat, String expected) {
+        assertEquals(expected, MGRS.forward(new double[]{lon, lat}, 5));
+    }
+
+    @Test
+    void testRejectsCoordinatesOutsideSupportedBoundaries() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{Math.nextDown(-180.0), 0.0}));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{Math.nextUp(180.0), 0.0}));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{0.0, Math.nextDown(-80.0)}));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{0.0, Math.nextUp(84.0)}));
+    }
+
     @Test
     void testNearPoles() {
         // Near north pole (but within MGRS bounds)
@@ -254,10 +319,39 @@ public class MGRSTest {
 
     @Test
     void testInvalidMGRSNull() {
-        // Null input throws either IllegalArgumentException or NullPointerException
-        assertThrows(Exception.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             MGRS.toPoint(null);
         });
+        assertThrows(IllegalArgumentException.class, () -> MGRS.inverse(null));
+    }
+
+    @Test
+    void testInvalidMGRSWhitespaceOnly() {
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint(" \t\n\r "));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.inverse(" \t\n\r "));
+    }
+
+    @Test
+    void testInvalidForwardCoordinateShapeAndValues() {
+        assertThrows(IllegalArgumentException.class, () -> MGRS.forward(null));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.forward(new double[0]));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.forward(new double[]{0.0}));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{Double.NaN, 0.0}));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{0.0, Double.NaN}));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{Double.POSITIVE_INFINITY, 0.0}));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{0.0, Double.NEGATIVE_INFINITY}));
+    }
+
+    @Test
+    void testInvalidAccuracy() {
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{0.0, 0.0}, -1));
+        assertThrows(IllegalArgumentException.class,
+            () -> MGRS.forward(new double[]{0.0, 0.0}, 6));
     }
 
     @Test
@@ -274,6 +368,19 @@ public class MGRSTest {
         assertThrows(IllegalArgumentException.class, () -> {
             MGRS.toPoint("18SUJ23383"); // 5 digits instead of 4 or 6
         });
+    }
+
+    @Test
+    void testInvalidMGRSZonePrecisionAndCharacters() {
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("0NAA"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("61NAA"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("99ZZZ"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UXP123456123456"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UXP12A4"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UIA"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UXZ"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("33UAP"));
+        assertThrows(IllegalArgumentException.class, () -> MGRS.toPoint("32XNA"));
     }
 
     // ========== Known Coordinate Tests ==========
@@ -349,5 +456,29 @@ public class MGRSTest {
         
         assertTrue(lonSpan < 0.0001, "1m precision should have tiny longitude span");
         assertTrue(latSpan < 0.0001, "1m precision should have tiny latitude span");
+    }
+
+    @Test
+    void testHundredKilometerCellBoundsAndCenterMatchUpstream() {
+        double[] expectedBounds = {
+            16.33659097483748,
+            47.84556125140088,
+            17.719358497550818,
+            48.720914867739545
+        };
+        double[] expectedCenter = {17.02797473619415, 48.28323805957021};
+
+        assertArrayEquals(expectedBounds, MGRS.inverse("33UXP"), 1e-9);
+        assertArrayEquals(expectedCenter, MGRS.toPoint("33UXP"), 1e-9);
+        assertEquals("33UXP", MGRS.forward(expectedCenter, 0));
+    }
+
+    @Test
+    void testHundredKilometerCellCenterSecondUpstreamRegression() {
+        double[] center = MGRS.toPoint("34PBQ");
+
+        assertEquals(18.729117730990232, center[0], 1e-9);
+        assertEquals(8.587478059960034, center[1], 1e-9);
+        assertEquals("34PBQ", MGRS.forward(center, 0));
     }
 }


### PR DESCRIPTION
## Summary

- align MGRS encoding and decoding with upstream MGRS 2.2.0
- use truncation for easting and northing digits and support accuracy level zero
- validate zones, grid letters, precision, coordinate ranges, ASCII input, whitespace, and case consistently
- update public examples and MGRS documentation

## Root cause

The port retained behavior from an older MGRS implementation and accepted several inputs that current upstream rejects. It also rounded numeric components where upstream truncates them, producing different references near cell boundaries.

## Impact

Generated references now match upstream exactly, malformed tokens fail predictably, and coarse-cell inverse results follow the current library contract.

## Validation

- focused MGRS suite: 56/56 passed
- full Maven suite: 974/974 passed
- differential checks: 2,406 forward cases matched exactly; 401 inverse cases stayed within `2.84e-14` degrees
