### PR TITLE
Bump version to 0.1.3

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,14 +12,14 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.3</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'org.datasyslab:proj4sedona:0.1.1'
+implementation 'org.datasyslab:proj4sedona:0.1.3'
 ```
 
 ### Building from Source

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <packaging>jar</packaging>
 
     <name>Proj4Sedona</name>


### PR DESCRIPTION
## Summary

Patch release **0.1.2 → 0.1.3**, publishing the upstream-parity, CRS-serialization, and datum-registry fixes merged since 0.1.2.

### What changed since 0.1.2

- MGRS behavior is aligned with upstream `mgrs` 2.2.0 (#115).
- Projection defaults and CRS serialization now preserve executable semantics while rejecting unsafe lossy exports (#116–#119).
- WKT2 and PROJJSON parsing are synchronized with `wkt-parser` 1.5.6 (#120).
- The complete generated proj4js datum registry is included, fixing missing datum shifts such as RT90 in Apache Sedona issue #3161 (#121).

### Compatibility

No public API was removed. Serialization now fails explicitly for metadata that cannot be represented safely instead of silently emitting a lossy definition.

### Verification

- `mvn clean test -B`: 1,097 tests passed.
- `mvn package -DskipTests -B`: built `proj4sedona-0.1.3.jar`.
- Apache Sedona master: all 36 existing `CRSTransformProj4Test` cases plus a locally added issue-3161 regression passed against the 0.1.3 contents.

Contents:

- `pom.xml`: `0.1.2` → `0.1.3`
- `docs/getting-started.md`: Maven and Gradle dependency pins updated to `0.1.3`
