### PR TITLE
Align WKT2 PROJJSON with wkt-parser 1.5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,11 +270,10 @@ known to be wrong; each is noted in the relevant Javadoc and pinned by a test):
 
 | Upstream | Ported through | Date |
 |---|---|---|
-| [proj4js](https://github.com/proj4js/proj4js) | commit `695c191` | 2026-07-05 |
-| [wkt-parser](https://github.com/proj4js/wkt-parser) | v1.5.5 | 2026-07-13 (audit) |
+| [proj4js](https://github.com/proj4js/proj4js) | commit `888ce3a` | 2026-07-19 |
+| [wkt-parser](https://github.com/proj4js/wkt-parser) | v1.5.6 | 2026-07-23 |
 | [mgrs](https://github.com/proj4js/mgrs) | v2.2.0 | 2026-07-21 |
 
-The projection-parity fixtures additionally target proj4js master commit `888ce3a`.
 Some covered behavior is newer than the published `proj4@2.20.9` npm package and may
 differ until the next upstream release.
 
@@ -282,10 +281,10 @@ To find upstream changes that may need porting since the last sync:
 
 ```bash
 # In a proj4js checkout:
-git log 695c191..origin/master -- lib/
+git log 888ce3a..origin/main -- lib/
 
 # For wkt-parser, diff the published packages:
-npm pack wkt-parser@1.5.5 && npm pack wkt-parser@latest
+npm pack wkt-parser@1.5.6 && npm pack wkt-parser@latest
 
 # For MGRS, diff the published packages:
 npm pack mgrs@2.2.0 && npm pack mgrs@latest

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -533,7 +533,7 @@ public final class ProjJsonBuilder {
     private static void convertAxis(List<Object> node, Map<String, Object> result) {
         if (!result.containsKey("coordinate_system")) {
             Map<String, Object> coordSystem = new HashMap<>();
-            coordSystem.put("type", "unspecified");
+            // An AXIS node alone does not identify a coordinate-system subtype.
             coordSystem.put("axis", new ArrayList<Map<String, Object>>());
             result.put("coordinate_system", coordSystem);
         }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -142,7 +142,7 @@ public final class ProjJsonBuilder {
         if (csNode != null) {
             Map<String, Object> coordSystem = new HashMap<>();
             if (csNode.size() > 1) {
-                coordSystem.put("type", csNode.get(1));
+                coordSystem.put("subtype", csNode.get(1));
             }
             coordSystem.put("axis", extractAxes(node));
             result.put("coordinate_system", coordSystem);
@@ -237,11 +237,10 @@ public final class ProjJsonBuilder {
 
         // Coordinate system. For GEODCRS the CS node's subtype decides geographic
         // (ellipsoidal) vs geocentric (Cartesian) in the downstream transformer.
-        // Divergence from proj4js/wkt-parser 1.5.5, which honors the CS node only in
-        // its WKT2-2019 builder: PROJ's own WKT2:2015 output for EPSG:4978 carries
-        // CS[Cartesian,3] and no USAGE node (USAGE is 2019-only), and PROJ parses it
-        // as geocentric, while proj4js silently yields longlat for it. The subtype is
-        // read here for both forms, matching PROJ.
+        // Backported ahead of wkt-parser 1.5.6 (b7abacf), which now honors the CS
+        // node in WKT2-2015 too. PROJ's own WKT2:2015 output for EPSG:4978 carries
+        // CS[Cartesian,3] and no USAGE node (USAGE is 2019-only), and both parsers
+        // now classify it as geocentric.
         Map<String, Object> coordSystem = new HashMap<>();
         String subtype = "ellipsoidal";
         List<Object> csNode = findNode(node, "CS");

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -235,6 +235,7 @@ class WktParserTest {
 
     @Test
     @DisplayName("Parse WKT2 PROJCRS (UTM)")
+    @SuppressWarnings("unchecked")
     void testParseWkt2ProjcrsUtm() {
         String wkt = "PROJCRS[\"WGS 84 / UTM zone 32N\"," +
                 "BASEGEOGCRS[\"WGS 84\"," +
@@ -259,6 +260,13 @@ class WktParserTest {
         assertEquals(6378137.0, def.getA(), 0.1);
         assertEquals(0.9996, def.getK0(), 1e-6);
         assertEquals(500000.0, def.getX0(), 0.1);
+
+        Map<String, Object> projjson = WktParser.parseWkt2ToProjJson(wkt);
+        Map<String, Object> coordinateSystem =
+            (Map<String, Object>) projjson.get("coordinate_system");
+        assertEquals("Cartesian", coordinateSystem.get("subtype"));
+        assertFalse(coordinateSystem.containsKey("type"),
+            "PROJJSON coordinate systems use the subtype key");
     }
 
     @Test
@@ -708,12 +716,17 @@ class WktParserTest {
     @Test
     @DisplayName("GEODCRS geocentric (WKT2-2015 form, no USAGE) parses as geocent")
     void testGeodcrsGeocentric2015() {
-        // Documented divergence from proj4js/wkt-parser 1.5.5, which honors the CS
-        // subtype only in its WKT2-2019 builder and silently parses this form as
-        // longlat. USAGE does not exist in WKT2-2015, and PROJ's own WKT2:2015
-        // output for EPSG:4978 is exactly this shape — PROJ parses it as geocentric
-        // (verified via pyproj 3.7.2: CRS.from_wkt(...).is_geocentric == True).
-        assertGeocentric4978(GEODCRS_4978_HEAD + GEODCRS_4978_CS + ",ID[\"EPSG\",4978]]");
+        // Exact wkt-parser 1.5.6 fixture added by b7abacf.
+        String wkt = "GEODCRS[\"WGS 84\","
+            + "DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563,LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "CS[Cartesian,3],"
+            + "AXIS[\"(X)\",geocentricX,ORDER[1],LENGTHUNIT[\"metre\",1]],"
+            + "AXIS[\"(Y)\",geocentricY,ORDER[2],LENGTHUNIT[\"metre\",1]],"
+            + "AXIS[\"(Z)\",geocentricZ,ORDER[3],LENGTHUNIT[\"metre\",1]],"
+            + "ID[\"EPSG\",4978]]";
+        assertGeocentric4978(wkt);
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -235,7 +235,6 @@ class WktParserTest {
 
     @Test
     @DisplayName("Parse WKT2 PROJCRS (UTM)")
-    @SuppressWarnings("unchecked")
     void testParseWkt2ProjcrsUtm() {
         String wkt = "PROJCRS[\"WGS 84 / UTM zone 32N\"," +
                 "BASEGEOGCRS[\"WGS 84\"," +
@@ -262,11 +261,29 @@ class WktParserTest {
         assertEquals(500000.0, def.getX0(), 0.1);
 
         Map<String, Object> projjson = WktParser.parseWkt2ToProjJson(wkt);
-        Map<String, Object> coordinateSystem =
-            (Map<String, Object>) projjson.get("coordinate_system");
+        Object coordinateSystemValue = projjson.get("coordinate_system");
+        assertTrue(coordinateSystemValue instanceof Map);
+        Map<?, ?> coordinateSystem = (Map<?, ?>) coordinateSystemValue;
         assertEquals("Cartesian", coordinateSystem.get("subtype"));
         assertFalse(coordinateSystem.containsKey("type"),
             "PROJJSON coordinate systems use the subtype key");
+    }
+
+    @Test
+    @DisplayName("Standalone AXIS fallback does not invent a coordinate-system subtype")
+    void testStandaloneAxisFallbackOmitsUnknownSubtype() {
+        Map<String, Object> projjson = ProjJsonBuilder.convert(
+            List.<Object>of("AXIS", "easting", "east"), new HashMap<>());
+
+        Object coordinateSystemValue = projjson.get("coordinate_system");
+        assertTrue(coordinateSystemValue instanceof Map);
+        Map<?, ?> coordinateSystem = (Map<?, ?>) coordinateSystemValue;
+        assertFalse(coordinateSystem.containsKey("type"));
+        assertFalse(coordinateSystem.containsKey("subtype"));
+
+        Object axes = coordinateSystem.get("axis");
+        assertTrue(axes instanceof List);
+        assertEquals(1, ((List<?>) axes).size());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- emit the standard `coordinate_system.subtype` key when converting projected WKT2 to intermediate PROJJSON
- pin wkt-parser 1.5.6's WKT2-2015 geocentric fixture and projected coordinate-system schema
- record the completed upstream audit through proj4js `888ce3a` and wkt-parser `v1.5.6`

## Upstream audit

The new proj4js behavior through `888ce3a` was already present, including the Plessis and Carthage ellipsoid corrections, Van der Grinten axis handling, and projection scale-factor defaults. The remaining proj4js changes affect upstream maintenance scripts only.

Proj4Sedona also already handled wkt-parser 1.5.6's WKT2-2015 `GEODCRS` Cartesian classification. The missing parity detail was the projected coordinate-system key, which still used `type` instead of the PROJJSON-standard `subtype`.

## Validation

- `mvn -B -Dtest=WktParserTest test` — 47 tests passed
- `mvn -B clean test` — 1,093 tests passed
