### PR TITLE
Remove serializer parity transition bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Full documentation is available in the [docs/](docs/) folder:
 `UnsupportedOperationException` instead of returning lossy output for definitions they
 cannot represent. In particular, WKT2 and PROJJSON reject non-zero `+towgs84`, and all
 standard exporters reject grid shifts, `+over`, `+R_A`, and two-point `omerc`. WKT2 and
-PROJJSON also reject `+approx`; WKT1 preserves approximate Transverse Mercator only when
-the executable `Fast_Transverse_Mercator` alias is available and otherwise rejects it.
+PROJJSON also reject `+approx`; WKT1 preserves approximate Transverse Mercator with the
+executable `Fast_Transverse_Mercator` method.
 Use `toProjString()` when those operation semantics must be preserved. The complete list
 is in the [CRS export fidelity guide](docs/crs-formats.md#export-fidelity).
 

--- a/docs/crs-formats.md
+++ b/docs/crs-formats.md
@@ -246,8 +246,8 @@ This applies to PROJ-only longitude handling (`+over`, `+lon_wrap`), authalic-ra
 mode (`+R_A`), `ob_tran`, Tilted Perspective, unsupported Oblique Mercator variants
 (`+no_rot` and the two-point form), and grid-shift operations. Approximate Transverse
 Mercator is format-dependent: WKT2 and PROJJSON reject it, while WKT1 emits
-`Fast_Transverse_Mercator` when that executable alias is available and otherwise
-rejects it. Other uses of `+approx` are rejected by all standard exporters. WKT2 and
+the executable `Fast_Transverse_Mercator` method. Other uses of `+approx` are rejected
+by all standard exporters. WKT2 and
 PROJJSON also reject non-zero `+towgs84` operations until bound-CRS export is
 implemented; WKT1 preserves them with `TOWGS84`. Geocentric CRS export is supported as
 a PROJ string or PROJJSON, but not yet as WKT.

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -43,6 +43,7 @@ public final class CRSSerializer {
     private static final double RAD_TO_DEG = 180.0 / Math.PI;
     private static final double DEG_TO_RAD = Math.PI / 180.0;
     private static final String DEG_TO_RAD_STR = Double.toString(DEG_TO_RAD);
+
     // Projection name mappings: PROJ -> WKT method names (short/generic names)
     private static final Map<String, String> PROJ_TO_WKT_METHOD = new LinkedHashMap<>();
     
@@ -574,7 +575,8 @@ public final class CRSSerializer {
         // Projection
         String methodName;
         if (isApproximateTransverseMercator(proj, params)) {
-            // The built-in WKT1 method preserves the traditional approximate algorithm.
+            // ExtendedTransverseMercator registers this built-in WKT1 method, so it
+            // preserves the traditional approximate algorithm without a runtime probe.
             methodName = "Fast_Transverse_Mercator";
         } else if ("krovak".equals(proj)) {
             // WKT1 uses the legacy Krovak method for either axis orientation; WKT2

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -43,9 +43,6 @@ public final class CRSSerializer {
     private static final double RAD_TO_DEG = 180.0 / Math.PI;
     private static final double DEG_TO_RAD = Math.PI / 180.0;
     private static final String DEG_TO_RAD_STR = Double.toString(DEG_TO_RAD);
-    private static final boolean PROJECTION_PARITY_SEMANTICS_AVAILABLE =
-        detectProjectionParitySemantics();
-
     // Projection name mappings: PROJ -> WKT method names (short/generic names)
     private static final Map<String, String> PROJ_TO_WKT_METHOD = new LinkedHashMap<>();
     
@@ -577,8 +574,7 @@ public final class CRSSerializer {
         // Projection
         String methodName;
         if (isApproximateTransverseMercator(proj, params)) {
-            // This path is admitted only when the runtime projection registry can
-            // execute the Fast_Transverse_Mercator alias (see the preflight gate).
+            // The built-in WKT1 method preserves the traditional approximate algorithm.
             methodName = "Fast_Transverse_Mercator";
         } else if ("krovak".equals(proj)) {
             // WKT1 uses the legacy Krovak method for either axis orientation; WKT2
@@ -2507,24 +2503,15 @@ public final class CRSSerializer {
     /** Return the latitude of true scale actually consumed by the runtime projection. */
     private static Double latitudeOfTrueScaleForSerialization(
             String proj, ProjectionParams params) {
-        if (projectionParitySemanticsAvailable()) {
-            if ("eqc".equals(proj)) {
-                // The projection parity update follows JavaScript's lat_ts || 0.
-                return params.latTs == null || params.latTs == 0.0
-                        || Double.isNaN(params.latTs) ? 0.0 : params.latTs;
-            }
-            if ("cea".equals(proj)
-                    && (params.latTs == null
-                        || (!params.sphere && !Double.isFinite(params.latTs)))) {
-                return 0.0;
-            }
-        } else if (("eqc".equals(proj) || "cea".equals(proj))
-                && params.latTs == null) {
-            // On the main branch both projections call getLatTs(), which inherits
-            // lat_0 when lat_ts is absent. Keep this standalone exporter faithful to
-            // that initialized behavior; the feature check switches automatically
-            // when the projection parity update is present.
-            return params.getLatTs();
+        if ("eqc".equals(proj)) {
+            // Equidistant Cylindrical follows JavaScript's lat_ts || 0.
+            return params.latTs == null || params.latTs == 0.0
+                    || Double.isNaN(params.latTs) ? 0.0 : params.latTs;
+        }
+        if ("cea".equals(proj)
+                && (params.latTs == null
+                    || (!params.sphere && !Double.isFinite(params.latTs)))) {
+            return 0.0;
         }
         return params.latTs;
     }
@@ -2571,11 +2558,10 @@ public final class CRSSerializer {
         if ("utm".equals(proj)) {
             return 0.9996;
         }
-        if (projectionParitySemanticsAvailable()
-                && ("gstmerc".equals(proj) || "omerc".equals(proj)
-                    || "somerc".equals(proj) || "lcc".equals(proj)
-                    || "sterea".equals(proj) || "gnom".equals(proj)
-                    || isApproximateTransverseMercator(proj, params))) {
+        if ("gstmerc".equals(proj) || "omerc".equals(proj)
+                || "somerc".equals(proj) || "lcc".equals(proj)
+                || "sterea".equals(proj) || "gnom".equals(proj)
+                || isApproximateTransverseMercator(proj, params)) {
             return defaultScaleOne(params.k0);
         }
         return params.k0;
@@ -2585,21 +2571,14 @@ public final class CRSSerializer {
         if (!"merc".equals(proj) || params.latTs == null) {
             return false;
         }
-        // Main currently lets any supplied value drive Mercator.init. The numerical
-        // parity update follows proj4js truthiness and only treats finite, non-zero
-        // lat_ts as the standard-parallel form.
-        return !projectionParitySemanticsAvailable()
-            || (params.latTs != 0.0 && Double.isFinite(params.latTs));
+        return params.latTs != 0.0 && Double.isFinite(params.latTs);
     }
 
     private static double effectiveMercatorScale(ProjectionParams params) {
         Double latTs = params.latTs;
-        boolean derives = projectionParitySemanticsAvailable()
-            ? latTs != null && latTs != 0.0 && !Double.isNaN(latTs)
-            : latTs != null;
+        boolean derives = latTs != null && latTs != 0.0 && !Double.isNaN(latTs);
         if (!derives) {
-            return projectionParitySemanticsAvailable()
-                ? defaultScaleOne(params.k0) : params.k0;
+            return defaultScaleOne(params.k0);
         }
 
         double scale;
@@ -2612,7 +2591,7 @@ public final class CRSSerializer {
             scale = ProjMath.msfnz(
                 eccentricity, Math.sin(latTs), Math.cos(latTs));
         }
-        return projectionParitySemanticsAvailable() ? defaultScaleOne(scale) : scale;
+        return defaultScaleOne(scale);
     }
 
     private static double effectiveStereographicScale(ProjectionParams params) {
@@ -2634,7 +2613,7 @@ public final class CRSSerializer {
                         eccentricity, pole * latTs, pole * Math.sin(latTs));
             }
         }
-        return projectionParitySemanticsAvailable() ? defaultScaleOne(scale) : scale;
+        return defaultScaleOne(scale);
     }
 
     private static double defaultScaleOne(double scale) {
@@ -2694,14 +2673,10 @@ public final class CRSSerializer {
         if (Boolean.TRUE.equals(params.approx) && !approximateTransverseMercator) {
             throw unsupportedStandardParameter("+approx cannot be represented losslessly");
         }
-        if (approximateTransverseMercator) {
-            boolean executableFastWkt1 = format == StandardFormat.WKT1
-                && fastTransverseMercatorWkt1Available();
-            if (!executableFastWkt1) {
-                throw unsupportedStandardParameter(
-                    "Approximate Transverse Mercator has no executable "
-                        + formatName(format) + " representation");
-            }
+        if (approximateTransverseMercator && format != StandardFormat.WKT1) {
+            throw unsupportedStandardParameter(
+                "Approximate Transverse Mercator has no executable "
+                    + formatName(format) + " representation");
         }
         if (params.a > 0.0 && params.b <= 0.0 && !"vandg".equals(proj)) {
             throw unsupportedStandardParameter(
@@ -2904,54 +2879,17 @@ public final class CRSSerializer {
         return false;
     }
 
-    /**
-     * Whether the independent numerical parity update is on the runtime classpath.
-     * Its scale-default helper is a stable, non-spoofable capability marker, unlike a
-     * projection alias that an application can register itself.
-     */
-    private static boolean projectionParitySemanticsAvailable() {
-        return PROJECTION_PARITY_SEMANTICS_AVAILABLE;
-    }
-
-    private static boolean detectProjectionParitySemantics() {
-        // TODO: This reflection-based dual-mode bridge is transitional. Remove the
-        // capability probe and its branches once projection parity semantics are a
-        // permanent dependency; a future helper rename must not silently select legacy
-        // serializer behavior.
-        try {
-            ProjectionParams.class.getMethod("getK0OrDefault", double.class);
-            return true;
-        } catch (NoSuchMethodException e) {
-            return false;
-        }
-    }
-
-    private static boolean fastTransverseMercatorWkt1Available() {
-        if (!projectionParitySemanticsAvailable()) {
-            return false;
-        }
-        ProjectionRegistry.start();
-        return ProjectionRegistry.get("Fast_Transverse_Mercator") != null;
-    }
-
     private static boolean isApproximateTransverseMercator(
             String proj, ProjectionParams params) {
         boolean explicitlyApproximate = Boolean.TRUE.equals(params.approx)
             || isFastTransverseMercatorName(params.projName);
         if ("utm".equals(proj)) {
-            return explicitlyApproximate || (!projectionParitySemanticsAvailable()
-                && (!Double.isFinite(params.es) || params.es <= 0.0));
+            return explicitlyApproximate;
         }
         if (!"etmerc".equals(proj) && !"tmerc".equals(proj)) {
             return false;
         }
-        if (explicitlyApproximate) {
-            return true;
-        }
-        // Before the numerical parity update, spherical ETMERC silently falls back
-        // to the traditional implementation. Preserve that standalone behavior.
-        return !projectionParitySemanticsAvailable()
-            && (!Double.isFinite(params.es) || params.es <= 0.0);
+        return explicitlyApproximate;
     }
 
     private static boolean isFastTransverseMercatorName(String projectionName) {
@@ -3002,11 +2940,7 @@ public final class CRSSerializer {
         if (!isPolarStereographic(proj, params) || params.latTs == null) {
             return false;
         }
-        if (projectionParitySemanticsAvailable()) {
-            return !Double.isNaN(params.latTs)
-                && (params.sphere || Math.abs(Math.cos(params.latTs)) > Values.EPSLN);
-        }
-        return params.k0 == 1.0
+        return !Double.isNaN(params.latTs)
             && (params.sphere || Math.abs(Math.cos(params.latTs)) > Values.EPSLN);
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -96,10 +96,6 @@ public class ProjectionParams {
     /**
      * Resolve a projection-local scale default using JavaScript numeric truthiness.
      * Current proj4js treats zero and NaN as absent when applying these defaults.
-     *
-     * <p>The CRS serializer transition in PR #117 temporarily uses the presence of this
-     * exact method as a capability marker. Do not rename or remove it until that
-     * transition is cleaned up.</p>
      */
     public double getK0OrDefault(double defaultValue) {
         return k0 == 0.0 || Double.isNaN(k0) ? defaultValue : k0;

--- a/src/test/java/org/datasyslab/proj4sedona/benchmark/SpeedBenchmark.java
+++ b/src/test/java/org/datasyslab/proj4sedona/benchmark/SpeedBenchmark.java
@@ -42,9 +42,6 @@ public class SpeedBenchmark {
     private static final double ROBINSON_TOLERANCE = 0.5;     // meters
     /** WKT normalization is deliberately stable to one nanodegree. */
     private static final double ANGLE_SEMANTIC_TOLERANCE = Math.toRadians(1e-9);
-    private static final boolean PROJECTION_PARITY_SEMANTICS_AVAILABLE =
-        detectProjectionParitySemantics();
-
     private static final Map<String, String> TRANSFORM_SKIPS;
     private static final Map<String, String> GRID_SKIPS;
     private static final Set<String> PROJECTION_TOLERANCE_OVERRIDES;
@@ -650,19 +647,14 @@ public class SpeedBenchmark {
 
     private static double effectiveLatitudeOfTrueScale(
             String method, ProjectionParams params) {
-        if (projectionParitySemanticsAvailable()) {
-            if ("eqc".equals(method)) {
-                return params.latTs == null || params.latTs == 0.0
-                        || Double.isNaN(params.latTs) ? 0.0 : params.latTs;
-            }
-            if ("cea".equals(method)
-                    && (params.latTs == null
-                        || (!params.sphere && !Double.isFinite(params.latTs)))) {
-                return 0.0;
-            }
-        } else if (("cea".equals(method) || "eqc".equals(method))
-                && params.latTs == null) {
-            return params.getLatTs();
+        if ("eqc".equals(method)) {
+            return params.latTs == null || params.latTs == 0.0
+                    || Double.isNaN(params.latTs) ? 0.0 : params.latTs;
+        }
+        if ("cea".equals(method)
+                && (params.latTs == null
+                    || (!params.sphere && !Double.isFinite(params.latTs)))) {
+            return 0.0;
         }
         return valueOrZero(params.latTs);
     }
@@ -670,33 +662,27 @@ public class SpeedBenchmark {
     private static double effectiveScaleFactor(String method, ProjectionParams params) {
         String baseMethod = method == null ? null : method.replace(":approx", "");
         if ("merc".equals(baseMethod)) {
-            boolean derives = projectionParitySemanticsAvailable()
-                ? params.latTs != null && params.latTs != 0.0
-                    && !Double.isNaN(params.latTs)
-                : params.latTs != null;
+            boolean derives = params.latTs != null && params.latTs != 0.0
+                && !Double.isNaN(params.latTs);
             if (!derives) {
-                return projectionParitySemanticsAvailable()
-                    ? defaultScaleOne(params.k0) : params.k0;
+                return defaultScaleOne(params.k0);
             }
             double sin = Math.sin(params.latTs);
             double cos = Math.cos(params.latTs);
             if (params.sphere) {
-                return projectionParitySemanticsAvailable()
-                    ? defaultScaleOne(cos) : cos;
+                return defaultScaleOne(cos);
             }
             double ratio = params.b / params.a;
             double eccentricity = Math.sqrt(1.0 - ratio * ratio);
             double scale = ProjMath.msfnz(eccentricity, sin, cos);
-            return projectionParitySemanticsAvailable()
-                ? defaultScaleOne(scale) : scale;
+            return defaultScaleOne(scale);
         }
         if ("stere".equals(baseMethod)) {
             double scale = params.k0;
             double lat0 = params.getLat0();
             boolean derives = params.latTs != null
                 && Math.abs(Math.cos(lat0)) <= Values.EPSLN
-                && (projectionParitySemanticsAvailable()
-                    ? !Double.isNaN(params.latTs) : scale == 1.0);
+                && !Double.isNaN(params.latTs);
             if (derives) {
                 if (params.sphere) {
                     scale = 0.5 * (1.0 + ProjMath.sign(lat0) * Math.sin(params.latTs));
@@ -712,8 +698,7 @@ public class SpeedBenchmark {
                             pole * Math.sin(params.latTs));
                 }
             }
-            return projectionParitySemanticsAvailable()
-                ? defaultScaleOne(scale) : scale;
+            return defaultScaleOne(scale);
         }
         if ("krovak".equals(baseMethod)) {
             return Krovak.resolveScaleFactor(params);
@@ -725,27 +710,13 @@ public class SpeedBenchmark {
                 || "omerc".equals(baseMethod) || "somerc".equals(baseMethod)
                 || "sterea".equals(baseMethod) || "gnom".equals(baseMethod)
                 || "tmerc:approx".equals(method)) {
-            return projectionParitySemanticsAvailable()
-                ? defaultScaleOne(params.k0) : params.k0;
+            return defaultScaleOne(params.k0);
         }
         return params.k0;
     }
 
     private static double defaultScaleOne(double scale) {
         return scale == 0.0 || Double.isNaN(scale) ? 1.0 : scale;
-    }
-
-    private static boolean projectionParitySemanticsAvailable() {
-        return PROJECTION_PARITY_SEMANTICS_AVAILABLE;
-    }
-
-    private static boolean detectProjectionParitySemantics() {
-        try {
-            ProjectionParams.class.getMethod("getK0OrDefault", double.class);
-            return true;
-        } catch (NoSuchMethodException e) {
-            return false;
-        }
     }
 
     private static boolean isFastTransverseMercatorName(String projectionName) {
@@ -764,17 +735,12 @@ public class SpeedBenchmark {
                 : ProjectionRegistry.getNormalizedProjName(
                     params.projName.toLowerCase(Locale.ROOT));
         }
-        String sourceCode = code;
         // UTM is a constrained Transverse Mercator conversion in WKT and PROJJSON.
         if ("utm".equals(code)) {
             code = "tmerc";
         }
         boolean approximate = Boolean.TRUE.equals(params.approx)
-            || isFastTransverseMercatorName(params.projName)
-            || (!projectionParitySemanticsAvailable()
-                && ("tmerc".equals(sourceCode) || "etmerc".equals(sourceCode)
-                    || "utm".equals(sourceCode))
-                && (!Double.isFinite(params.es) || params.es <= 0.0));
+            || isFastTransverseMercatorName(params.projName);
         if ("tmerc".equals(code) && approximate) {
             return "tmerc:approx";
         }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerProjectionSemanticsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerProjectionSemanticsTest.java
@@ -12,9 +12,6 @@ import static org.junit.jupiter.api.Assertions.*;
 /** Integration coverage where serialization depends on projection initialization. */
 class CRSSerializerProjectionSemanticsTest {
 
-    private static final boolean PROJECTION_PARITY_SEMANTICS_AVAILABLE =
-        detectProjectionParitySemantics();
-
     @BeforeAll
     static void setup() {
         ProjectionRegistry.start();
@@ -50,14 +47,9 @@ class CRSSerializerProjectionSemanticsTest {
         assertPointEquals(expected, project(new Proj(projString), 20.0, 50.0),
             1e-8, projString);
 
-        if (fastTransverseMercatorWkt1Available()) {
-            String wkt1 = CRSSerializer.toWkt1(approximate);
-            assertTrue(wkt1.contains("PROJECTION[\"Fast_Transverse_Mercator\"]"), wkt1);
-            assertPointEquals(expected, project(new Proj(wkt1), 20.0, 50.0), 1e-8, wkt1);
-        } else {
-            assertThrows(UnsupportedOperationException.class,
-                () -> CRSSerializer.toWkt1(approximate));
-        }
+        String wkt1 = CRSSerializer.toWkt1(approximate);
+        assertTrue(wkt1.contains("PROJECTION[\"Fast_Transverse_Mercator\"]"), wkt1);
+        assertPointEquals(expected, project(new Proj(wkt1), 20.0, 50.0), 1e-8, wkt1);
         assertThrows(UnsupportedOperationException.class,
             () -> CRSSerializer.toWkt2(approximate));
         assertThrows(UnsupportedOperationException.class,
@@ -65,24 +57,19 @@ class CRSSerializerProjectionSemanticsTest {
     }
 
     @Test
-    void mercatorNonfiniteTrueScaleFollowsTheActiveRuntime() {
+    void mercatorNonfiniteTrueScaleUsesDefaultScale() {
         for (String value : new String[]{"NaN", "Infinity"}) {
             Proj projection = new Proj("+proj=merc +lat_ts=" + value
                 + " +k=0 +lon_0=0 +ellps=WGS84 +units=m +no_defs");
             String projString = CRSSerializer.toProjString(projection);
-            if (projectionParitySemanticsAvailable()) {
-                assertFalse(projString.contains("+lat_ts="), projString);
-                assertTrue(projString.contains("+k_0=1.0"), projString);
-                Point expected = project(projection, 10.0, 50.0);
-                assertTrue(Double.isFinite(expected.x) && Double.isFinite(expected.y), value);
-                for (String standard : standardFormats(projection)) {
-                    assertFalse(standard.contains("Mercator (variant B)"), standard);
-                    assertPointEquals(expected, project(new Proj(standard), 10.0, 50.0),
-                        1e-8, standard);
-                }
-            } else {
-                assertTrue(projString.contains("+lat_ts=" + value), projString);
-                assertAllStandardsReject(projection);
+            assertFalse(projString.contains("+lat_ts="), projString);
+            assertTrue(projString.contains("+k_0=1.0"), projString);
+            Point expected = project(projection, 10.0, 50.0);
+            assertTrue(Double.isFinite(expected.x) && Double.isFinite(expected.y), value);
+            for (String standard : standardFormats(projection)) {
+                assertFalse(standard.contains("Mercator (variant B)"), standard);
+                assertPointEquals(expected, project(new Proj(standard), 10.0, 50.0),
+                    1e-8, standard);
             }
         }
 
@@ -90,11 +77,9 @@ class CRSSerializerProjectionSemanticsTest {
             "+proj=merc +lat_ts=0 +lon_0=0 +ellps=WGS84 +units=m +no_defs");
         String projString = CRSSerializer.toProjString(equatorial);
         assertFalse(projString.contains("+lat_ts="), projString);
-        if (projectionParitySemanticsAvailable()) {
-            assertTrue(projString.contains("+k_0=1.0"), projString);
-            for (String standard : standardFormats(equatorial)) {
-                assertFalse(standard.contains("Mercator (variant B)"), standard);
-            }
+        assertTrue(projString.contains("+k_0=1.0"), projString);
+        for (String standard : standardFormats(equatorial)) {
+            assertFalse(standard.contains("Mercator (variant B)"), standard);
         }
     }
 
@@ -154,7 +139,7 @@ class CRSSerializerProjectionSemanticsTest {
     }
 
     @Test
-    void scaleOneProjectionFallbacksFollowTheActiveRuntime() {
+    void scaleOneProjectionFallbacksDefaultToOne() {
         String[] definitions = {
             "+proj=lcc +lat_0=39 +lat_1=33 +lat_2=45 +lon_0=-96 "
                 + "+ellps=WGS84 +units=m +no_defs",
@@ -174,24 +159,17 @@ class CRSSerializerProjectionSemanticsTest {
             for (String scale : new String[]{"0", "NaN"}) {
                 Proj projection = new Proj(definition + " +k=" + scale);
                 String projString = CRSSerializer.toProjString(projection);
-                if (projectionParitySemanticsAvailable()) {
-                    assertTrue(projString.contains("+k_0=1.0"), projString);
-                    if (approximateTm) {
-                        if (fastTransverseMercatorWkt1Available()) {
-                            assertDoesNotThrow(() -> CRSSerializer.toWkt1(projection));
-                        }
-                        assertThrows(UnsupportedOperationException.class,
-                            () -> CRSSerializer.toWkt2(projection));
-                        assertThrows(UnsupportedOperationException.class,
-                            () -> CRSSerializer.toProjJson(projection));
-                    } else {
-                        for (String standard : standardFormats(projection)) {
-                            assertDoesNotThrow(() -> new Proj(standard), standard);
-                        }
-                    }
+                assertTrue(projString.contains("+k_0=1.0"), projString);
+                if (approximateTm) {
+                    assertDoesNotThrow(() -> CRSSerializer.toWkt1(projection));
+                    assertThrows(UnsupportedOperationException.class,
+                        () -> CRSSerializer.toWkt2(projection));
+                    assertThrows(UnsupportedOperationException.class,
+                        () -> CRSSerializer.toProjJson(projection));
                 } else {
-                    assertTrue(projString.contains("+k_0=" + scale), projString);
-                    assertAllStandardsReject(projection);
+                    for (String standard : standardFormats(projection)) {
+                        assertDoesNotThrow(() -> new Proj(standard), standard);
+                    }
                 }
             }
         }
@@ -216,16 +194,11 @@ class CRSSerializerProjectionSemanticsTest {
         Proj ellipsoidalCeaInfinity = new Proj(
             "+proj=cea +lat_ts=Infinity +ellps=WGS84 +units=m +no_defs");
         String ceaProj = CRSSerializer.toProjString(ellipsoidalCeaInfinity);
-        if (projectionParitySemanticsAvailable()) {
-            assertFalse(ceaProj.contains("+lat_ts="), ceaProj);
-            Point expected = project(ellipsoidalCeaInfinity, 10.0, 20.0);
-            for (String standard : standardFormats(ellipsoidalCeaInfinity)) {
-                assertPointEquals(expected, project(new Proj(standard), 10.0, 20.0),
-                    1e-8, standard);
-            }
-        } else {
-            assertTrue(ceaProj.contains("+lat_ts=Infinity"), ceaProj);
-            assertAllStandardsReject(ellipsoidalCeaInfinity);
+        assertFalse(ceaProj.contains("+lat_ts="), ceaProj);
+        Point expected = project(ellipsoidalCeaInfinity, 10.0, 20.0);
+        for (String standard : standardFormats(ellipsoidalCeaInfinity)) {
+            assertPointEquals(expected, project(new Proj(standard), 10.0, 20.0),
+                1e-8, standard);
         }
 
         for (Proj projOnly : new Proj[]{
@@ -275,35 +248,24 @@ class CRSSerializerProjectionSemanticsTest {
             Proj projection = new Proj(
                 "+proj=stere +lat_0=90 +k=" + scale + " +ellps=WGS84 +no_defs");
             String projString = CRSSerializer.toProjString(projection);
-            if (projectionParitySemanticsAvailable()) {
-                assertTrue(projString.contains("+k_0=1.0"), projString);
-                for (String standard : standardFormats(projection)) {
-                    assertDoesNotThrow(() -> new Proj(standard), standard);
-                }
-            } else {
-                assertTrue(projString.contains("+k_0=" + scale), projString);
-                assertAllStandardsReject(projection);
+            assertTrue(projString.contains("+k_0=1.0"), projString);
+            for (String standard : standardFormats(projection)) {
+                assertDoesNotThrow(() -> new Proj(standard), standard);
             }
         }
     }
 
     @Test
-    void bareSemiMajorAxisRoundTripsItsActiveFigureSemantics() {
+    void bareSemiMajorAxisRoundTripsAsSphere() {
         Proj original = new Proj("+proj=merc +a=6400000 +no_defs");
         String projString = CRSSerializer.toProjString(original);
         assertTrue(projString.contains("+a=6400000.0"), projString);
-        if (projectionParitySemanticsAvailable()) {
-            assertTrue(original.getParams().sphere);
-            assertTrue(projString.contains("+b=6400000.0"), projString);
-        }
+        assertTrue(original.getParams().sphere);
+        assertTrue(projString.contains("+b=6400000.0"), projString);
         Proj projRoundTrip = new Proj(projString);
         assertEquals(original.getParams().a, projRoundTrip.getParams().a, 0.0, projString);
         assertEquals(original.getParams().b, projRoundTrip.getParams().b, 0.0, projString);
         assertEquals(original.getParams().sphere, projRoundTrip.getParams().sphere, projString);
-        if (!projectionParitySemanticsAvailable()) {
-            assertAllStandardsReject(original);
-            return;
-        }
         for (String serialized : standardFormats(original)) {
             Proj reimported = new Proj(serialized);
             assertEquals(original.getParams().a, reimported.getParams().a, 0.0, serialized);
@@ -323,25 +285,6 @@ class CRSSerializerProjectionSemanticsTest {
         for (String serialized : allFormats(explicit)) {
             assertTrue(new Proj(serialized).getParams().k0Specified, serialized);
         }
-    }
-
-    private static boolean projectionParitySemanticsAvailable() {
-        return PROJECTION_PARITY_SEMANTICS_AVAILABLE;
-    }
-
-    private static boolean detectProjectionParitySemantics() {
-        try {
-            Class.forName("org.datasyslab.proj4sedona.projection.ProjectionParams")
-                .getMethod("getK0OrDefault", double.class);
-            return true;
-        } catch (ReflectiveOperationException e) {
-            return false;
-        }
-    }
-
-    private static boolean fastTransverseMercatorWkt1Available() {
-        return projectionParitySemanticsAvailable()
-            && ProjectionRegistry.get("Fast_Transverse_Mercator") != null;
     }
 
     private static String[] standardFormats(Proj projection) {

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
@@ -102,22 +102,13 @@ class CRSSerializerRoundTripSafetyTest {
         assertTrue(projString.contains("+proj=tmerc"), projString);
         assertTrue(projString.contains("+approx"), projString);
 
-        ProjectionRegistry.start();
-        if (!fastTransverseMercatorWkt1Available()) {
-            // Standalone on main: the WKT alias is not executable, so no standard
-            // exporter may silently turn the approximate operation into exact TM.
-            assertAllStandardsReject(approximate);
-        } else {
-            // When the independent projection parity update is also present, WKT1
-            // gains an executable method alias. WKT2 and PROJJSON still have none.
-            String wkt1 = CRSSerializer.toWkt1(approximate);
-            assertTrue(wkt1.contains("PROJECTION[\"Fast_Transverse_Mercator\"]"), wkt1);
-            assertDoesNotThrow(() -> new Proj(wkt1));
-            assertThrows(UnsupportedOperationException.class,
-                () -> CRSSerializer.toWkt2(approximate));
-            assertThrows(UnsupportedOperationException.class,
-                () -> CRSSerializer.toProjJson(approximate));
-        }
+        String wkt1 = CRSSerializer.toWkt1(approximate);
+        assertTrue(wkt1.contains("PROJECTION[\"Fast_Transverse_Mercator\"]"), wkt1);
+        assertDoesNotThrow(() -> new Proj(wkt1));
+        assertThrows(UnsupportedOperationException.class,
+            () -> CRSSerializer.toWkt2(approximate));
+        assertThrows(UnsupportedOperationException.class,
+            () -> CRSSerializer.toProjJson(approximate));
     }
 
     @Test
@@ -367,14 +358,4 @@ class CRSSerializerRoundTripSafetyTest {
         assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toProjJson(proj));
     }
 
-    private static boolean fastTransverseMercatorWkt1Available() {
-        try {
-            return Proj.class.getClassLoader()
-                    .loadClass("org.datasyslab.proj4sedona.projection.ProjectionParams")
-                    .getMethod("getK0OrDefault", double.class) != null
-                && ProjectionRegistry.get("Fast_Transverse_Mercator") != null;
-        } catch (ReflectiveOperationException e) {
-            return false;
-        }
-    }
 }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -15,9 +15,6 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 class CRSSerializerTest {
 
-    private static final boolean PROJECTION_PARITY_SEMANTICS_AVAILABLE =
-        detectProjectionParitySemantics();
-
     @BeforeAll
     static void setup() {
         ProjectionRegistry.start();
@@ -1834,9 +1831,8 @@ class CRSSerializerTest {
         String def = "+proj=stere +lat_0=90 +lat_ts=-90 +R=6371000 +no_defs";
         String serialized = CRSSerializer.toProjString(new Proj(def));
         assertFalse(serialized.contains("+lat_ts="), "opposite-pole lat_ts dropped: " + serialized);
-        String expectedScale = PROJECTION_PARITY_SEMANTICS_AVAILABLE
-            ? "+k_0=1.0" : "+k_0=0.0";
-        assertTrue(serialized.contains(expectedScale), "effective scale kept: " + serialized);
+        assertTrue(serialized.contains("+k_0=1.0"),
+            "effective scale kept: " + serialized);
 
         Point before = Proj4.proj4(src, def).forward(new Point(10, 80));
         Point after = Proj4.proj4(src, serialized).forward(new Point(10, 80));
@@ -2149,13 +2145,4 @@ class CRSSerializerTest {
             "the datum transform survives the +towgs84= round-trip");
     }
 
-    private static boolean detectProjectionParitySemantics() {
-        try {
-            Class.forName("org.datasyslab.proj4sedona.projection.ProjectionParams")
-                .getMethod("getK0OrDefault", double.class);
-            return true;
-        } catch (ReflectiveOperationException e) {
-            return false;
-        }
-    }
 }


### PR DESCRIPTION
## Summary

- remove the reflection-based projection parity transition bridge
- make the merged projection and serializer semantics unconditional
- simplify benchmark and serializer tests to assert the current behavior directly
- document the built-in Fast Transverse Mercator WKT1 path without an availability caveat

## Why

PRs #116 and #117 could land independently, so the serializer temporarily detected which projection semantics were present and retained both code paths. Both changes are now on `main`; the legacy branches are unreachable and a future helper rename could otherwise select them accidentally.

## Impact

This is a behavior-preserving cleanup. It removes 193 net lines while retaining scale defaults, non-finite latitude handling, polar stereographic precedence, and approximate Transverse Mercator export behavior.

## Validation

- `mvn -B -Dtest=CRSSerializerProjectionSemanticsTest,CRSSerializerRoundTripSafetyTest,CRSSerializerTest,SpeedBenchmarkTest test` — 162/162 passed
- `mvn -B verify -Pbenchmarks` — 1,087/1,087 tests passed
- strict parity — 470 compared, 35 documented skips, 0 failures, 0 mismatches
- `git diff --check`
