### PR TITLE
Align projection defaults with proj4js and PROJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,10 @@ known to be wrong; each is noted in the relevant Javadoc and pinned by a test):
 | [wkt-parser](https://github.com/proj4js/wkt-parser) | v1.5.5 | 2026-07-13 (audit) |
 | [mgrs](https://github.com/proj4js/mgrs) | v1.0.0 | — |
 
+The projection-parity fixtures additionally target proj4js master commit `888ce3a`.
+Some covered behavior is newer than the published `proj4@2.20.9` npm package and may
+differ until the next upstream release.
+
 To find upstream changes that may need porting since the last sync:
 
 ```bash

--- a/docs/constants-reference.md
+++ b/docs/constants-reference.md
@@ -15,7 +15,7 @@ Retrieved via `Datum.get(code)`. The `towgs84` field contains the parameters for
 | `ch1903` | bessel | `674.374,15.056,405.346` | Swiss CH1903 |
 | `ggrs87` | GRS80 | `-199.87,74.79,246.62` | Greek Geodetic Reference System 1987 |
 | `potsdam` | bessel | `598.1,73.7,418.2,0.202,0.045,-2.455,6.7` | Potsdam Rauenberg 1950 DHDN |
-| `carthage` | clark80 | `-263.0,6.0,431.0` | Carthage 1934 Tunisia |
+| `carthage` | clrk80ign | `-263.0,6.0,431.0` | Carthage 1934 Tunisia |
 | `hermannskogel` | bessel | `577.326,90.129,463.919,5.137,1.474,5.297,2.4232` | Hermannskogel |
 | `mgi` | bessel | `577.326,90.129,463.919,5.137,1.474,5.297,2.4232` | Militar-Geographische Institut |
 | `osni52` | airy | `482.530,-130.596,564.557,-1.042,-0.214,-0.631,8.15` | Irish National |

--- a/docs/datum-transformations.md
+++ b/docs/datum-transformations.md
@@ -100,7 +100,7 @@ Proj4Sedona includes definitions for common datums. Each datum specifies an elli
 | `potsdam` | bessel | 7-param | Potsdam Rauenberg 1950 DHDN |
 | `ch1903` | bessel | 3-param | Swiss CH1903 |
 | `ggrs87` | GRS80 | 3-param | Greek Geodetic Reference System 1987 |
-| `carthage` | clark80 | 3-param | Carthage 1934 Tunisia |
+| `carthage` | clrk80ign | 3-param | Carthage 1934 Tunisia |
 | `hermannskogel` | bessel | 7-param | Hermannskogel |
 | `mgi` | bessel | 7-param | Militar-Geographische Institut |
 | `osni52` | airy | 7-param | Irish National |

--- a/scripts/pyproj-reference/generate_transform_reference.py
+++ b/scripts/pyproj-reference/generate_transform_reference.py
@@ -133,8 +133,11 @@ def get_projection_coverage_pairs() -> List[Dict[str, Any]]:
         {
             "name": "proj_eqc",
             "from_crs": "EPSG:4326",
-            "to_crs": "+proj=eqc +lat_ts=30 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
-            "desc": "Equidistant Cylindrical",
+            # The small nonzero origin makes an omitted origin shift obvious while
+            # keeping every shared +/-89.9-degree point inside proj4js's adjust_lat
+            # domain, where its behavior can be compared directly with PROJ.
+            "to_crs": "+proj=eqc +lat_0=0.05 +lat_ts=30 +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs",
+            "desc": "Equidistant Cylindrical (nonzero natural origin)",
         },
         {
             "name": "proj_cea",

--- a/src/main/java/org/datasyslab/proj4sedona/constants/Datum.java
+++ b/src/main/java/org/datasyslab/proj4sedona/constants/Datum.java
@@ -52,7 +52,7 @@ public final class Datum {
     /** German DHDN datum (Potsdam) */
     public static final Datum POTSDAM = register("potsdam", "598.1,73.7,418.2,0.202,0.045,-2.455,6.7", "bessel", "Potsdam Rauenberg 1950 DHDN");
     /** Carthage datum (Tunisia) */
-    public static final Datum CARTHAGE = register("carthage", "-263.0,6.0,431.0", "clark80", "Carthage 1934 Tunisia");
+    public static final Datum CARTHAGE = register("carthage", "-263.0,6.0,431.0", "clrk80ign", "Carthage 1934 Tunisia");
     /** Austrian MGI datum */
     public static final Datum HERMANNSKOGEL = register("hermannskogel", "577.326,90.129,463.919,5.137,1.474,5.297,2.4232", "bessel", "Hermannskogel");
     /** Austrian Military Geographic Institute datum */

--- a/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
+++ b/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
@@ -88,10 +88,8 @@ public final class Ellipsoid {
     public static final Ellipsoid MPRTS = register("mprts", 6397300, 191, "Maupertius 1738");
     public static final Ellipsoid NEW_INTL = registerWithB("new_intl", 6378157.5, 6356772.2, "New International 1967");
     /**
-     * Plessis 1817. Documented divergence from proj4js, whose table stores 6355863
-     * as the inverse flattening (a typo — it is the semi-minor axis; the derived
-     * b there is 6376521.997, a near-sphere 20.7 km off). PROJ defines plessis as
-     * a=6376523, b=6355863, which this entry matches.
+     * Plessis 1817. The value 6355863 is the semi-minor axis, not the inverse
+     * flattening; this matches PROJ and current proj4js (a83fc2e).
      */
     public static final Ellipsoid PLESSIS = registerWithB("plessis", 6376523, 6355863, "Plessis 1817 (France)");
     /** Krassovsky 1942 - used in Russia and Eastern Europe */
@@ -107,8 +105,8 @@ public final class Ellipsoid {
     public static final Ellipsoid SPHERE = registerWithB("sphere", 6370997, 6370997, "Normal Sphere (r=6370997)");
 
     static {
-        // Legacy alias: the datum registry's carthage entry (ported from proj4js
-        // constants/Datum.js) spells Clarke 1880 mod. as "clark80".
+        // Keep accepting the legacy "clark80" spelling used by older PROJ strings.
+        // Current proj4js names Carthage's ellipsoid explicitly as "clrk80ign".
         ELLIPSOIDS.put("clark80", CLRK80);
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
+++ b/src/main/java/org/datasyslab/proj4sedona/constants/Ellipsoid.java
@@ -105,8 +105,8 @@ public final class Ellipsoid {
     public static final Ellipsoid SPHERE = registerWithB("sphere", 6370997, 6370997, "Normal Sphere (r=6370997)");
 
     static {
-        // Keep accepting the legacy "clark80" spelling used by older PROJ strings.
-        // Current proj4js names Carthage's ellipsoid explicitly as "clrk80ign".
+        // Legacy compatibility alias: interpret "clark80" as Clarke 1880 mod.
+        // Current proj4js does not define it (and falls back to WGS84); PROJ rejects it.
         ELLIPSOIDS.put("clark80", CLRK80);
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/core/DeriveConstants.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/DeriveConstants.java
@@ -69,8 +69,30 @@ public final class DeriveConstants {
             rfVal = ellipsoidParams[2];
         } else {
             aVal = a;
-            bVal = b != null ? b : 0;
-            rfVal = rf;
+            // PROJ treats a bare +a as spherical shorthand, but retains the named
+            // ellipsoid's flattening when +ellps or +datum is also present. Current
+            // proj4js carries b=undefined/es=NaN for both forms, so prefer PROJ's
+            // executable, serializable semantics.
+            if (b == null && rf == null) {
+                if (ellps == null) {
+                    bVal = aVal;
+                    rfVal = null;
+                    isSphere = true;
+                } else {
+                    Double[] ellipsoidParams = getEllipsoidParams(ellps);
+                    rfVal = ellipsoidParams[2];
+                    if (rfVal == null) {
+                        bVal = aVal;
+                        isSphere = true;
+                    } else {
+                        // Let the shared rf branch below derive b from the explicit a.
+                        bVal = 0.0;
+                    }
+                }
+            } else {
+                bVal = b != null ? b : 0;
+                rfVal = rf;
+            }
         }
 
         // If rf is given but not b, calculate b

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -69,6 +69,12 @@ public class Proj {
         // Process datum definition
         processDatumDef(def);
 
+        // Keep track of whether flattening came from an explicit ellipsoid/datum.
+        // The public definition still receives proj4js's WGS84 default below, but
+        // PROJ treats a bare +a as spherical shorthand and +a with +ellps/+datum as
+        // an ellipsoid using that named flattening.
+        String ellpsForDerivation = def.getEllps();
+
         // Set defaults
         if (def.getK0() == null) def.setK0(1.0);
         if (def.getAxis() == null) def.setAxis("enu");
@@ -79,7 +85,7 @@ public class Proj {
 
         // Derive sphere constants
         DeriveConstants.SphereResult sphere = DeriveConstants.sphere(
-            def.getA(), def.getB(), def.getRf(), def.getEllps(), def.getSphere()
+            def.getA(), def.getB(), def.getRf(), ellpsForDerivation, def.getSphere()
         );
 
         // Derive eccentricity

--- a/src/main/java/org/datasyslab/proj4sedona/projection/CylindricalEqualArea.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/CylindricalEqualArea.java
@@ -10,6 +10,11 @@ import org.datasyslab.proj4sedona.core.Point;
  * 
  * <p>A cylindrical projection that preserves area. Also known as Lambert
  * Cylindrical Equal Area when lat_ts=0.</p>
+ *
+ * <p>A spherical definition with omitted {@code lat_ts} intentionally follows
+ * PROJ and defaults to the equator. Current proj4js leaves that value undefined
+ * and produces non-finite coordinates; the PROJ behavior is executable and is
+ * pinned by {@code ScaleFactorZeroParityTest}.</p>
  */
 public class CylindricalEqualArea implements Projection {
 
@@ -40,7 +45,13 @@ public class CylindricalEqualArea implements Projection {
         this.es = params.es;
         this.e = Math.sqrt(es);
         this.lat0 = params.getLat0();
-        this.latTs = params.getLatTs();
+        // CEA reads lat_ts directly upstream; lat_0 is not a fallback true-scale
+        // latitude. Ellipsoidal proj4js effectively defaults omission to the equator
+        // through its post-init scale fallback, while its spherical path leaks the
+        // missing value into cos(undefined) and returns NaN. Follow PROJ's usable
+        // equatorial default for both paths; the intentional divergence is pinned by
+        // ScaleFactorZeroParityTest.
+        this.latTs = params.latTs != null ? params.latTs : 0.0;
         this.long0 = params.getLong0();
         this.x0 = params.x0;
         this.y0 = params.y0;
@@ -51,6 +62,12 @@ public class CylindricalEqualArea implements Projection {
             k0 = Math.cos(latTs);
         } else {
             k0 = ProjMath.msfnz(e, Math.sin(latTs), Math.cos(latTs));
+            // Proj applies its generic JavaScript-falsy scale fallback after init.
+            // The spherical formulas use cos(lat_ts) directly upstream, so only the
+            // ellipsoidal derived k0 follows this normalization.
+            if (k0 == 0.0 || Double.isNaN(k0)) {
+                k0 = 1.0;
+            }
             qp = ProjMath.qsfnz(e, 1);
             apa = authset(es);
         }

--- a/src/main/java/org/datasyslab/proj4sedona/projection/EquidistantCylindrical.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/EquidistantCylindrical.java
@@ -26,19 +26,36 @@ public class EquidistantCylindrical implements Projection {
     @Override
     public void init(ProjectionParams params) {
         this.a = params.a;
-        this.lat0 = params.getLat0();
-        this.latTs = params.getLatTs();
-        this.long0 = params.getLong0();
-        this.x0 = params.x0;
-        this.y0 = params.y0;
+        this.lat0 = defaultToZero(params.lat0);
+        this.latTs = resolveLatitudeOfTrueScale(params.latTs);
+        this.long0 = defaultToZero(params.long0);
+        this.x0 = defaultToZero(params.x0);
+        this.y0 = defaultToZero(params.y0);
         this.over = params.over;
         this.rc = Math.cos(latTs);
+    }
+
+    /**
+     * Resolve {@code +lat_ts} using JavaScript's {@code value || 0} semantics.
+     * In particular, an omitted, zero, or NaN value selects Plate Carrée rather
+     * than inheriting {@code +lat_0}.
+     */
+    public static double resolveLatitudeOfTrueScale(Double latTs) {
+        return latTs == null ? 0.0 : defaultToZero(latTs);
+    }
+
+    private static double defaultToZero(Double value) {
+        return value == null ? 0.0 : defaultToZero(value.doubleValue());
+    }
+
+    private static double defaultToZero(double value) {
+        return value == 0.0 || Double.isNaN(value) ? 0.0 : value;
     }
 
     @Override
     public Point forward(Point p) {
         double lon = ProjMath.adjustLon(p.x - long0, over);
-        double lat = p.y;
+        double lat = ProjMath.adjustLat(p.y - lat0);
         double x = a * lon * rc + x0;
         double y = a * lat + y0;
         return new Point(x, y, p.z);
@@ -49,7 +66,7 @@ public class EquidistantCylindrical implements Projection {
         double x = p.x - x0;
         double y = p.y - y0;
         double lon = ProjMath.adjustLon(x / (a * rc) + long0, over);
-        double lat = y / a;
+        double lat = ProjMath.adjustLat(lat0 + y / a);
         return new Point(lon, lat, p.z);
     }
 }

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ExtendedTransverseMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ExtendedTransverseMercator.java
@@ -30,7 +30,8 @@ public class ExtendedTransverseMercator implements Projection {
     private static final String[] NAMES = {
         "Extended_Transverse_Mercator", "Extended Transverse Mercator", 
         "etmerc", "Transverse_Mercator", "Transverse Mercator", 
-        "Gauss Kruger", "Gauss_Kruger", "tmerc"
+        "Gauss Kruger", "Gauss_Kruger", "tmerc",
+        "Fast_Transverse_Mercator", "Fast Transverse Mercator"
     };
 
     // Projection parameters
@@ -76,10 +77,19 @@ public class ExtendedTransverseMercator implements Projection {
         this.over = params.over;
         this.approx = params.approx;
 
+        // Current proj4js requires an ellipsoid for exact ETMERC. A sphere is only
+        // supported through the explicitly requested traditional TM algorithm.
+        if (!usesApproximateAlgorithm(params) && (Double.isNaN(es) || es <= 0)) {
+            throw new IllegalArgumentException(
+                "Incorrect elliptical usage. Try using the +approx option in the proj string, "
+                    + "or PROJECTION[\"Fast_Transverse_Mercator\"] in the WKT.");
+        }
+
         // Check if we should use approximate (simple tmerc) mode
-        if (Boolean.TRUE.equals(approx) || Double.isNaN(es) || es <= 0) {
+        if (usesApproximateAlgorithm(params)) {
             useApprox = true;
-            if (es > 0) {
+            this.k0 = params.getK0OrDefault(1.0);
+            if (es != 0.0 && !Double.isNaN(es)) {
                 en = ProjMath.pjEnfn(es);
                 ml0 = ProjMath.pjMlfn(lat0, Math.sin(lat0), Math.cos(lat0), en);
             }
@@ -139,6 +149,21 @@ public class ExtendedTransverseMercator implements Projection {
         Zb = -Qn * (Z + ProjMath.clens(gtu, 2 * Z));
     }
 
+    /** Whether this parameter set takes the traditional Transverse Mercator path. */
+    public static boolean usesApproximateAlgorithm(ProjectionParams params) {
+        return Boolean.TRUE.equals(params.approx) || isFastProjectionName(params.projName);
+    }
+
+    /** Whether a WKT method name directly selects proj4js's traditional TM implementation. */
+    public static boolean isFastProjectionName(String projectionName) {
+        if (projectionName == null) {
+            return false;
+        }
+        String normalized = ProjectionRegistry.getNormalizedProjName(
+            projectionName.toLowerCase(java.util.Locale.ROOT));
+        return "fast_transverse_mercator".equals(normalized);
+    }
+
     /**
      * Forward projection: geographic (lon/lat in radians) to projected (x/y in meters).
      */
@@ -192,6 +217,9 @@ public class ExtendedTransverseMercator implements Projection {
             // Spherical case
             double b = cosPhi * Math.sin(deltaLon);
             if (Math.abs(Math.abs(b) - 1) < 1e-10) {
+                // proj4js returns the legacy numeric error sentinel 93 here. The
+                // Point-returning Java API represents the same singularity as a
+                // non-finite coordinate instead of leaking an incompatible type.
                 return new Point(Double.NaN, Double.NaN, p.z);
             }
             x = 0.5 * a * k0 * Math.log((1 + b) / (1 - b)) + x0;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/GaussSchreiberTransverseMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/GaussSchreiberTransverseMercator.java
@@ -39,7 +39,8 @@ public class GaussSchreiberTransverseMercator implements Projection {
         double pc = Math.asin(sinz / rs);
         double sinzpc = Math.sin(pc);
         this.cp = ProjMath.latiso(0, pc, sinzpc) - rs * ProjMath.latiso(e, lat0, sinz);
-        this.n2 = params.k0 * params.a * Math.sqrt(1 - e * e) / (1 - e * e * sinz * sinz);
+        double k0 = params.getK0OrDefault(1.0);
+        this.n2 = k0 * params.a * Math.sqrt(1 - e * e) / (1 - e * e * sinz * sinz);
         this.xs = params.x0;
         this.ys = params.y0 - n2 * pc;
     }

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Gnomonic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Gnomonic.java
@@ -28,7 +28,7 @@ public class Gnomonic implements Projection {
     @Override
     public void init(ProjectionParams params) {
         this.a = params.a;
-        this.k0 = params.k0;
+        this.k0 = params.getK0OrDefault(1.0);
         this.lat0 = params.getLat0();
         this.long0 = params.getLong0();
         this.x0 = params.x0;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/LambertConformalConic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/LambertConformalConic.java
@@ -38,7 +38,7 @@ public class LambertConformalConic implements Projection {
         this.lat1 = params.getLat1();
         this.lat2 = params.getLat2();
         this.long0 = params.getLong0();
-        this.k0 = params.k0;
+        this.k0 = params.getK0OrDefault(1.0);
         this.x0 = params.x0;
         this.y0 = params.y0;
         this.over = params.over;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Mercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Mercator.java
@@ -58,17 +58,30 @@ public class Mercator implements Projection {
         this.es = 1 - con * con;
         this.e = Math.sqrt(this.es);
 
-        // Determine k0 based on lat_ts or explicit k0
-        // Mirrors: lib/projections/merc.js lines 26-40
-        if (latTs != null) {
-            if (sphere) {
-                this.k0 = Math.cos(latTs);
+        this.k0 = resolveScaleFactor(params);
+    }
+
+    /** Resolve Mercator's lat_ts precedence followed by Proj's falsy scale fallback. */
+    public static double resolveScaleFactor(ProjectionParams params) {
+        Double latitudeOfTrueScale = params.latTs;
+        double scale;
+        if (latitudeOfTrueScale != null
+                && latitudeOfTrueScale != 0.0
+                && !Double.isNaN(latitudeOfTrueScale)) {
+            if (params.sphere) {
+                scale = Math.cos(latitudeOfTrueScale);
             } else {
-                this.k0 = ProjMath.msfnz(this.e, Math.sin(latTs), Math.cos(latTs));
+                // merc.init recomputes eccentricity from the axes, as current
+                // proj4js does. In particular, +R_A may set params.es to zero
+                // before Mercator restores the ellipsoidal value here.
+                double axisRatio = params.b / params.a;
+                double eccentricity = Math.sqrt(1.0 - axisRatio * axisRatio);
+                scale = ProjMath.msfnz(eccentricity,
+                    Math.sin(latitudeOfTrueScale), Math.cos(latitudeOfTrueScale));
             }
-        } else {
-            this.k0 = params.k0;
+            return scale == 0.0 || Double.isNaN(scale) ? 1.0 : scale;
         }
+        return params.getK0OrDefault(1.0);
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ObliqueMercator.java
@@ -64,7 +64,7 @@ public class ObliqueMercator implements Projection {
         this.a = params.a;
         this.es = params.es;
         this.e = Math.sqrt(es);
-        this.k0 = params.k0;
+        this.k0 = params.getK0OrDefault(1.0);
         this.lat0 = params.getLat0();
         this.x0 = params.x0;
         this.y0 = params.y0;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -96,6 +96,10 @@ public class ProjectionParams {
     /**
      * Resolve a projection-local scale default using JavaScript numeric truthiness.
      * Current proj4js treats zero and NaN as absent when applying these defaults.
+     *
+     * <p>The CRS serializer transition in PR #117 temporarily uses the presence of this
+     * exact method as a capability marker. Do not rename or remove it until that
+     * transition is cleaned up.</p>
      */
     public double getK0OrDefault(double defaultValue) {
         return k0 == 0.0 || Double.isNaN(k0) ? defaultValue : k0;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -92,6 +92,14 @@ public class ProjectionParams {
     
     /** Scale factor at central meridian (+k_0 or +k), defaults to 1.0 */
     public double k0 = 1.0;
+
+    /**
+     * Resolve a projection-local scale default using JavaScript numeric truthiness.
+     * Current proj4js treats zero and NaN as absent when applying these defaults.
+     */
+    public double getK0OrDefault(double defaultValue) {
+        return k0 == 0.0 || Double.isNaN(k0) ? defaultValue : k0;
+    }
     
     /** False easting in projection units (+x_0), defaults to 0.0 */
     public double x0 = 0.0;
@@ -224,6 +232,9 @@ public class ProjectionParams {
 
     /**
      * Get second standard parallel (lat2), defaulting to lat1 if not set.
+     * An explicit zero is preserved. This intentionally follows PROJ rather than
+     * proj4js's truthy {@code lat2 || lat1} fallback, which loses an equatorial
+     * second standard parallel.
      * @return Second standard parallel in radians
      */
     public double getLat2() {

--- a/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/Stereographic.java
@@ -28,7 +28,6 @@ public class Stereographic implements Projection {
 
     private double a, e, es, lat0, long0, k0, x0, y0;
     private double sinlat0, coslat0, con, cons, ms1, X0, cosX0, sinX0;
-    private Double latTs;
     private boolean sphere;
     private Boolean over;
 
@@ -42,34 +41,56 @@ public class Stereographic implements Projection {
         this.e = Math.sqrt(es);
         this.lat0 = params.getLat0();
         this.long0 = params.getLong0();
-        this.k0 = params.k0;
         this.x0 = params.x0;
         this.y0 = params.y0;
-        this.latTs = params.latTs;
         this.sphere = params.sphere;
         this.over = params.over;
 
         coslat0 = Math.cos(lat0);
         sinlat0 = Math.sin(lat0);
 
-        if (sphere) {
-            if (k0 == 1 && latTs != null && Math.abs(coslat0) <= Values.EPSLN) {
-                k0 = 0.5 * (1 + ProjMath.sign(lat0) * Math.sin(latTs));
-            }
-        } else {
+        if (!sphere) {
             if (Math.abs(coslat0) <= Values.EPSLN) {
                 con = (lat0 > 0) ? 1 : -1;  // North or South pole
             }
             cons = Math.sqrt(Math.pow(1 + e, 1 + e) * Math.pow(1 - e, 1 - e));
-            if (k0 == 1 && latTs != null && Math.abs(coslat0) <= Values.EPSLN && Math.abs(Math.cos(latTs)) > Values.EPSLN) {
-                k0 = 0.5 * cons * ProjMath.msfnz(e, Math.sin(latTs), Math.cos(latTs)) / 
-                     ProjMath.tsfnz(e, con * latTs, con * Math.sin(latTs));
-            }
             ms1 = ProjMath.msfnz(e, sinlat0, coslat0);
             X0 = 2 * Math.atan(ssfn(lat0, sinlat0, e)) - Values.HALF_PI;
             cosX0 = Math.cos(X0);
             sinX0 = Math.sin(X0);
         }
+
+        this.k0 = resolveScaleFactor(params);
+    }
+
+    /** Whether current proj4js derives the polar scale from {@code lat_ts}. */
+    public static boolean derivesScaleFromLatitudeOfTrueScale(ProjectionParams params) {
+        if (params.latTs == null || Double.isNaN(params.latTs)
+                || Math.abs(Math.cos(params.getLat0())) > Values.EPSLN) {
+            return false;
+        }
+        return params.sphere || Math.abs(Math.cos(params.latTs)) > Values.EPSLN;
+    }
+
+    /** Resolve init-time {@code lat_ts} precedence followed by Proj's scale-one fallback. */
+    public static double resolveScaleFactor(ProjectionParams params) {
+        double scale = params.k0;
+        if (derivesScaleFromLatitudeOfTrueScale(params)) {
+            double lat0 = params.getLat0();
+            double latTs = params.latTs;
+            if (params.sphere) {
+                scale = 0.5 * (1 + ProjMath.sign(lat0) * Math.sin(latTs));
+            } else {
+                double e = Math.sqrt(params.es);
+                double con = lat0 > 0 ? 1 : -1;
+                double cons = Math.sqrt(
+                    Math.pow(1 + e, 1 + e) * Math.pow(1 - e, 1 - e));
+                scale = 0.5 * cons
+                    * ProjMath.msfnz(e, Math.sin(latTs), Math.cos(latTs))
+                    / ProjMath.tsfnz(e, con * latTs, con * Math.sin(latTs));
+            }
+        }
+        return scale == 0.0 || Double.isNaN(scale) ? 1.0 : scale;
     }
 
     private double ssfn(double phit, double sinphi, double eccen) {

--- a/src/main/java/org/datasyslab/proj4sedona/projection/StereographicAlternative.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/StereographicAlternative.java
@@ -39,7 +39,7 @@ public class StereographicAlternative implements Projection {
         this.e = Math.sqrt(es);
         this.lat0 = params.getLat0();
         this.long0 = params.getLong0();
-        this.k0 = params.k0;
+        this.k0 = params.getK0OrDefault(1.0);
         this.x0 = params.x0;
         this.y0 = params.y0;
         this.over = params.over;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercator.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercator.java
@@ -37,7 +37,8 @@ public class SwissObliqueMercator implements Projection {
         double flattening = 1 / invF;
         double e2 = 2 * flattening - Math.pow(flattening, 2);
         this.e = Math.sqrt(e2);
-        this.R = params.k0 * semiMajorAxis * Math.sqrt(1 - e2) / (1 - e2 * Math.pow(sinPhy0, 2));
+        double k0 = params.getK0OrDefault(1.0);
+        this.R = k0 * semiMajorAxis * Math.sqrt(1 - e2) / (1 - e2 * Math.pow(sinPhy0, 2));
         this.alpha = Math.sqrt(1 + e2 / (1 - e2) * Math.pow(Math.cos(phy0), 4));
         this.b0 = Math.asin(sinPhy0 / this.alpha);
         double k1 = Math.log(Math.tan(Math.PI / 4 + this.b0 / 2));

--- a/src/main/java/org/datasyslab/proj4sedona/projection/UTM.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/UTM.java
@@ -27,7 +27,11 @@ import org.datasyslab.proj4sedona.core.Point;
  * </pre>
  * 
  * <p>This implementation delegates to {@link ExtendedTransverseMercator} for the
- * actual projection math, after setting up the UTM-specific parameters.</p>
+ * actual projection math, after setting up the UTM-specific parameters. With
+ * {@code +approx}, this port intentionally keeps the traditional TM path selected by
+ * that delegate. Current proj4js (commit 888ce3a) overwrites the approximate functions
+ * after initialization and effectively ignores the flag for UTM. Honoring it matches
+ * proj4js's own {@code +proj=tmerc +approx} expansion and PROJ more closely.</p>
  */
 public class UTM implements Projection {
 

--- a/src/main/java/org/datasyslab/proj4sedona/projection/VanDerGrinten.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/VanDerGrinten.java
@@ -10,10 +10,9 @@ import org.datasyslab.proj4sedona.core.Point;
  *
  * <p>Projects the world into a circle. Computed on a sphere of radius {@code a}.</p>
  *
- * <p>proj4js's vandg forward leaves the equator/meridian/pole special cases unreturned,
- * so the general formula overwrites them and divides by zero at the equator (it throws
- * on the resulting non-finite value). This port returns those special cases, matching
- * PROJ, so the equator and poles project correctly.</p>
+ * <p>The equator/meridian/pole branches return immediately so the general formula
+ * cannot divide by zero on either axis. This matches PROJ and current proj4js
+ * (7e58cf1).</p>
  */
 public class VanDerGrinten implements Projection {
 

--- a/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/Proj4jsBackportsTest.java
@@ -3,6 +3,7 @@ package org.datasyslab.proj4sedona;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.datasyslab.proj4sedona.constants.Datum;
 import org.datasyslab.proj4sedona.constants.Values;
 import org.datasyslab.proj4sedona.core.Point;
 import org.datasyslab.proj4sedona.core.Proj;
@@ -22,6 +23,58 @@ class Proj4jsBackportsTest {
     @BeforeAll
     static void setup() {
         ProjectionRegistry.start();
+    }
+
+    @Test
+    @DisplayName("proj4js 6fa5384: Carthage uses the Clarke 1880 (IGN) ellipsoid")
+    void testCarthageEllipsoid() {
+        Datum carthage = Datum.get("carthage");
+        assertNotNull(carthage);
+        assertEquals("clrk80ign", carthage.getEllipse(), "current upstream ellipsoid code");
+
+        Proj crs = new Proj("+proj=longlat +datum=carthage +no_defs");
+        assertEquals("clrk80ign", crs.getParams().ellps, "resolved ellipsoid code");
+        assertEquals(6378249.2, crs.getParams().a, 1e-9, "semi-major axis");
+        assertEquals(6356515.0, crs.getParams().b, 1e-9, "semi-minor axis");
+        assertEquals(293.4660213, crs.getParams().rf, 1e-9, "inverse flattening");
+
+        // Current proj4js testData vector, also matching PROJ.
+        Converter conv = Proj4.proj4(WGS84,
+            "+proj=utm +zone=32 +datum=carthage +units=m +no_defs");
+        Point xy = conv.forward(new Point(10, 36));
+        assertEquals(590082.503079214, xy.x, 0.01, "easting");
+        assertEquals(3983954.003957999, xy.y, 0.01, "northing");
+    }
+
+    @Test
+    @DisplayName("proj4js 71b4ffc: scale-one projections retain their default")
+    void testProjectionScaleOneDefaults() {
+        // These are the four projection initializers that current proj4js explicitly
+        // defaults to one after moving the generic default past projection init.
+        String[][] cases = {
+            {"+proj=tmerc +lat_0=0 +lon_0=3 +ellps=WGS84 +units=m +no_defs", "4", "50"},
+            {"+proj=gstmerc +lat_0=-21.116666667 +lon_0=55.53333333 "
+                + "+x_0=160000 +y_0=50000 +ellps=intl +units=m +no_defs", "55.5", "-21.1"},
+            {"+proj=omerc +lat_0=37.4769061 +lonc=141.0039618 +alpha=202.22 "
+                + "+x_0=138 +y_0=77.65 +ellps=WGS84 +units=m +no_defs", "141.003611", "37.476802"},
+            {"+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 "
+                + "+x_0=600000 +y_0=200000 +ellps=bessel +units=m +no_defs", "8.55", "47.37"},
+        };
+
+        for (String[] c : cases) {
+            Proj implicit = new Proj(c[0]);
+            Proj explicit = new Proj(c[0] + " +k=1");
+            assertEquals(1.0, implicit.getParams().k0, 0.0, c[0]);
+
+            Point input = new Point(
+                Double.parseDouble(c[1]) * Values.D2R,
+                Double.parseDouble(c[2]) * Values.D2R);
+            Point actual = implicit.forward(input);
+            Point expected = explicit.forward(input);
+            assertTrue(Double.isFinite(actual.x) && Double.isFinite(actual.y), c[0]);
+            assertEquals(expected.x, actual.x, 1e-8, "default-one easting: " + c[0]);
+            assertEquals(expected.y, actual.y, 1e-8, "default-one northing: " + c[0]);
+        }
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -1420,7 +1420,7 @@ class CRSSerializerTest {
         Proj p = new Proj("+proj=longlat +ellps=bess-nam +no_defs");
         assertEquals(6377483.865, p.getParams().a, 1e-6, "bess-nam resolves to bess_nam");
 
-        // The legacy clark80 alias spelling resolves to clrk80 (carthage's ellipse).
+        // The legacy clark80 alias spelling resolves to clrk80 (Clarke 1880 mod.).
         assertEquals(6378249.145,
             new Proj("+proj=longlat +ellps=clark80 +no_defs").getParams().a, 1e-6);
 

--- a/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
@@ -273,6 +273,17 @@ class AllProjectionsTest {
     }
 
     @Test
+    void testLccExplicitEquatorialSecondParallelMatchesProj() {
+        Converter converter = Proj4.proj4(
+            "+proj=longlat +datum=WGS84",
+            "+proj=lcc +lat_1=30 +lat_2=0 +lat_0=10 +lon_0=0 +ellps=WGS84"
+        );
+        Point projected = converter.forward(new Point(5, 20));
+        assertEquals(507252.1405529205, projected.x, 1e-6);
+        assertEquals(1076164.3771528224, projected.y, 1e-6);
+    }
+
+    @Test
     void testLAEAAtPole() {
         Converter conv = Proj4.proj4(
             "+proj=longlat +datum=WGS84",

--- a/src/test/java/org/datasyslab/proj4sedona/projection/EquidistantCylindricalTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/EquidistantCylindricalTest.java
@@ -1,0 +1,68 @@
+package org.datasyslab.proj4sedona.projection;
+
+import org.datasyslab.proj4sedona.Proj4;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.transform.Converter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Regression tests against proj4js 2.20.9 lib/projections/eqc.js. */
+class EquidistantCylindricalTest {
+
+    private static final double XY_TOLERANCE = 1e-6;
+    private static final double ANGULAR_TOLERANCE = 1e-12;
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+    private static final String EQC =
+        "+proj=eqc +lat_0=20 +lat_ts=30 +lon_0=10 "
+            + "+x_0=1234 +y_0=-5678 +datum=WGS84 +units=m +no_defs";
+
+    @BeforeEach
+    void setUp() {
+        ProjectionRegistry.reset();
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void nonzeroLatitudeOfOriginMatchesProj4jsForwardAndInverse() {
+        Converter converter = Proj4.proj4(WGS84, EQC);
+
+        Point projected = converter.forward(new Point(25, 35));
+        assertEquals(1447316.6044498428, projected.x, XY_TOLERANCE);
+        assertEquals(1664114.3618991035, projected.y, XY_TOLERANCE);
+
+        Point geographic = converter.inverse(projected);
+        assertEquals(25.0, geographic.x, ANGULAR_TOLERANCE);
+        assertEquals(35.0, geographic.y, ANGULAR_TOLERANCE);
+    }
+
+    @Test
+    void latitudeNormalizationMatchesProj4jsAtHalfPiBoundary() {
+        Proj projection = new Proj(EQC);
+
+        Point projected = projection.forward(new Point(25 * Values.D2R, 110 * Values.D2R));
+        assertEquals(1447316.6044498428, projected.x, XY_TOLERANCE);
+        assertEquals(-10024432.171394622, projected.y, XY_TOLERANCE);
+
+        Point geographic = projection.inverse(projected);
+        assertEquals(25 * Values.D2R, geographic.x, ANGULAR_TOLERANCE);
+        assertEquals(-70 * Values.D2R, geographic.y, ANGULAR_TOLERANCE);
+    }
+
+    @Test
+    void omittedZeroAndNanLatitudeOfTrueScaleAllSelectPlateCarree() {
+        String base = "+proj=eqc +lat_0=20 +lon_0=10 +x_0=1234 +y_0=-5678 "
+            + "+datum=WGS84 +units=m +no_defs";
+
+        for (String latTs : new String[] {"", " +lat_ts=0", " +lat_ts=NaN"}) {
+            Proj projection = new Proj(base + latTs);
+            Point projected = projection.forward(new Point(25 * Values.D2R, 35 * Values.D2R));
+            assertEquals(1671026.3618991037, projected.x, XY_TOLERANCE, latTs);
+            assertEquals(1664114.3618991035, projected.y, XY_TOLERANCE, latTs);
+        }
+    }
+
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ProjectionTest.java
@@ -49,6 +49,17 @@ class ProjectionTest {
     }
 
     @Test
+    void testSphereWithSemiMajorAxisOnly() {
+        DeriveConstants.SphereResult result = DeriveConstants.sphere(
+            6400000.0, null, null, null, null
+        );
+
+        assertEquals(6400000.0, result.a, 0.0);
+        assertEquals(6400000.0, result.b, 0.0);
+        assertTrue(result.sphere);
+    }
+
+    @Test
     void testSphereWithEllipsoidName() {
         // No explicit params, lookup by name
         DeriveConstants.SphereResult result = DeriveConstants.sphere(

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ScaleFactorZeroParityTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ScaleFactorZeroParityTest.java
@@ -1,0 +1,398 @@
+package org.datasyslab.proj4sedona.projection;
+
+import java.util.stream.Stream;
+
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Current proj4js parity for JavaScript-falsy projection scale factors. */
+class ScaleFactorZeroParityTest {
+
+    @BeforeAll
+    static void setup() {
+        ProjectionRegistry.start();
+    }
+
+    static Stream<Arguments> scaleOneCases() {
+        return Stream.of(
+            Arguments.of("gstmerc",
+                "+proj=gstmerc +lat_0=-21.116666667 +lon_0=55.53333333 "
+                    + "+x_0=160000 +y_0=50000 +ellps=intl +units=m +no_defs",
+                55.5, -21.1),
+            Arguments.of("omerc",
+                "+proj=omerc +lat_0=37.4769061 +lonc=141.0039618 +alpha=202.22 "
+                    + "+x_0=138 +y_0=77.65 +ellps=WGS84 +units=m +no_defs",
+                141.003611, 37.476802),
+            Arguments.of("somerc",
+                "+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333 "
+                    + "+x_0=600000 +y_0=200000 +ellps=bessel +units=m +no_defs",
+                8.55, 47.37),
+            Arguments.of("lcc",
+                "+proj=lcc +lat_0=39 +lat_1=33 +lat_2=45 +lon_0=-96 "
+                    + "+ellps=WGS84 +units=m +no_defs",
+                -100, 40),
+            Arguments.of("merc",
+                "+proj=merc +lon_0=0 +ellps=WGS84 +units=m +no_defs",
+                10, 50),
+            Arguments.of("merc lat_ts=0",
+                "+proj=merc +lat_ts=0 +lon_0=0 +ellps=WGS84 +units=m +no_defs",
+                10, 50),
+            Arguments.of("stere",
+                "+proj=stere +lat_0=45 +lon_0=0 +ellps=WGS84 +units=m +no_defs",
+                10, 50),
+            Arguments.of("sterea",
+                "+proj=sterea +lat_0=52.15616055555555 +lon_0=5.38763888888889 "
+                    + "+x_0=155000 +y_0=463000 +ellps=bessel +units=m +no_defs",
+                5.2, 52.25),
+            Arguments.of("gnom",
+                "+proj=gnom +lat_0=40 +lon_0=-100 +R=6371000 +units=m +no_defs",
+                -99, 41),
+            Arguments.of("etmerc approx",
+                "+proj=etmerc +approx +lat_0=0 +lon_0=3 +ellps=WGS84 +units=m +no_defs",
+                4, 50),
+            Arguments.of("tmerc approx",
+                "+proj=tmerc +approx +lat_0=0 +lon_0=3 +ellps=WGS84 +units=m +no_defs",
+                4, 50));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("scaleOneCases")
+    @DisplayName("Explicit zero uses the projection's scale-one fallback")
+    void testExplicitZeroMatchesOmittedAndOne(
+            String name, String definition, double longitude, double latitude) {
+        Proj omitted = new Proj(definition);
+        Proj zero = new Proj(definition + " +k=0");
+        Proj one = new Proj(definition + " +k=1");
+
+        assertEquals(0.0, zero.getParams().k0, 0.0, name);
+
+        Point expected = project(omitted, longitude, latitude);
+        Point explicitZero = project(zero, longitude, latitude);
+        Point explicitOne = project(one, longitude, latitude);
+        assertFinite(expected, name);
+        assertPointEquals(expected, explicitZero, 1e-8, name + " zero");
+        assertPointEquals(expected, explicitOne, 1e-8, name + " one");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("scaleOneCases")
+    @DisplayName("Explicit NaN uses the projection's scale-one fallback")
+    void testExplicitNaNMatchesOmitted(
+            String name, String definition, double longitude, double latitude) {
+        Point expected = project(new Proj(definition), longitude, latitude);
+        Proj nan = new Proj(definition + " +k=NaN");
+        Point actual = project(nan, longitude, latitude);
+        assertFinite(actual, name);
+        assertPointEquals(expected, actual, 1e-8, name);
+    }
+
+    @Test
+    @DisplayName("Polar stereographic derives scale from lat_ts before zero fallback")
+    void testStereographicLatTsDerivationPrecedesFallback() {
+        String definition = "+proj=stere +lat_0=90 +lat_ts=70 +ellps=WGS84 +units=m +no_defs";
+        Point expected = project(new Proj(definition), 10, 80);
+        assertPointEquals(expected, project(new Proj(definition + " +k=0"), 10, 80),
+            1e-8, "polar zero");
+        assertPointEquals(expected, project(new Proj(definition + " +k=0.5"), 10, 80),
+            1e-8, "polar conflicting scale");
+    }
+
+    @Test
+    @DisplayName("UTM retains its fixed 0.9996 scale when zero is supplied")
+    void testUtmFixedScaleOverridesZero() {
+        String definition = "+proj=utm +zone=32 +ellps=WGS84 +units=m +no_defs";
+        Proj zero = new Proj(definition + " +k=0");
+        assertEquals(0.9996, zero.getParams().k0, 0.0);
+        assertPointEquals(project(new Proj(definition), 10, 50), project(zero, 10, 50),
+            1e-8, "UTM fixed scale");
+    }
+
+    @ParameterizedTest(name = "+proj={0}")
+    @ValueSource(strings = {"etmerc", "tmerc"})
+    @DisplayName("Exact transverse Mercator preserves a zero scale")
+    void testExactTransverseMercatorZeroKeepsInitializedQn(String projectionName) {
+        String definition = "+proj=" + projectionName
+            + " +lat_0=0 +lon_0=3 +x_0=500 +y_0=700 "
+            + "+ellps=WGS84 +units=m +no_defs";
+        Proj projection = new Proj(definition + " +k=0");
+        Point zero = project(projection, 4, 50);
+        Point omitted = project(new Proj(definition), 4, 50);
+
+        assertEquals(500.0, zero.x, 0.0);
+        assertEquals(700.0, zero.y, 0.0);
+        assertNotEquals(omitted.x, zero.x, 1.0);
+        assertNotEquals(omitted.y, zero.y, 1.0);
+    }
+
+    @ParameterizedTest(name = "+proj={0}")
+    @ValueSource(strings = {"etmerc", "tmerc"})
+    @DisplayName("Transverse Mercator requires +approx for a sphere")
+    void testTransverseMercatorSphereRequiresApprox(String projectionName) {
+        String definition = "+proj=" + projectionName
+            + " +lat_0=0 +lon_0=3 +R=6371000 +units=m +no_defs";
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class, () -> new Proj(definition));
+        assertTrue(exception.getMessage().contains("Try using the +approx option"),
+            exception.getMessage());
+
+        Proj approximate = new Proj(definition + " +approx +k=0");
+        Point projected = project(approximate, 4, 50);
+        assertFinite(projected, definition + " +approx");
+    }
+
+    @ParameterizedTest(name = "+proj={0}")
+    @ValueSource(strings = {"etmerc", "tmerc"})
+    @DisplayName("Approximate transverse Mercator handles prolate ellipsoids as ellipsoidal")
+    void testApproximateTransverseMercatorProlate(String projectionName) {
+        Proj projection = new Proj("+proj=" + projectionName
+            + " +approx +lat_0=0 +lon_0=3 +k=1 +a=6378137 +b=6400000 +no_defs");
+        Point projected = project(projection, 4, 50);
+        // Pinned proj4js tmerc.js reference (negative es is JavaScript-truthy).
+        assertEquals(71410.40935168377, projected.x, 1e-7);
+        assertEquals(5592137.669711486, projected.y, 1e-7);
+
+        Point inverse = projection.inverse(new Point(projected.x, projected.y));
+        assertEquals(4 * Values.D2R, inverse.x, 1e-12);
+        assertEquals(50 * Values.D2R, inverse.y, 1e-12);
+    }
+
+    @Test
+    @DisplayName("Approximate transverse Mercator follows the authalic-radius path")
+    void testApproximateTransverseMercatorAuthalicFlag() {
+        Proj projection = new Proj(
+            "+proj=tmerc +approx +R_A +lat_0=0 +lon_0=3 "
+                + "+ellps=WGS84 +units=m +no_defs");
+        Point projected = project(projection, 10, 50);
+        // Current proj4js 888ce3a takes the spherical traditional-TM path.
+        assertEquals(500664.2004314585, projected.x, 1e-8);
+        assertEquals(5589456.452970307, projected.y, 1e-8);
+    }
+
+    @Test
+    @DisplayName("Pinned proj4js +approx a-only fixture uses spherical tmerc")
+    void testApproximateTransverseMercatorUpstreamFixture() {
+        Proj projection = new Proj(
+            "+proj=tmerc +approx +a=6400000 +lat_1=0.5 +lat_2=2 +n=0.5");
+        Point projected = project(projection, 2, 1);
+        assertEquals(223413.46640632232, projected.x, 1e-8);
+        assertEquals(111769.14504059685, projected.y, 1e-8);
+        assertTrue(projection.getParams().sphere);
+        assertEquals(6400000.0, projection.getParams().b, 0.0);
+    }
+
+    @Test
+    @DisplayName("Hyphenated Fast transverse Mercator alias selects approximate math")
+    void testHyphenatedFastTransverseMercatorAlias() {
+        Proj projection = new Proj(
+            "+proj=Fast-Transverse-Mercator +R=6371000 +lon_0=3 +no_defs");
+        Point projected = project(projection, 4, 50);
+        // Current proj4js 888ce3a normalizes hyphens before alias lookup.
+        assertEquals(71474.09080788007, projected.x, 1e-8);
+        assertEquals(5560224.158597246, projected.y, 1e-8);
+    }
+
+    @Test
+    @DisplayName("Approximate UTM expands to the traditional TM parameters")
+    void testApproximateUtmNormalization() {
+        Proj approximate = new Proj(
+            "+proj=utm +zone=32 +approx +ellps=WGS84 +units=m +no_defs");
+        Point expected = project(approximate, 20, 50);
+        Proj expanded = new Proj(
+            "+proj=tmerc +approx +lat_0=0 +lon_0=9 +k=0.9996 "
+                + "+x_0=500000 +y_0=0 +ellps=WGS84 +units=m +no_defs");
+        assertPointEquals(expected, project(expanded, 20, 50), 1e-8, "approximate UTM");
+    }
+
+    @Test
+    @DisplayName("Fast transverse Mercator singularity returns a non-finite point")
+    void testFastTransverseMercatorSingularity() {
+        Point singular = project(new Proj(
+            "+proj=tmerc +approx +lat_0=0 +lon_0=0 +R=6371000 +no_defs"), 90, 0);
+        assertFalse(Double.isFinite(singular.x));
+        assertFalse(Double.isFinite(singular.y));
+    }
+
+    @Test
+    @DisplayName("Mercator nonzero lat_ts remains the defining scale parameter")
+    void testMercatorLatTsSuppressesConflictingZeroScale() {
+        String definition = "+proj=merc +lat_ts=30 +lon_0=0 +ellps=WGS84 +units=m +no_defs";
+        assertPointEquals(project(new Proj(definition), 10, 50),
+            project(new Proj(definition + " +k=0"), 10, 50), 1e-8, "lat_ts precedence");
+    }
+
+    @Test
+    @DisplayName("Mercator NaN lat_ts follows the scale-one fallback")
+    void testMercatorNaNLatTsUsesScaleOneFallback() {
+        String definition = "+proj=merc +lat_ts=NaN +k=0 +lon_0=0 "
+            + "+ellps=WGS84 +units=m +no_defs";
+        Proj projection = new Proj(definition);
+        Point expected = project(new Proj(
+            "+proj=merc +k=1 +lon_0=0 +ellps=WGS84 +units=m +no_defs"), 10, 50);
+        Point actual = project(projection, 10, 50);
+        assertFinite(actual, definition);
+        assertPointEquals(expected, actual, 1e-8, definition);
+    }
+
+    @Test
+    @DisplayName("Mercator infinite lat_ts derives then falls back to scale one")
+    void testMercatorInfiniteLatTsUsesScaleOneFallback() {
+        Proj projection = new Proj(
+            "+proj=merc +lat_ts=Infinity +k=0.5 +lon_0=0 +ellps=WGS84 +no_defs");
+        Point actual = project(projection, 10, 50);
+        Point expected = project(new Proj(
+            "+proj=merc +k=1 +lon_0=0 +ellps=WGS84 +no_defs"), 10, 50);
+        assertPointEquals(expected, actual, 1e-8, "infinite lat_ts");
+    }
+
+    @Test
+    @DisplayName("Mercator derives lat_ts scale from its recomputed axes with R_A")
+    void testMercatorAuthalicFlagLatTsScale() {
+        Proj projection = new Proj(
+            "+proj=merc +R_A +lat_ts=30 +ellps=WGS84 +units=m +no_defs");
+        Point projected = project(projection, 10, 50);
+        // Current proj4js 888ce3a: merc.init recomputes eccentricity from a/b.
+        assertEquals(964862.8025089651, projected.x, 1e-8);
+        assertEquals(5558928.87201279, projected.y, 1e-8);
+    }
+
+    @ParameterizedTest(name = "k={0}")
+    @ValueSource(strings = {"-0.5", "Infinity"})
+    @DisplayName("Nonstandard truthy scales remain numerically effective")
+    void testTruthyNonstandardScale(String scale) {
+        Proj projection = new Proj(
+            "+proj=merc +k=" + scale + " +lon_0=0 +ellps=WGS84 +no_defs");
+        if ("Infinity".equals(scale)) {
+            Point projected = project(projection, 10, 50);
+            assertFalse(Double.isFinite(projected.x));
+            assertFalse(Double.isFinite(projected.y));
+        } else {
+            Point projected = project(projection, 10, 50);
+            assertTrue(Double.isFinite(projected.x));
+            assertTrue(projected.x < 0);
+        }
+    }
+
+    @Test
+    @DisplayName("CEA uses explicit lat_ts, not lat_0, and canonicalizes ellipsoidal Infinity")
+    void testCeaTrueScaleFallbacks() {
+        Proj omitted = new Proj(
+            "+proj=cea +lat_0=30 +ellps=WGS84 +units=m +no_defs");
+        Point expected = project(new Proj(
+            "+proj=cea +lat_ts=0 +lat_0=30 +ellps=WGS84 +units=m +no_defs"), 10, 20);
+        Point actual = project(omitted, 10, 20);
+        assertEquals(1113194.9079327357, actual.x, 1e-7);
+        assertEquals(2167979.8945611375, actual.y, 1e-7);
+        assertPointEquals(expected, actual, 1e-8, "omitted CEA lat_ts");
+
+        Proj infinite = new Proj(
+            "+proj=cea +lat_ts=Infinity +ellps=WGS84 +units=m +no_defs");
+        Point infiniteResult = project(infinite, 10, 20);
+        assertPointEquals(expected, infiniteResult, 1e-8, "infinite CEA lat_ts");
+    }
+
+    @Test
+    @DisplayName("Spherical CEA omission follows PROJ's equatorial default")
+    void testSphericalCeaOmittedLatTsUsesProjDefault() {
+        Proj projection = new Proj("+proj=cea +R=6371000 +units=m +no_defs");
+        Point projected = project(projection, 10, 20);
+        // PROJ 9.5.1. Current proj4js leaks undefined into cos() and returns NaN;
+        // this is an intentional, documented correctness divergence.
+        assertEquals(1111949.2664455874, projected.x, 1e-8);
+        assertEquals(2179010.3331278353, projected.y, 1e-8);
+    }
+
+    @Test
+    @DisplayName("Spherical CEA preserves a nonfinite lat_ts numerically")
+    void testSphericalCeaNonfiniteLatTs() {
+        Proj projection = new Proj(
+            "+proj=cea +lat_ts=Infinity +R=6371000 +units=m +no_defs");
+        Point projected = project(projection, 10, 20);
+        assertFalse(Double.isFinite(projected.x));
+        assertFalse(Double.isFinite(projected.y));
+    }
+
+    @Test
+    @DisplayName("EQC preserves an infinite lat_ts numerically")
+    void testEqcInfiniteLatTs() {
+        Proj projection = new Proj(
+            "+proj=eqc +lat_ts=Infinity +R=6371000 +units=m +no_defs");
+        Point projected = project(projection, 10, 20);
+        assertFalse(Double.isFinite(projected.x));
+    }
+
+    @ParameterizedTest(name = "+proj={0}")
+    @ValueSource(strings = {"cea", "eqc"})
+    @DisplayName("CEA and EQC ignore input scale factors")
+    void testTrueScaleOnlyProjectionsIgnoreScale(String projectionName) {
+        String definition = "+proj=" + projectionName
+            + " +lat_ts=30 +R=6371000 +units=m +no_defs";
+        Proj projection = new Proj(definition + " +k=-0.5");
+        Point projected = project(projection, 10, 20);
+        assertPointEquals(project(new Proj(definition), 10, 20), projected,
+            1e-8, projectionName);
+    }
+
+    @Test
+    @DisplayName("A-only Mercator is a sphere matching PROJ")
+    void testAOnlyMercatorSphere() {
+        Proj projection = new Proj("+proj=merc +a=6400000 +no_defs");
+        assertTrue(projection.getParams().sphere);
+        Point projected = project(projection, 2, 1);
+        assertEquals(223402.14425527418, projected.x, 1e-8);
+        assertEquals(111706.74357494432, projected.y, 1e-8);
+    }
+
+    @ParameterizedTest(name = "+{0}")
+    @ValueSource(strings = {"ellps=WGS84", "datum=WGS84"})
+    @DisplayName("Explicit a retains named ellipsoid or datum flattening")
+    void testAWithNamedEllipsoidUsesProjFlattening(String figureDefinition) {
+        Proj projection = new Proj(
+            "+proj=merc +a=6400000 +" + figureDefinition + " +no_defs");
+        assertFalse(projection.getParams().sphere);
+        assertEquals(298.257223563, projection.getParams().rf, 0.0);
+        assertEquals(6378542.011745616, projection.getParams().b, 1e-8);
+
+        Point projected = project(projection, 2, 1);
+        // PROJ 9.5.1 for +a=6400000 with WGS84 inverse flattening.
+        assertEquals(223402.14425527418, projected.x, 1e-8);
+        assertEquals(110959.01160795633, projected.y, 1e-8);
+    }
+
+    @ParameterizedTest(name = "lat_ts={0}")
+    @ValueSource(strings = {"0", "NaN"})
+    @DisplayName("Non-driving Mercator lat_ts uses the variant-A scale")
+    void testMercatorNonDrivingLatTsUsesScaleOne(String latitudeOfTrueScale) {
+        Proj projection = new Proj("+proj=merc +lat_ts=" + latitudeOfTrueScale
+            + " +lon_0=0 +ellps=WGS84 +units=m +no_defs");
+        Point expected = project(new Proj(
+            "+proj=merc +k=1 +lon_0=0 +ellps=WGS84 +units=m +no_defs"), 10, 50);
+        assertPointEquals(expected, project(projection, 10, 50), 1e-8, latitudeOfTrueScale);
+    }
+
+    private static Point project(Proj projection, double longitude, double latitude) {
+        return projection.forward(new Point(longitude * Values.D2R, latitude * Values.D2R));
+    }
+
+    private static void assertFinite(Point point, String message) {
+        assertTrue(Double.isFinite(point.x) && Double.isFinite(point.y), message);
+    }
+
+    private static void assertPointEquals(Point expected, Point actual, double tolerance, String message) {
+        assertEquals(expected.x, actual.x, tolerance, message + " x");
+        assertEquals(expected.y, actual.y, tolerance, message + " y");
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/projection/ScaleFactorZeroParityTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/ScaleFactorZeroParityTest.java
@@ -206,8 +206,11 @@ class ScaleFactorZeroParityTest {
     }
 
     @Test
-    @DisplayName("Approximate UTM expands to the traditional TM parameters")
+    @DisplayName("Approximate UTM intentionally honors +approx and expands to traditional TM")
     void testApproximateUtmNormalization() {
+        // Current proj4js 888ce3a overwrites UTM's approximate functions after init,
+        // ignoring +approx. This intentional divergence preserves the flag and matches
+        // proj4js's own tmerc +approx expansion (and PROJ) below.
         Proj approximate = new Proj(
             "+proj=utm +zone=32 +approx +ellps=WGS84 +units=m +no_defs");
         Point expected = project(approximate, 20, 50);

--- a/src/test/java/org/datasyslab/proj4sedona/projection/StereographicAlternativeTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/StereographicAlternativeTest.java
@@ -60,6 +60,18 @@ class StereographicAlternativeTest {
     }
 
     @Test
+    void testPolarLatTsTakesPrecedenceOverExplicitScale() {
+        // Polar Stereographic variant B derives its scale from lat_ts. Current
+        // proj4js (71b4ffc) and PROJ ignore a conflicting explicit k value here.
+        Converter conv = Proj4.proj4("+proj=longlat +datum=WGS84 +no_defs",
+            "+proj=stere +lat_0=90 +lat_ts=70 +lon_0=0 +k=0.5 "
+                + "+x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs");
+        Point xy = conv.forward(new Point(10, 80));
+        assertEquals(188568.08, xy.x, 0.5, "easting");
+        assertEquals(-1069422.73, xy.y, 0.5, "northing");
+    }
+
+    @Test
     void testEpsg28992RdNew() {
         // Amersfoort / RD New (Netherlands). proj4js: ll=[5.2, 52.25] -> xy=[142216.10, 473567.13]
         assertForwardInverse(

--- a/src/test/java/org/datasyslab/proj4sedona/projection/VanDerGrintenBonneTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/VanDerGrintenBonneTest.java
@@ -53,8 +53,7 @@ class VanDerGrintenBonneTest {
 
     @Test
     void testVanDerGrintenEquator() {
-        // proj4js throws (non-finite) at the equator; this port returns the correct
-        // x = R * dlon, y = 0.
+        // Current proj4js 7e58cf1 and PROJ return x = R * dlon, y = 0.
         Converter conv = Proj4.proj4(WGS84, VANDG);
         Point xy = conv.forward(new Point(30, 0));
         assertEquals(6371007 * 30 * Math.PI / 180, xy.x, XY_EPSLN, "equator easting");


### PR DESCRIPTION
## Summary

- align projection scale/default handling with proj4js and PROJ semantics
- correct Carthage ellipsoid parameters and bare `+a` derivation
- preserve `lat_0`/`lat_ts` for Equidistant Cylindrical
- complete exact/approximate Transverse Mercator and UTM normalization behavior
- add focused regression coverage for zero-valued and omitted projection parameters

## Why

Several Java defaults erased the distinction between an omitted value and an explicitly supplied zero. That differs from proj4js numeric truthiness in some projections and from projection-specific defaults in others, producing incorrect coordinates for valid definitions.

## Validation

- full test suite: 1,017/1,017 passed
- final focused test run: 52/52 passed
- direct proj4js spot checks: 5/5 matched

This change is standalone and does not include CRS serialization, MGRS, benchmark, or Krovak changes.
