### PR TITLE
Export TOWGS84 operations as BoundCRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,13 @@ Full documentation is available in the [docs/](docs/) folder:
 
 **Serialization compatibility:** Standard WKT/PROJJSON exporters now throw
 `UnsupportedOperationException` instead of returning lossy output for definitions they
-cannot represent. In particular, WKT2 and PROJJSON reject non-zero `+towgs84`, and all
-standard exporters reject grid shifts, `+over`, `+R_A`, and two-point `omerc`. WKT2 and
-PROJJSON also reject `+approx`; WKT1 preserves approximate Transverse Mercator with the
-executable `Fast_Transverse_Mercator` method.
-Use `toProjString()` when those operation semantics must be preserved. The complete list
-is in the [CRS export fidelity guide](docs/crs-formats.md#export-fidelity).
+cannot represent. WKT2 and PROJJSON preserve supported three- and seven-parameter
+`+towgs84` operations as a `BoundCRS` (geocentric sources are supported in PROJJSON
+only), while WKT1 uses `TOWGS84`. All standard exporters reject grid shifts, `+over`,
+`+R_A`, and two-point `omerc`. WKT2 and PROJJSON also reject `+approx`; WKT1 preserves
+approximate Transverse Mercator with the executable `Fast_Transverse_Mercator` method.
+Use `toProjString()` for remaining unsupported operation semantics. The complete list is
+in the [CRS export fidelity guide](docs/crs-formats.md#export-fidelity).
 
 ## Quick Start
 

--- a/docs/crs-formats.md
+++ b/docs/crs-formats.md
@@ -258,9 +258,17 @@ mode (`+R_A`), `ob_tran`, Tilted Perspective, unsupported Oblique Mercator varia
 Mercator is format-dependent: WKT2 and PROJJSON reject it, while WKT1 emits
 the executable `Fast_Transverse_Mercator` method. Other uses of `+approx` are rejected
 by all standard exporters. WKT2 and
-PROJJSON also reject non-zero `+towgs84` operations until bound-CRS export is
-implemented; WKT1 preserves them with `TOWGS84`. Geocentric CRS export is supported as
-a PROJ string or PROJJSON, but not yet as WKT.
+PROJJSON preserve coordinate-affecting three- and seven-parameter `+towgs84`
+operations as a `BoundCRS` targeting WGS 84. This includes zero-valued operations
+on a non-WGS84 ellipsoid when they are not recoverable from a canonical named datum;
+the ellipsoid conversion still changes coordinates in that case.
+Geographic and projected sources target EPSG:4326 with EPSG methods 9603 and 9606;
+geocentric PROJJSON targets EPSG:4978 with methods 1031 and 1033. Helmert BoundCRS
+import is limited to those target/method combinations so an arbitrary target or
+coordinate-frame rotation cannot be silently rewritten as `+towgs84`. WKT1 preserves
+the same operation with `TOWGS84`. Grid-shift operations remain importable but are not
+yet exportable. Geocentric CRS export is supported as a PROJ string or PROJJSON, but
+not yet as WKT.
 
 For supported definitions, standard exports preserve projection parameters,
 linear-unit factors, horizontal axis order and direction, and non-Greenwich prime

--- a/scripts/pyproj-reference/generate_format_reference.py
+++ b/scripts/pyproj-reference/generate_format_reference.py
@@ -100,11 +100,7 @@ def get_test_crs_definitions() -> List[Dict[str, Any]]:
         {
             "input": "+proj=longlat +ellps=intl +towgs84=-87,-98,-121 +axis=enu +no_defs",
             "name": "longlat_three_parameter_datum",
-            "desc": "Geographic CRS with a three-parameter datum transformation",
-            # The Java implementation deliberately refuses standard formats that
-            # would otherwise discard the bound-CRS operation.  A refusal is part
-            # of the contract and is checked by the benchmark.
-            "java_supported_formats": ["wkt1", "proj_string"]
+            "desc": "Geographic CRS with a three-parameter datum transformation"
         },
     ]
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -42,7 +42,10 @@ public final class CRSSerializer {
 
     private static final double RAD_TO_DEG = 180.0 / Math.PI;
     private static final double DEG_TO_RAD = Math.PI / 180.0;
+    private static final double ARC_SECOND_TO_RAD = DEG_TO_RAD / 3600.0;
+    private static final double PARTS_PER_MILLION_TO_SCALE = 1e-6;
     private static final String DEG_TO_RAD_STR = Double.toString(DEG_TO_RAD);
+    private static final String TOWGS84_TRANSFORMATION_NAME = "Transformation to WGS 84";
 
     // Projection name mappings: PROJ -> WKT method names (short/generic names)
     private static final Map<String, String> PROJ_TO_WKT_METHOD = new LinkedHashMap<>();
@@ -825,7 +828,22 @@ public final class CRSSerializer {
         rejectNonRepresentableStandardParameters(params, StandardFormat.WKT2);
 
         StringBuilder sb = new StringBuilder();
+        if (needsTowgs84BoundCrs(params)) {
+            sb.append("BOUNDCRS[SOURCECRS[");
+            appendWkt2Crs(sb, params);
+            sb.append("],TARGETCRS[");
+            appendWkt2Wgs84TargetCrs(sb);
+            sb.append("],");
+            appendWkt2Towgs84Transformation(sb, params.datum);
+            sb.append("]");
+            return sb.toString();
+        }
 
+        appendWkt2Crs(sb, params);
+        return sb.toString();
+    }
+
+    private static void appendWkt2Crs(StringBuilder sb, ProjectionParams params) {
         boolean isGeographic = "longlat".equals(normalizeProjName(params.projName));
 
         if (isGeographic) {
@@ -837,8 +855,57 @@ public final class CRSSerializer {
             appendWkt2ProjCRS(sb, params);
             sb.append("]");
         }
+    }
 
-        return sb.toString();
+    private static void appendWkt2Wgs84TargetCrs(StringBuilder sb) {
+        sb.append("GEOGCRS[\"WGS 84\",")
+          .append("DATUM[\"World Geodetic System 1984\",")
+          .append("ELLIPSOID[\"WGS 84\",6378137,298.257223563,")
+          .append("LENGTHUNIT[\"metre\",1]]],")
+          .append("PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",")
+          .append(DEG_TO_RAD_STR)
+          .append("]],CS[ellipsoidal,2],")
+          .append("AXIS[\"latitude\",north,ORDER[1],ANGLEUNIT[\"degree\",")
+          .append(DEG_TO_RAD_STR)
+          .append("]],")
+          .append("AXIS[\"longitude\",east,ORDER[2],ANGLEUNIT[\"degree\",")
+          .append(DEG_TO_RAD_STR)
+          .append("]],ID[\"EPSG\",4326]]");
+    }
+
+    private static void appendWkt2Towgs84Transformation(
+            StringBuilder sb, DatumParams datum) {
+        double[] values = toHumanTowgs84(datum);
+        boolean sevenParameters = values.length == 7;
+
+        sb.append("ABRIDGEDTRANSFORMATION[\"")
+          .append(TOWGS84_TRANSFORMATION_NAME)
+          .append("\",METHOD[\"")
+          .append(sevenParameters
+              ? "Position Vector transformation (geog2D domain)"
+              : "Geocentric translations (geog2D domain)")
+          .append("\",ID[\"EPSG\",")
+          .append(sevenParameters ? 9606 : 9603)
+          .append("]]");
+        appendWkt2Towgs84Parameter(sb, "X-axis translation", values[0], 8605);
+        appendWkt2Towgs84Parameter(sb, "Y-axis translation", values[1], 8606);
+        appendWkt2Towgs84Parameter(sb, "Z-axis translation", values[2], 8607);
+        if (sevenParameters) {
+            appendWkt2Towgs84Parameter(sb, "X-axis rotation", values[3], 8608);
+            appendWkt2Towgs84Parameter(sb, "Y-axis rotation", values[4], 8609);
+            appendWkt2Towgs84Parameter(sb, "Z-axis rotation", values[5], 8610);
+            appendWkt2Towgs84Parameter(
+                sb, "Scale difference",
+                1.0 + values[6] * PARTS_PER_MILLION_TO_SCALE, 8611);
+        }
+        sb.append("]");
+    }
+
+    private static void appendWkt2Towgs84Parameter(
+            StringBuilder sb, String name, double value, int epsgCode) {
+        sb.append(",PARAMETER[\"").append(name).append("\",")
+          .append(formatNumber(value))
+          .append(",ID[\"EPSG\",").append(epsgCode).append("]]");
     }
 
     private static void appendWkt2GeogCRS(StringBuilder sb, ProjectionParams params) {
@@ -1133,6 +1200,23 @@ public final class CRSSerializer {
         }
         rejectNonRepresentableStandardParameters(params, StandardFormat.PROJJSON);
 
+        Map<String, Object> sourceCrs = buildProjJsonCrs(params);
+        if (!needsTowgs84BoundCrs(params)) {
+            return sourceCrs;
+        }
+
+        Map<String, Object> json = new LinkedHashMap<>();
+        boolean geocentric = isGeocentric(params);
+        json.put("type", "BoundCRS");
+        json.put("source_crs", sourceCrs);
+        json.put("target_crs", buildProjJsonWgs84TargetCrs(geocentric));
+        json.put(
+            "transformation",
+            buildProjJsonTowgs84Transformation(params.datum, geocentric));
+        return json;
+    }
+
+    private static Map<String, Object> buildProjJsonCrs(ProjectionParams params) {
         Map<String, Object> json = new LinkedHashMap<>();
 
         boolean isGeographic = "longlat".equals(normalizeProjName(params.projName));
@@ -1160,17 +1244,128 @@ public final class CRSSerializer {
         // Add "id" field when the authority is known
         String[] authority = toAuthority(params);
         if (authority != null) {
-            Map<String, Object> id = new LinkedHashMap<>();
-            id.put("authority", authority[0]);
+            Object code;
             try {
-                id.put("code", Integer.parseInt(authority[1]));
+                code = Integer.parseInt(authority[1]);
             } catch (NumberFormatException e) {
-                id.put("code", authority[1]);
+                code = authority[1];
             }
-            json.put("id", id);
+            json.put("id", buildProjJsonId(authority[0], code));
         }
 
         return json;
+    }
+
+    private static Map<String, Object> buildProjJsonWgs84TargetCrs(boolean geocentric) {
+        Map<String, Object> targetCrs = new LinkedHashMap<>();
+        targetCrs.put("type", geocentric ? "GeodeticCRS" : "GeographicCRS");
+        targetCrs.put("name", "WGS 84");
+
+        Map<String, Object> datum = new LinkedHashMap<>();
+        datum.put("type", "GeodeticReferenceFrame");
+        datum.put("name", "World Geodetic System 1984");
+
+        Map<String, Object> ellipsoid = new LinkedHashMap<>();
+        ellipsoid.put("name", "WGS 84");
+        ellipsoid.put("semi_major_axis", 6378137);
+        ellipsoid.put("inverse_flattening", 298.257223563);
+        datum.put("ellipsoid", ellipsoid);
+
+        targetCrs.put("datum", datum);
+        targetCrs.put(
+            "coordinate_system",
+            geocentric ? buildProjJsonGeocentricCS() : buildProjJsonGeogCS());
+        targetCrs.put("id", buildProjJsonId("EPSG", geocentric ? 4978 : 4326));
+        return targetCrs;
+    }
+
+    private static Map<String, Object> buildProjJsonTowgs84Transformation(
+            DatumParams datum, boolean geocentric) {
+        double[] values = toHumanTowgs84(datum);
+        boolean sevenParameters = values.length == 7;
+
+        Map<String, Object> transformation = new LinkedHashMap<>();
+        transformation.put("name", TOWGS84_TRANSFORMATION_NAME);
+
+        Map<String, Object> method = new LinkedHashMap<>();
+        if (geocentric) {
+            method.put("name", sevenParameters
+                ? "Position Vector transformation (geocentric domain)"
+                : "Geocentric translations (geocentric domain)");
+            method.put("id", buildProjJsonId("EPSG", sevenParameters ? 1033 : 1031));
+        } else {
+            method.put("name", sevenParameters
+                ? "Position Vector transformation (geog2D domain)"
+                : "Geocentric translations (geog2D domain)");
+            method.put("id", buildProjJsonId("EPSG", sevenParameters ? 9606 : 9603));
+        }
+        transformation.put("method", method);
+
+        List<Map<String, Object>> parameters = new ArrayList<>();
+        parameters.add(buildProjJsonTowgs84Parameter(
+            "X-axis translation", values[0], "metre", 8605));
+        parameters.add(buildProjJsonTowgs84Parameter(
+            "Y-axis translation", values[1], "metre", 8606));
+        parameters.add(buildProjJsonTowgs84Parameter(
+            "Z-axis translation", values[2], "metre", 8607));
+        if (sevenParameters) {
+            parameters.add(buildProjJsonTowgs84Parameter(
+                "X-axis rotation", values[3],
+                buildProjJsonUnit("AngularUnit", "arc-second", ARC_SECOND_TO_RAD),
+                8608));
+            parameters.add(buildProjJsonTowgs84Parameter(
+                "Y-axis rotation", values[4],
+                buildProjJsonUnit("AngularUnit", "arc-second", ARC_SECOND_TO_RAD),
+                8609));
+            parameters.add(buildProjJsonTowgs84Parameter(
+                "Z-axis rotation", values[5],
+                buildProjJsonUnit("AngularUnit", "arc-second", ARC_SECOND_TO_RAD),
+                8610));
+            parameters.add(buildProjJsonTowgs84Parameter(
+                "Scale difference", values[6],
+                buildProjJsonUnit(
+                    "ScaleUnit", "parts per million", PARTS_PER_MILLION_TO_SCALE),
+                8611));
+        }
+        transformation.put("parameters", parameters);
+        return transformation;
+    }
+
+    private static Map<String, Object> buildProjJsonTowgs84Parameter(
+            String name, double value, Object unit, int epsgCode) {
+        Map<String, Object> parameter = new LinkedHashMap<>();
+        parameter.put("name", name);
+        parameter.put("value", value);
+        parameter.put("unit", unit);
+        parameter.put("id", buildProjJsonId("EPSG", epsgCode));
+        return parameter;
+    }
+
+    private static Map<String, Object> buildProjJsonUnit(
+            String type, String name, double conversionFactor) {
+        Map<String, Object> unit = new LinkedHashMap<>();
+        unit.put("type", type);
+        unit.put("name", name);
+        unit.put("conversion_factor", conversionFactor);
+        return unit;
+    }
+
+    private static Map<String, Object> buildProjJsonId(String authority, Object code) {
+        Map<String, Object> id = new LinkedHashMap<>();
+        id.put("authority", authority);
+        id.put("code", code);
+        return id;
+    }
+
+    private static Map<String, Object> buildProjJsonGeocentricCS() {
+        Map<String, Object> cs = new LinkedHashMap<>();
+        cs.put("subtype", "Cartesian");
+        cs.put("axis", Arrays.asList(
+            buildGeocentricAxis("Geocentric X", "X", "geocentricX", "metre"),
+            buildGeocentricAxis("Geocentric Y", "Y", "geocentricY", "metre"),
+            buildGeocentricAxis("Geocentric Z", "Z", "geocentricZ", "metre")
+        ));
+        return cs;
     }
 
     /**
@@ -2640,9 +2835,9 @@ public final class CRSSerializer {
 
     /**
      * Fail instead of emitting a syntactically plausible CRS that silently drops a
-     * transform-affecting PROJ extension.  These exporters describe a CRS, not an
-     * arbitrary PROJ operation pipeline; callers can always request the lossless
-     * PROJ string instead.
+     * transform-affecting PROJ extension. These exporters describe a CRS, not an
+     * arbitrary PROJ operation pipeline; the one supported operation wrapper is a
+     * BoundCRS for PROJ's three- and seven-parameter TOWGS84 semantics.
      */
     private static void rejectNonRepresentableStandardParameters(
             ProjectionParams params, StandardFormat format) {
@@ -2700,11 +2895,6 @@ public final class CRSSerializer {
         if (datum != null && datum.isGridShift()) {
             throw unsupportedStandardParameter(
                 "Grid-shift datum operations cannot be represented losslessly");
-        }
-        if (format != StandardFormat.WKT1 && hasTransformingTowgs84(datum)) {
-            throw unsupportedStandardParameter(
-                "TOWGS84 datum operations cannot be represented losslessly in "
-                    + formatName(format));
         }
 
         validateStandardAxis(params, proj, format);
@@ -2865,7 +3055,7 @@ public final class CRSSerializer {
             && params.alpha == null && params.rectifiedGridAngle == null;
     }
 
-    /** Non-zero Helmert values affect coordinates; an all-zero list does not. */
+    /** Whether at least one Helmert parameter is non-zero. */
     private static boolean hasTransformingTowgs84(DatumParams datum) {
         if (datum == null || datum.getDatumParams() == null) {
             return false;
@@ -2877,6 +3067,35 @@ public final class CRSSerializer {
             }
         }
         return false;
+    }
+
+    /**
+     * An explicit zero-valued Helmert operation is still significant when its source
+     * ellipsoid is not WGS 84: the geodetic/geocentric conversion changes coordinates
+     * even though the Cartesian translation, rotation, and scale are identities.
+     * Canonical named datums can stay unbound because their operation is recovered
+     * from the datum identity, and an unnamed WGS 84 ellipsoid with zero parameters
+     * is already equivalent to the target.
+     */
+    private static boolean needsTowgs84BoundCrs(ProjectionParams params) {
+        DatumParams datum = params.datum;
+        if (datum == null || datum.getDatumParams() == null) {
+            return false;
+        }
+        if (hasTransformingTowgs84(datum)) {
+            return true;
+        }
+        return resolveProjDatumToken(params) == null
+            && !hasWgs84EquivalentEllipsoid(params);
+    }
+
+    private static boolean hasWgs84EquivalentEllipsoid(ProjectionParams params) {
+        Ellipsoid wgs84 = Ellipsoid.get("WGS84");
+        double rf = effectiveRf(params);
+        double b = params.b > 0 ? params.b
+            : rf > 0 ? params.a * (1 - 1 / rf) : params.a;
+        return Math.abs(params.a - wgs84.getA()) < 1e-6
+            && Math.abs(b - wgs84.getB()) < 1e-6;
     }
 
     private static boolean hasNonFiniteTowgs84(DatumParams datum) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -441,7 +441,8 @@ public final class ProjJsonBuilder {
         List<Object> sourceCrsNode = findNode(node, "SOURCECRS");
         if (sourceCrsNode != null) {
             // Find the actual CRS content within SOURCECRS
-            List<Object> sourceCrsContent = findNodeAny(sourceCrsNode, "PROJCRS", "GEOGCRS");
+            List<Object> sourceCrsContent =
+                findNodeAny(sourceCrsNode, "PROJCRS", "GEOGCRS", "GEODCRS");
             if (sourceCrsContent != null) {
                 result.put("source_crs", convert(sourceCrsContent, new HashMap<>()));
             }
@@ -450,7 +451,8 @@ public final class ProjJsonBuilder {
         // Process TARGETCRS
         List<Object> targetCrsNode = findNode(node, "TARGETCRS");
         if (targetCrsNode != null) {
-            List<Object> targetCrsContent = findNodeAny(targetCrsNode, "PROJCRS", "GEOGCRS");
+            List<Object> targetCrsContent =
+                findNodeAny(targetCrsNode, "PROJCRS", "GEOGCRS", "GEODCRS");
             if (targetCrsContent != null) {
                 result.put("target_crs", convert(targetCrsContent, new HashMap<>()));
             }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -509,7 +509,8 @@ public final class ProjJsonBuilder {
         // Adjust Scale difference parameter if present (for 7-param transforms)
         if (parameters.size() == 7) {
             Map<String, Object> scaleDiff = parameters.get(6);
-            if ("Scale difference".equals(scaleDiff.get("name"))) {
+            if ("Scale difference".equals(scaleDiff.get("name"))
+                    || hasEpsgId(scaleDiff, 8611)) {
                 Object valueObj = scaleDiff.get("value");
                 if (valueObj instanceof Number) {
                     double value = ((Number) valueObj).doubleValue();
@@ -524,6 +525,19 @@ public final class ProjJsonBuilder {
         if (id != null) {
             result.put("id", id);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean hasEpsgId(Map<String, Object> object, int expectedCode) {
+        Object idValue = object.get("id");
+        if (!(idValue instanceof Map)) {
+            return false;
+        }
+        Map<String, Object> id = (Map<String, Object>) idValue;
+        Object authority = id.get("authority");
+        Double code = parseDouble(id.get("code"));
+        return authority != null && "EPSG".equalsIgnoreCase(authority.toString())
+            && code != null && code == expectedCode;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -16,6 +16,16 @@ import java.util.Map;
  */
 public final class ProjJsonTransformer {
 
+    private static final String[] TOWGS84_PARAMETER_NAMES = {
+        "X-axis translation",
+        "Y-axis translation",
+        "Z-axis translation",
+        "X-axis rotation",
+        "Y-axis rotation",
+        "Z-axis rotation",
+        "Scale difference"
+    };
+
     private ProjJsonTransformer() {
         // Utility class
     }
@@ -37,16 +47,22 @@ public final class ProjJsonTransformer {
         // Handle BoundCRS specially - recurse into source_crs
         if ("BoundCRS".equals(projjson.get("type"))) {
             Object sourceCrs = projjson.get("source_crs");
-            if (sourceCrs instanceof Map) {
-                def = transform((Map<String, Object>) sourceCrs);
+            if (!(sourceCrs instanceof Map)) {
+                throw new IllegalArgumentException("BoundCRS requires a source_crs");
             }
-            
-            // Process transformation for datum params
             Object transformation = projjson.get("transformation");
-            if (transformation instanceof Map) {
-                processTransformation((Map<String, Object>) transformation, def);
+            if (!(transformation instanceof Map)) {
+                throw new IllegalArgumentException("BoundCRS requires a transformation");
             }
-            
+
+            Map<String, Object> source = (Map<String, Object>) sourceCrs;
+            Map<String, Object> operation = (Map<String, Object>) transformation;
+            if (!isNtv2Transformation(operation)) {
+                validateSupportedTowgs84BoundCrs(projjson, source, operation);
+            }
+
+            def = transform(source);
+            processTransformation(operation, def);
             return def;
         }
 
@@ -569,23 +585,19 @@ public final class ProjJsonTransformer {
      */
     @SuppressWarnings("unchecked")
     private static void processTransformation(Map<String, Object> transformation, ProjectionDef def) {
-        Object method = transformation.get("method");
-        if (method instanceof Map) {
-            Object methodName = ((Map<String, Object>) method).get("name");
-            if (methodName != null && "NTv2".equals(methodName.toString())) {
-                // Set nadgrids from parameter file
-                Object params = transformation.get("parameters");
-                if (params instanceof List) {
-                    List<Map<String, Object>> paramList = (List<Map<String, Object>>) params;
-                    if (!paramList.isEmpty()) {
-                        Object value = paramList.get(0).get("value");
-                        if (value != null) {
-                            def.setNadgrids(value.toString());
-                        }
+        if (isNtv2Transformation(transformation)) {
+            // Set nadgrids from parameter file
+            Object params = transformation.get("parameters");
+            if (params instanceof List) {
+                List<Map<String, Object>> paramList = (List<Map<String, Object>>) params;
+                if (!paramList.isEmpty()) {
+                    Object value = paramList.get(0).get("value");
+                    if (value != null) {
+                        def.setNadgrids(value.toString());
                     }
                 }
-                return;
             }
+            return;
         }
 
         // For non-NTv2 transformations, extract datum_params
@@ -599,6 +611,319 @@ public final class ProjJsonTransformer {
             }
             def.setDatumParams(datumParams);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean isNtv2Transformation(Map<String, Object> transformation) {
+        Object method = transformation.get("method");
+        if (!(method instanceof Map)) {
+            return false;
+        }
+        Object methodName = ((Map<String, Object>) method).get("name");
+        return methodName != null && "NTv2".equals(methodName.toString());
+    }
+
+    /**
+     * ProjectionDef can represent only PROJ's legacy three/seven-parameter
+     * transformation to WGS 84. Reject other BoundCRS operations before flattening
+     * them into datumParams, otherwise a later export would silently replace the
+     * original target or rotation convention.
+     */
+    @SuppressWarnings("unchecked")
+    private static void validateSupportedTowgs84BoundCrs(
+            Map<String, Object> boundCrs,
+            Map<String, Object> sourceCrs,
+            Map<String, Object> transformation) {
+        boolean geocentric = isGeocentricCrs(sourceCrs);
+
+        Object parametersValue = transformation.get("parameters");
+        if (!(parametersValue instanceof List)) {
+            throw unsupportedBoundCrs(
+                "transformation parameters must be a three- or seven-element array");
+        }
+        List<?> parameters = (List<?>) parametersValue;
+        if (parameters.size() != 3 && parameters.size() != 7) {
+            throw unsupportedBoundCrs(
+                "transformation must contain exactly three or seven parameters");
+        }
+
+        int methodCode;
+        String methodName;
+        if (geocentric) {
+            methodCode = parameters.size() == 7 ? 1033 : 1031;
+            methodName = parameters.size() == 7
+                ? "Position Vector transformation (geocentric domain)"
+                : "Geocentric translations (geocentric domain)";
+        } else {
+            methodCode = parameters.size() == 7 ? 9606 : 9603;
+            methodName = parameters.size() == 7
+                ? "Position Vector transformation (geog2D domain)"
+                : "Geocentric translations (geog2D domain)";
+        }
+
+        validateBoundCrsTarget(boundCrs.get("target_crs"), geocentric);
+        validateBoundCrsMethod(transformation.get("method"), methodCode, methodName);
+        validateTowgs84Parameters(parameters);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean isGeocentricCrs(Map<String, Object> crs) {
+        Object type = crs.get("type");
+        if ("GeographicCRS".equals(type) || "ProjectedCRS".equals(type)) {
+            return false;
+        }
+        if (!"GeodeticCRS".equals(type)) {
+            throw unsupportedBoundCrs("source CRS type is not supported");
+        }
+        Object coordinateSystem = crs.get("coordinate_system");
+        return coordinateSystem instanceof Map
+            && "Cartesian".equals(((Map<String, Object>) coordinateSystem).get("subtype"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void validateBoundCrsTarget(Object targetValue, boolean geocentric) {
+        if (!(targetValue instanceof Map)) {
+            throw unsupportedBoundCrs("target_crs must be WGS 84");
+        }
+        Map<String, Object> target = (Map<String, Object>) targetValue;
+
+        Object type = target.get("type");
+        Object coordinateSystem = target.get("coordinate_system");
+        boolean cartesian = coordinateSystem instanceof Map
+            && "Cartesian".equals(((Map<String, Object>) coordinateSystem).get("subtype"));
+        if (geocentric) {
+            if (!"GeodeticCRS".equals(type) || !cartesian) {
+                throw unsupportedBoundCrs(
+                    "geocentric sources require a geocentric WGS 84 target");
+            }
+        } else if (!(("GeographicCRS".equals(type) || "GeodeticCRS".equals(type))
+                && !cartesian)) {
+            throw unsupportedBoundCrs(
+                "geographic and projected sources require a geographic WGS 84 target");
+        }
+
+        Object idValue = target.get("id");
+        if (idValue != null) {
+            if (!(idValue instanceof Map)) {
+                throw unsupportedBoundCrs("target CRS identifier is malformed");
+            }
+            Map<String, Object> id = (Map<String, Object>) idValue;
+            Object authority = id.get("authority");
+            Object code = id.get("code");
+            int expectedCode = geocentric ? 4978 : 4326;
+            if (authority == null || code == null
+                    || !"EPSG".equalsIgnoreCase(authority.toString())
+                    || parseInteger(code, "target CRS identifier") != expectedCode) {
+                throw unsupportedBoundCrs(
+                    "target CRS must be EPSG:" + expectedCode);
+            }
+            return;
+        }
+
+        if (!hasWgs84Identity(target)) {
+            throw unsupportedBoundCrs(
+                "ID-less target CRS must identify the WGS 84 datum and ellipsoid");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean hasWgs84Identity(Map<String, Object> target) {
+        Object datumValue = target.get("datum");
+        if (!(datumValue instanceof Map)) {
+            datumValue = target.get("datum_ensemble");
+        }
+        if (!(datumValue instanceof Map)) {
+            return false;
+        }
+        Map<String, Object> datum = (Map<String, Object>) datumValue;
+        Object ellipsoidValue = datum.get("ellipsoid");
+        return isWgs84Name(datum.get("name")) && ellipsoidValue instanceof Map
+            && isWgs84Ellipsoid((Map<String, Object>) ellipsoidValue);
+    }
+
+    private static boolean isWgs84Name(Object value) {
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.toString().replaceAll("[^A-Za-z0-9]", "");
+        return "WGS84".equalsIgnoreCase(normalized)
+            || "WorldGeodeticSystem1984".equalsIgnoreCase(normalized)
+            || "WorldGeodeticSystem1984ensemble".equalsIgnoreCase(normalized);
+    }
+
+    private static boolean isWgs84Ellipsoid(Map<String, Object> ellipsoid) {
+        Object semiMajor = ellipsoid.get("semi_major_axis");
+        Object inverseFlattening = ellipsoid.get("inverse_flattening");
+        if (semiMajor == null || inverseFlattening == null) {
+            return false;
+        }
+        return Math.abs(parseFiniteDouble(semiMajor, "target semi-major axis")
+                - 6378137.0) < 1e-6
+            && Math.abs(parseFiniteDouble(
+                    inverseFlattening, "target inverse flattening")
+                - 298.257223563) < 1e-9;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void validateBoundCrsMethod(
+            Object methodValue, int expectedCode, String expectedName) {
+        if (!(methodValue instanceof Map)) {
+            throw unsupportedBoundCrs("transformation method is required");
+        }
+        Map<String, Object> method = (Map<String, Object>) methodValue;
+        Object name = method.get("name");
+        Object idValue = method.get("id");
+        if (name == null && idValue == null) {
+            throw unsupportedBoundCrs("transformation method is required");
+        }
+        if (idValue != null) {
+            requireEpsgCode(idValue, expectedCode, "transformation method");
+        } else if (!expectedName.equalsIgnoreCase(name.toString())) {
+            throw unsupportedBoundCrs(
+                "transformation method must be " + expectedName);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void validateTowgs84Parameters(List<?> parameters) {
+        for (int i = 0; i < parameters.size(); i++) {
+            Object parameterValue = parameters.get(i);
+            if (!(parameterValue instanceof Map)) {
+                throw unsupportedBoundCrs("transformation parameter is malformed");
+            }
+            Map<String, Object> parameter = (Map<String, Object>) parameterValue;
+            String expectedName = TOWGS84_PARAMETER_NAMES[i];
+            int expectedCode = 8605 + i;
+            Object name = parameter.get("name");
+            Object id = parameter.get("id");
+            if (name == null && id == null) {
+                throw unsupportedBoundCrs(
+                    "transformation parameter " + (i + 1) + " has no identity");
+            }
+            if (id != null) {
+                requireEpsgCode(id, expectedCode, "transformation parameter");
+            } else if (!expectedName.equalsIgnoreCase(name.toString())) {
+                throw unsupportedBoundCrs(
+                    "transformation parameters must use canonical TOWGS84 order");
+            }
+            parseFiniteDouble(parameter.get("value"), expectedName);
+            validateTowgs84Unit(parameter.get("unit"), i);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void validateTowgs84Unit(Object unitValue, int parameterIndex) {
+        if (unitValue == null) {
+            // WKT2 ABRIDGEDTRANSFORMATION may omit explicit parameter units.
+            return;
+        }
+
+        String expectedType;
+        double expectedFactor;
+        String[] acceptedNames;
+        if (parameterIndex < 3) {
+            expectedType = "LinearUnit";
+            expectedFactor = 1.0;
+            acceptedNames = new String[]{"metre", "meter", "m"};
+        } else if (parameterIndex < 6) {
+            expectedType = "AngularUnit";
+            expectedFactor = Values.SEC_TO_RAD;
+            acceptedNames = new String[]{"arc-second", "arcsecond", "arc second"};
+        } else {
+            expectedType = "ScaleUnit";
+            expectedFactor = 1e-6;
+            acceptedNames = new String[]{"parts per million", "ppm"};
+        }
+
+        if (unitValue instanceof String) {
+            if (!equalsAnyIgnoreCase(unitValue.toString(), acceptedNames)) {
+                throw unsupportedBoundCrs("transformation parameter unit is not supported");
+            }
+            return;
+        }
+        if (!(unitValue instanceof Map)) {
+            throw unsupportedBoundCrs("transformation parameter unit is malformed");
+        }
+
+        Map<String, Object> unit = (Map<String, Object>) unitValue;
+        Object type = unit.get("type");
+        if (type != null && !expectedType.equalsIgnoreCase(type.toString())) {
+            throw unsupportedBoundCrs("transformation parameter unit type is not supported");
+        }
+        Object factor = unit.get("conversion_factor");
+        Object name = unit.get("name");
+        if (factor == null && (name == null
+                || !equalsAnyIgnoreCase(name.toString(), acceptedNames))) {
+            throw unsupportedBoundCrs("transformation parameter unit is not supported");
+        }
+        if (factor != null) {
+            double actualFactor =
+                parseFiniteDouble(factor, "transformation unit conversion factor");
+            double tolerance = Math.max(1e-15, Math.abs(expectedFactor) * 1e-12);
+            if (Math.abs(actualFactor - expectedFactor) > tolerance) {
+                throw unsupportedBoundCrs("transformation parameter unit is not supported");
+            }
+        }
+    }
+
+    private static boolean equalsAnyIgnoreCase(String value, String[] candidates) {
+        for (String candidate : candidates) {
+            if (candidate.equalsIgnoreCase(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void requireEpsgCode(
+            Object idValue, int expectedCode, String description) {
+        if (!(idValue instanceof Map)) {
+            throw unsupportedBoundCrs(description + " identifier is malformed");
+        }
+        Map<String, Object> id = (Map<String, Object>) idValue;
+        Object authority = id.get("authority");
+        Object code = id.get("code");
+        if (authority == null || code == null
+                || !"EPSG".equalsIgnoreCase(authority.toString())
+                || parseInteger(code, description + " identifier") != expectedCode) {
+            throw unsupportedBoundCrs(
+                description + " must use EPSG:" + expectedCode);
+        }
+    }
+
+    private static int parseInteger(Object value, String description) {
+        double numeric = parseFiniteDouble(value, description);
+        if (numeric != Math.rint(numeric)
+                || numeric < Integer.MIN_VALUE || numeric > Integer.MAX_VALUE) {
+            throw unsupportedBoundCrs(description + " is not an integer");
+        }
+        return (int) numeric;
+    }
+
+    private static double parseFiniteDouble(Object value, String description) {
+        if (value == null) {
+            throw unsupportedBoundCrs(description + " is missing");
+        }
+        final double numeric;
+        if (value instanceof Number) {
+            numeric = ((Number) value).doubleValue();
+        } else {
+            try {
+                numeric = Double.parseDouble(value.toString());
+            } catch (NumberFormatException e) {
+                throw unsupportedBoundCrs(description + " is not numeric");
+            }
+        }
+        if (!Double.isFinite(numeric)) {
+            throw unsupportedBoundCrs(description + " is not finite");
+        }
+        return numeric;
+    }
+
+    private static IllegalArgumentException unsupportedBoundCrs(String detail) {
+        return new IllegalArgumentException(
+            "Unsupported BoundCRS: " + detail);
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerBoundCrsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerBoundCrsTest.java
@@ -1,0 +1,487 @@
+package org.datasyslab.proj4sedona.parser;
+
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
+import org.datasyslab.proj4sedona.transform.Converter;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CRSSerializerBoundCrsTest {
+
+    private static final String WGS84 = "+proj=longlat +datum=WGS84 +no_defs";
+    private static final String THREE_PARAMETER =
+        "+proj=longlat +ellps=bessel +towgs84=674.374,15.056,405.346 +no_defs";
+    private static final String SEVEN_PARAMETER =
+        "+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 "
+            + "+x_0=400000 +y_0=-100000 +ellps=airy "
+            + "+towgs84=446.448,-125.157,542.06,0.1502,0.247,0.8421,-20.4894 "
+            + "+units=m +no_defs";
+    private static final String[] TOWGS84_PARAMETER_NAMES = {
+        "X-axis translation",
+        "Y-axis translation",
+        "Z-axis translation",
+        "X-axis rotation",
+        "Y-axis rotation",
+        "Z-axis rotation",
+        "Scale difference"
+    };
+
+    @BeforeAll
+    static void setup() {
+        ProjectionRegistry.start();
+    }
+
+    @Test
+    void threeParameterTowgs84ExportsAsGeographicBoundCrs() {
+        Proj original = new Proj(THREE_PARAMETER);
+        double[] values = {674.374, 15.056, 405.346};
+
+        String wkt2 = CRSSerializer.toWkt2(original);
+        assertTrue(wkt2.startsWith("BOUNDCRS[SOURCECRS[GEOGCRS["), wkt2);
+        assertBoundCrs(
+            WktParser.parseWkt2ToProjJson(wkt2),
+            "GeographicCRS", 9603, "Geocentric translations (geog2D domain)", values);
+
+        Map<String, Object> projJson =
+            CRSSerializer.toProjJsonMap(original.getParams());
+        assertBoundCrs(
+            projJson,
+            "GeographicCRS", 9603, "Geocentric translations (geog2D domain)", values);
+        assertTranslationUnits(projJson);
+
+        assertRoundTripCoordinates(
+            original, wkt2, new Point(7.438632, 46.951082));
+        assertRoundTripCoordinates(
+            original, CRSSerializer.toProjJson(original, false),
+            new Point(7.438632, 46.951082));
+    }
+
+    @Test
+    void sevenParameterTowgs84ExportsAsProjectedBoundCrs() {
+        Proj original = new Proj(SEVEN_PARAMETER);
+        double[] values = {
+            446.448, -125.157, 542.06, 0.1502, 0.247, 0.8421, -20.4894
+        };
+
+        String wkt2 = CRSSerializer.toWkt2(original);
+        assertTrue(wkt2.startsWith("BOUNDCRS[SOURCECRS[PROJCRS["), wkt2);
+        assertTrue(
+            wkt2.contains("PARAMETER[\"Scale difference\",0.9999795106,"),
+            wkt2);
+        Map<String, Object> parsedWkt = WktParser.parseWkt2ToProjJson(wkt2);
+        assertBoundCrs(
+            parsedWkt,
+            "ProjectedCRS", 9606,
+            "Position Vector transformation (geog2D domain)", values);
+        assertEquals(
+            "Transverse Mercator",
+            map(map(map(parsedWkt, "source_crs"), "conversion"), "method").get("name"));
+
+        Map<String, Object> projJson =
+            CRSSerializer.toProjJsonMap(original.getParams());
+        assertBoundCrs(
+            projJson,
+            "ProjectedCRS", 9606,
+            "Position Vector transformation (geog2D domain)", values);
+        assertSevenParameterUnits(projJson);
+
+        assertRoundTripCoordinates(
+            original, wkt2, new Point(651409.903, 313177.270));
+        assertRoundTripCoordinates(
+            original, CRSSerializer.toProjJson(original, false),
+            new Point(651409.903, 313177.270));
+    }
+
+    @Test
+    void sevenValueZeroTailStillUsesPositionVectorMethod() {
+        Proj original = new Proj(
+            "+proj=longlat +ellps=bessel +towgs84=1,2,3,0,0,0,0 +no_defs");
+        double[] values = {1, 2, 3, 0, 0, 0, 0};
+
+        String wkt2 = CRSSerializer.toWkt2(original);
+        assertTrue(wkt2.contains("PARAMETER[\"Scale difference\",1,"), wkt2);
+        assertBoundCrs(
+            WktParser.parseWkt2ToProjJson(wkt2),
+            "GeographicCRS", 9606,
+            "Position Vector transformation (geog2D domain)", values);
+        assertBoundCrs(
+            CRSSerializer.toProjJsonMap(original.getParams()),
+            "GeographicCRS", 9606,
+            "Position Vector transformation (geog2D domain)", values);
+    }
+
+    @Test
+    void zeroTowgs84OnWgs84RemainsAnUnboundCrs() {
+        Proj equivalent = new Proj(
+            "+proj=longlat +ellps=WGS84 +towgs84=0,0,0 +no_defs");
+        assertTrue(CRSSerializer.toWkt2(equivalent).startsWith("GEOGCRS["));
+        assertEquals(
+            "GeographicCRS",
+            CRSSerializer.toProjJsonMap(equivalent.getParams()).get("type"));
+    }
+
+    @Test
+    void zeroTowgs84OnAnotherEllipsoidStillUsesBoundCrs() {
+        Proj threeParameters = new Proj(
+            "+proj=longlat +ellps=bessel +towgs84=0,0,0 +no_defs");
+        double[] threeValues = {0, 0, 0};
+        String threeWkt = CRSSerializer.toWkt2(threeParameters);
+        assertBoundCrs(
+            WktParser.parseWkt2ToProjJson(threeWkt),
+            "GeographicCRS", 9603,
+            "Geocentric translations (geog2D domain)", threeValues);
+        assertBoundCrs(
+            CRSSerializer.toProjJsonMap(threeParameters.getParams()),
+            "GeographicCRS", 9603,
+            "Geocentric translations (geog2D domain)", threeValues);
+        assertRoundTripCoordinates(
+            threeParameters, threeWkt, new Point(7.4, 46.9));
+        assertRoundTripCoordinates(
+            threeParameters, CRSSerializer.toProjJson(threeParameters, false),
+            new Point(7.4, 46.9));
+
+        Proj sevenParameters = new Proj(
+            "+proj=longlat +ellps=bessel +towgs84=0,0,0,0,0,0,0 +no_defs");
+        double[] sevenValues = {0, 0, 0, 0, 0, 0, 0};
+        String sevenWkt = CRSSerializer.toWkt2(sevenParameters);
+        assertBoundCrs(
+            WktParser.parseWkt2ToProjJson(sevenWkt),
+            "GeographicCRS", 9606,
+            "Position Vector transformation (geog2D domain)", sevenValues);
+        assertBoundCrs(
+            CRSSerializer.toProjJsonMap(sevenParameters.getParams()),
+            "GeographicCRS", 9606,
+            "Position Vector transformation (geog2D domain)", sevenValues);
+        assertRoundTripCoordinates(
+            sevenParameters, sevenWkt, new Point(7.4, 46.9));
+    }
+
+    @Test
+    void geocentricProjJsonUsesGeocentricTargetAndMethods() {
+        Proj threeParameters = new Proj(
+            "+proj=geocent +ellps=bessel +towgs84=674.374,15.056,405.346 "
+                + "+units=m +no_defs");
+        assertGeocentricBoundCrs(
+            CRSSerializer.toProjJsonMap(threeParameters.getParams()),
+            1031, "Geocentric translations (geocentric domain)",
+            new double[]{674.374, 15.056, 405.346});
+
+        Proj sevenParameters = new Proj(
+            "+proj=geocent +ellps=airy "
+                + "+towgs84=446.448,-125.157,542.06,0.1502,0.247,0.8421,-20.4894 "
+                + "+units=m +no_defs");
+        Map<String, Object> projJson =
+            CRSSerializer.toProjJsonMap(sevenParameters.getParams());
+        assertGeocentricBoundCrs(
+            projJson,
+            1033, "Position Vector transformation (geocentric domain)",
+            new double[]{446.448, -125.157, 542.06, 0.1502, 0.247, 0.8421, -20.4894});
+        assertSevenParameterUnits(projJson);
+        assertRoundTripCoordinates(
+            sevenParameters,
+            CRSSerializer.toProjJson(sevenParameters, false),
+            new Point(3980000, 100000, 4970000));
+
+        assertThrows(
+            UnsupportedOperationException.class,
+            () -> CRSSerializer.toWkt2(sevenParameters));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void unsupportedImportedBoundCrsOperationsAreRejected() {
+        Map<String, Object> arbitraryTarget =
+            CRSSerializer.toProjJsonMap(new Proj(THREE_PARAMETER).getParams());
+        map(map(arbitraryTarget, "target_crs"), "id").put("code", 4269);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(arbitraryTarget));
+
+        Map<String, Object> misleadingTargetName =
+            CRSSerializer.toProjJsonMap(new Proj(THREE_PARAMETER).getParams());
+        Map<String, Object> misleadingTarget =
+            map(misleadingTargetName, "target_crs");
+        misleadingTarget.remove("id");
+        map(misleadingTarget, "datum").put("name", "North American Datum 1983");
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(misleadingTargetName));
+
+        String wkt = CRSSerializer.toWkt2(new Proj(THREE_PARAMETER));
+        String arbitraryTargetWkt = wkt.replace(
+            "ID[\"EPSG\",4326]]],ABRIDGEDTRANSFORMATION",
+            "ID[\"EPSG\",4269]]],ABRIDGEDTRANSFORMATION");
+        assertNotEquals(wkt, arbitraryTargetWkt);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(arbitraryTargetWkt));
+
+        Map<String, Object> coordinateFrame =
+            CRSSerializer.toProjJsonMap(new Proj(SEVEN_PARAMETER).getParams());
+        Map<String, Object> frameMethod =
+            map(map(coordinateFrame, "transformation"), "method");
+        frameMethod.put(
+            "name", "Coordinate Frame rotation (geog2D domain)");
+        map(frameMethod, "id").put("code", 9607);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(coordinateFrame));
+
+        Map<String, Object> wrongArity =
+            CRSSerializer.toProjJsonMap(new Proj(THREE_PARAMETER).getParams());
+        Map<String, Object> wrongArityMethod =
+            map(map(wrongArity, "transformation"), "method");
+        wrongArityMethod.put(
+            "name", "Position Vector transformation (geog2D domain)");
+        map(wrongArityMethod, "id").put("code", 9606);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(wrongArity));
+
+        Proj geocentric = new Proj(
+            "+proj=geocent +ellps=bessel +towgs84=1,2,3 +units=m +no_defs");
+        Map<String, Object> wrongDomain =
+            CRSSerializer.toProjJsonMap(geocentric.getParams());
+        Map<String, Object> wrongDomainMethod =
+            map(map(wrongDomain, "transformation"), "method");
+        wrongDomainMethod.put(
+            "name", "Geocentric translations (geog2D domain)");
+        map(wrongDomainMethod, "id").put("code", 9603);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(wrongDomain));
+
+        Map<String, Object> wrongUnit =
+            CRSSerializer.toProjJsonMap(new Proj(THREE_PARAMETER).getParams());
+        List<Map<String, Object>> wrongUnitParameters =
+            (List<Map<String, Object>>) map(
+                wrongUnit, "transformation").get("parameters");
+        wrongUnitParameters.get(0).put(
+            "unit",
+            Map.of(
+                "type", "LinearUnit",
+                "name", "foot",
+                "conversion_factor", 0.3048));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(wrongUnit));
+
+        Map<String, Object> wrongOrder =
+            CRSSerializer.toProjJsonMap(new Proj(THREE_PARAMETER).getParams());
+        List<Map<String, Object>> wrongOrderParameters =
+            (List<Map<String, Object>>) map(
+                wrongOrder, "transformation").get("parameters");
+        Map<String, Object> first = wrongOrderParameters.get(0);
+        wrongOrderParameters.set(0, wrongOrderParameters.get(1));
+        wrongOrderParameters.set(1, first);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(wrongOrder));
+    }
+
+    @Test
+    void ntv2BoundCrsImportRemainsSupported() {
+        Map<String, Object> bound =
+            CRSSerializer.toProjJsonMap(new Proj(THREE_PARAMETER).getParams());
+        Map<String, Object> transformation = map(bound, "transformation");
+        transformation.put("method", Map.of("name", "NTv2"));
+        transformation.put(
+            "parameters",
+            List.of(Map.of("name", "Latitude and longitude difference file",
+                "value", "@example.gsb")));
+
+        assertEquals("@example.gsb", WktParser.parse(bound).getNadgrids());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void epsgOperationIdentifiersAreAuthoritativeOverLabels() {
+        Proj original = new Proj(THREE_PARAMETER);
+        Map<String, Object> bound =
+            CRSSerializer.toProjJsonMap(original.getParams());
+        Map<String, Object> transformation = map(bound, "transformation");
+        map(transformation, "method").put("name", "localized method label");
+        List<Map<String, Object>> parameters =
+            (List<Map<String, Object>>) transformation.get("parameters");
+        for (int i = 0; i < parameters.size(); i++) {
+            parameters.get(i).put("name", "localized parameter " + i);
+        }
+
+        assertArrayEquals(
+            original.getParams().datum.getDatumParams(),
+            WktParser.parse(bound).getDatumParams(),
+            0.0);
+    }
+
+    @Test
+    void epsgIdentifiersPreserveLocalizedWktScaleSemantics() {
+        Proj original = new Proj(SEVEN_PARAMETER);
+        String localized = CRSSerializer.toWkt2(original)
+            .replace(
+                "Position Vector transformation (geog2D domain)",
+                "localized method label");
+        for (int i = 0; i < 7; i++) {
+            localized = localized.replace(
+                TOWGS84_PARAMETER_NAMES[i],
+                "localized parameter " + i);
+        }
+
+        assertRoundTripCoordinates(
+            original, localized, new Point(651409.903, 313177.270));
+    }
+
+    @Test
+    void idlessWgs84EnsembleTargetIsAcceptedStructurally() {
+        Proj original = new Proj(THREE_PARAMETER);
+        Map<String, Object> bound =
+            CRSSerializer.toProjJsonMap(original.getParams());
+        Map<String, Object> target = map(bound, "target_crs");
+        target.remove("id");
+        Map<String, Object> ensemble = map(target, "datum");
+        target.remove("datum");
+        ensemble.put("name", "World Geodetic System 1984 ensemble");
+        target.put("datum_ensemble", ensemble);
+
+        assertArrayEquals(
+            original.getParams().datum.getDatumParams(),
+            WktParser.parse(bound).getDatumParams(),
+            0.0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertBoundCrs(
+            Map<String, Object> root, String sourceType, int methodCode,
+            String methodName, double[] expectedValues) {
+        assertEquals("BoundCRS", root.get("type"));
+        assertFalse(root.containsKey("id"), "the source authority must not label the wrapper");
+
+        Map<String, Object> source = map(root, "source_crs");
+        assertEquals(sourceType, source.get("type"));
+
+        Map<String, Object> target = map(root, "target_crs");
+        assertEquals("GeographicCRS", target.get("type"));
+        assertEquals(4326, idCode(target));
+        List<Map<String, Object>> axes =
+            (List<Map<String, Object>>) map(target, "coordinate_system").get("axis");
+        assertEquals("north", axes.get(0).get("direction"));
+        assertEquals("east", axes.get(1).get("direction"));
+
+        assertTransformation(root, methodCode, methodName, expectedValues);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertGeocentricBoundCrs(
+            Map<String, Object> root, int methodCode,
+            String methodName, double[] expectedValues) {
+        assertEquals("BoundCRS", root.get("type"));
+        assertEquals("GeodeticCRS", map(root, "source_crs").get("type"));
+
+        Map<String, Object> target = map(root, "target_crs");
+        assertEquals("GeodeticCRS", target.get("type"));
+        assertEquals(4978, idCode(target));
+        List<Map<String, Object>> axes =
+            (List<Map<String, Object>>) map(target, "coordinate_system").get("axis");
+        assertEquals(3, axes.size());
+        assertEquals("geocentricX", axes.get(0).get("direction"));
+        assertEquals("geocentricY", axes.get(1).get("direction"));
+        assertEquals("geocentricZ", axes.get(2).get("direction"));
+
+        assertTransformation(root, methodCode, methodName, expectedValues);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertTransformation(
+            Map<String, Object> root, int methodCode,
+            String methodName, double[] expectedValues) {
+        Map<String, Object> transformation = map(root, "transformation");
+        Map<String, Object> method = map(transformation, "method");
+        assertEquals(methodName, method.get("name"));
+        assertEquals(methodCode, idCode(method));
+
+        List<Map<String, Object>> parameters =
+            (List<Map<String, Object>>) transformation.get("parameters");
+        assertEquals(expectedValues.length, parameters.size());
+        for (int i = 0; i < expectedValues.length; i++) {
+            assertEquals(8605 + i, idCode(parameters.get(i)));
+            assertEquals(expectedValues[i], number(parameters.get(i).get("value")), 1e-9);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertTranslationUnits(Map<String, Object> root) {
+        List<Map<String, Object>> parameters =
+            (List<Map<String, Object>>) map(root, "transformation").get("parameters");
+        for (Map<String, Object> parameter : parameters) {
+            assertEquals("metre", parameter.get("unit"));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertSevenParameterUnits(Map<String, Object> root) {
+        List<Map<String, Object>> parameters =
+            (List<Map<String, Object>>) map(root, "transformation").get("parameters");
+        for (int i = 0; i < 3; i++) {
+            assertEquals("metre", parameters.get(i).get("unit"));
+        }
+        for (int i = 3; i < 6; i++) {
+            Map<String, Object> unit = map(parameters.get(i), "unit");
+            assertEquals("AngularUnit", unit.get("type"));
+            assertEquals("arc-second", unit.get("name"));
+            assertEquals(Values.SEC_TO_RAD, number(unit.get("conversion_factor")), 0.0);
+        }
+        Map<String, Object> scaleUnit = map(parameters.get(6), "unit");
+        assertEquals("ScaleUnit", scaleUnit.get("type"));
+        assertEquals("parts per million", scaleUnit.get("name"));
+        assertEquals(1e-6, number(scaleUnit.get("conversion_factor")), 0.0);
+    }
+
+    private static void assertRoundTripCoordinates(
+            Proj original, String serialized, Point sourcePoint) {
+        Proj reimported = new Proj(serialized);
+        assertEquals(
+            original.getProjection().getClass(),
+            reimported.getProjection().getClass(),
+            serialized);
+        assertArrayEquals(
+            original.getParams().datum.getDatumParams(),
+            reimported.getParams().datum.getDatumParams(),
+            1e-12,
+            serialized);
+
+        Proj wgs84 = new Proj(WGS84);
+        Point expected = new Converter(original, wgs84).forward(
+            new Point(sourcePoint.x, sourcePoint.y, sourcePoint.z));
+        Point actual = new Converter(reimported, wgs84).forward(
+            new Point(sourcePoint.x, sourcePoint.y, sourcePoint.z));
+        assertEquals(expected.x, actual.x, 1e-10, serialized);
+        assertEquals(expected.y, actual.y, 1e-10, serialized);
+        assertEquals(expected.z, actual.z, 1e-8, serialized);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> map(Map<String, Object> parent, String key) {
+        return map(parent.get(key));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> map(Object value) {
+        assertInstanceOf(Map.class, value);
+        return (Map<String, Object>) value;
+    }
+
+    private static int idCode(Map<String, Object> object) {
+        return (int) number(map(object, "id").get("code"));
+    }
+
+    private static double number(Object value) {
+        assertInstanceOf(Number.class, value);
+        return ((Number) value).doubleValue();
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
@@ -7,6 +7,8 @@ import org.datasyslab.proj4sedona.transform.Converter;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /** Regression coverage for serializer fields whose omission changes coordinates. */
@@ -154,8 +156,15 @@ class CRSSerializerRoundTripSafetyTest {
         assertTrue(wkt1.contains("TOWGS84[674.374,15.056,405.346]"), wkt1);
         assertEquals(helmert.getParams().datum.getDatumParams()[0],
             new Proj(wkt1).getParams().datum.getDatumParams()[0], 0.0);
-        assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toWkt2(helmert));
-        assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toProjJson(helmert));
+        for (String bound : new String[]{
+                CRSSerializer.toWkt2(helmert),
+                CRSSerializer.toProjJson(helmert)}) {
+            assertEquals(
+                helmert.getParams().datum.getDatumParams()[0],
+                new Proj(bound).getParams().datum.getDatumParams()[0],
+                0.0,
+                bound);
+        }
 
         Proj grid = new Proj("+proj=longlat +datum=NAD27 +no_defs");
         assertTrue(CRSSerializer.toProjString(grid).contains("+datum=NAD27"));
@@ -250,10 +259,14 @@ class CRSSerializerRoundTripSafetyTest {
             if (!candidate.getParams().datum.isGridShift()
                     && !Boolean.TRUE.equals(candidate.getParams().over)
                     && candidate.getParams().longWrap == null) {
-                try {
-                    assertFalse(CRSSerializer.toProjJson(candidate).contains("\"id\""));
-                } catch (UnsupportedOperationException expectedForDatumOperation) {
-                    // Non-WKT1 datum operations are intentionally non-exportable.
+                Map<String, Object> json =
+                    CRSSerializer.toProjJsonMap(candidate.getParams());
+                assertFalse(json.containsKey("id"));
+                if ("BoundCRS".equals(json.get("type"))) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> source =
+                        (Map<String, Object>) json.get("source_crs");
+                    assertFalse(source.containsKey("id"));
                 }
             }
         }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -8,6 +8,8 @@ import org.datasyslab.proj4sedona.core.Point;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -1085,8 +1087,8 @@ class CRSSerializerTest {
     @DisplayName("Issue #46: WKT2 round-trip should not drift lat_0 for EPSG:28992 (sterea)")
     void testWkt2RoundTripNoDriftSterea28992() {
         // Projection parameters of EPSG:28992 (Amersfoort / RD New), without its
-        // Helmert operation: this test targets angle drift, while WKT2 export now
-        // correctly rejects CRS definitions whose TOWGS84 operation would be lost.
+        // Helmert operation: this test isolates angle drift; BoundCRS operation
+        // round trips are covered separately.
         Proj proj = new Proj("+proj=sterea +lat_0=52.15616055555555 "
             + "+lon_0=5.38763888888889 +k=0.9999079 +x_0=155000 +y_0=463000 "
             + "+ellps=bessel +units=m +no_defs");
@@ -1476,7 +1478,12 @@ class CRSSerializerTest {
         // export carried the 4326 id for a non-WGS84 ellipsoid.
         Proj q = new Proj("+proj=longlat +datum=WGS84 +a=6378137 +b=6300000 +rf=298.257223563 +no_defs");
         assertNull(CRSSerializer.toAuthority(q.getParams()), "conflicting b must not identify");
-        assertFalse(CRSSerializer.toProjJson(q).contains("4326"), "no EPSG:4326 id");
+        Map<String, Object> json = CRSSerializer.toProjJsonMap(q.getParams());
+        assertFalse(json.containsKey("id"), "the BoundCRS wrapper must not carry a source id");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> source = (Map<String, Object>) json.get("source_crs");
+        assertNotNull(source);
+        assertFalse(source.containsKey("id"), "the source CRS must not carry EPSG:4326");
 
         // Genuine WGS84 still identifies, and the rf discrimination still separates
         // GRS 1980 (b only 0.1 mm away) from WGS 84.

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -311,6 +311,42 @@ class WktParserTest {
         assertEquals(446.448, def.getDatumParams()[0], 0.001);
     }
 
+    @Test
+    @DisplayName("Parse WKT2 BOUNDCRS with geocentric GEODCRS source and target")
+    @SuppressWarnings("unchecked")
+    void testParseWkt2BoundCrsWithGeodcrsNodes() {
+        String source = "GEODCRS[\"Bessel geocentric\","
+            + "DATUM[\"Unknown based on Bessel 1841\","
+            + "ELLIPSOID[\"Bessel 1841\",6377397.155,299.1528128,"
+            + "LENGTHUNIT[\"metre\",1]]],"
+            + "PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + GEODCRS_4978_CS + "]";
+        String target =
+            GEODCRS_4978_HEAD + GEODCRS_4978_CS + ",ID[\"EPSG\",4978]]";
+        String wkt = "BOUNDCRS["
+            + "SOURCECRS[" + source + "],"
+            + "TARGETCRS[" + target + "],"
+            + "ABRIDGEDTRANSFORMATION[\"Transformation to WGS 84\","
+            + "METHOD[\"Geocentric translations (geocentric domain)\","
+            + "ID[\"EPSG\",1031]],"
+            + "PARAMETER[\"X-axis translation\",1,ID[\"EPSG\",8605]],"
+            + "PARAMETER[\"Y-axis translation\",2,ID[\"EPSG\",8606]],"
+            + "PARAMETER[\"Z-axis translation\",3,ID[\"EPSG\",8607]]]]";
+
+        Map<String, Object> projjson = WktParser.parseWkt2ToProjJson(wkt);
+        assertEquals(
+            "GeodeticCRS",
+            ((Map<String, Object>) projjson.get("source_crs")).get("type"));
+        assertEquals(
+            "GeodeticCRS",
+            ((Map<String, Object>) projjson.get("target_crs")).get("type"));
+
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals("geocent", def.getProjName());
+        assertArrayEquals(new double[]{1, 2, 3}, def.getDatumParams(), 0.0);
+        assertEquals(6377397.155, def.getA(), 1e-6);
+    }
+
     // ========== PROJJSON Parsing Tests ==========
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -297,7 +297,7 @@ class WktParserTest {
                 "DATUM[\"World Geodetic System 1984\"," +
                 "ELLIPSOID[\"WGS 84\",6378137,298.257223563]]]]," +
                 "ABRIDGEDTRANSFORMATION[\"OSGB 1936 to WGS 84 (6)\"," +
-                "METHOD[\"Position Vector transformation (geog2D domain)\"]," +
+                "METHOD[\"Geocentric translations (geog2D domain)\"]," +
                 "PARAMETER[\"X-axis translation\",446.448,LENGTHUNIT[\"metre\",1]]," +
                 "PARAMETER[\"Y-axis translation\",-125.157,LENGTHUNIT[\"metre\",1]]," +
                 "PARAMETER[\"Z-axis translation\",542.06,LENGTHUNIT[\"metre\",1]]]]";

--- a/src/test/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercatorTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/SwissObliqueMercatorTest.java
@@ -94,15 +94,16 @@ class SwissObliqueMercatorTest {
     void testSerializationRoundTrip() {
         // Regression guard for the round-trip bug: proj4sedona's serializer emits the
         // method name "Swiss Oblique Mercator", which must re-import (previously failed
-        // with "Unknown projection: Swiss Oblique Mercator"). Compare the projection
-        // math of the lossless PROJ and WKT1 forms against the original. WKT2 and
-        // PROJJSON have no implemented bound-CRS operation, so silently exporting
-        // them would discard the Swiss TOWGS84 transformation.
+        // with "Unknown projection: Swiss Oblique Mercator"). Compare every executable
+        // export against the original; WKT2 and PROJJSON preserve the Swiss TOWGS84
+        // transformation in a BoundCRS.
         Proj original = new Proj(LV03);
         double[][] coords = {{7.439583333, 46.952405556}, {8.55, 47.37}, {6.14, 46.2}};
         for (String serialized : new String[] {
                 CRSSerializer.toProjString(original),
-                CRSSerializer.toWkt1(original)}) {
+                CRSSerializer.toWkt1(original),
+                CRSSerializer.toWkt2(original),
+                CRSSerializer.toProjJson(original)}) {
             Proj reimported = new Proj(serialized); // must not throw
             for (double[] c : coords) {
                 Point want = original.forward(new Point(c[0] * Math.PI / 180, c[1] * Math.PI / 180));
@@ -111,10 +112,6 @@ class SwissObliqueMercatorTest {
                 assertEquals(want.y, got.y, XY_EPSLN, "northing after re-import of " + serialized);
             }
         }
-        assertThrows(UnsupportedOperationException.class,
-            () -> CRSSerializer.toWkt2(original));
-        assertThrows(UnsupportedOperationException.class,
-            () -> CRSSerializer.toProjJson(original));
     }
 
     private void assertForward(String def, double[][] cases) {


### PR DESCRIPTION
## Summary

- Export three- and seven-parameter `+towgs84` operations as WKT2 and PROJJSON `BoundCRS` objects instead of rejecting them.
- Use EPSG:4326 with methods 9603/9606 for geographic and projected sources, and EPSG:4978 with methods 1031/1033 for geocentric PROJJSON.
- Preserve zero-valued operations when a non-WGS84 ellipsoid still makes the datum conversion coordinate-affecting.
- Validate imported Helmert `BoundCRS` definitions before flattening them into the legacy datum model.

## Root cause

The internal datum model stores PROJ's legacy three- or seven-parameter transformation to WGS 84, but the standard exporters previously had no operation wrapper. WKT2 and PROJJSON therefore rejected every non-zero `TOWGS84` definition to avoid silently dropping its coordinate operation.

The existing `BoundCRS` importer also discarded the target CRS and method provenance. Once export becomes possible, accepting an arbitrary target or coordinate-frame method would allow a later export to silently rewrite it as a WGS 84 position-vector operation.

## Implementation

- Wrap supported geographic/projected WKT2 and PROJJSON source CRSs in a WGS 84 `BoundCRS`.
- Emit canonical EPSG method, parameter, target, and unit metadata.
- Convert WKT2 abridged scale factors and PROJJSON ppm values without changing the stored transformation.
- Keep geocentric WKT2 export unsupported, while supporting geocentric PROJJSON export with the correct domain-specific target and methods.
- Accept standard `GEODCRS` nodes when importing WKT2 `BoundCRS` definitions.
- Reject unsupported Helmert targets, domains, coordinate-frame conventions, arities, parameter orderings, units, and non-finite values before import.
- Keep existing NTv2 import behavior; grid-shift export remains unsupported.

## Impact

WKT2 and PROJJSON now round-trip executable datum operations for Apache Sedona's affected EPSG:27700, EPSG:28992, EPSG:3111, and EPSG:3577 cases. Generated definitions preserve projection class, datum parameters, and transformed coordinates.

## Validation

- `mvn test` — 1,109 tests passed.
- Focused WKT/BoundCRS parser coverage — 60 tests passed.
- Installed PROJ accepted generated geographic and projected WKT2/PROJJSON artifacts. Geocentric export is deliberately PROJJSON-only: `toWkt1()` and `toWkt2()` reject it, while installed PROJ accepted the generated geocentric PROJJSON artifact.
- proj4sedona parsed and re-exported PROJ-generated geographic three-parameter, projected seven-parameter, and zero-valued Bessel `BoundCRS` definitions. Import also accepts PROJ's WKT2 geocentric `GEODCRS` spelling, as pinned by `WktParserTest`.
- Relative to proj4sedona main before this PR, all eight TOWGS84 WKT2/PROJJSON errors are repaired. Apache Sedona currently pins proj4sedona 0.1.2 and passes all 81 `CrsRoundTripComplianceTest` cases, so adopting current main plus this PR changes the class from zero to eight errors. All eight are the separate polar-axis WKT2/PROJJSON cases for EPSG:3031, EPSG:32661, EPSG:3413, and EPSG:6931; they originate in the rejecting serializer policy introduced by #117 (`ec4d6ef`), not this PR. #119 repaired the corresponding legacy PROJ outputs, while WKT2/PROJJSON still requires dual-axis polar metadata.

## Remaining scope

This change does not implement dual-axis polar metadata, arbitrary-target bound operations, coordinate-frame rotation conversion, grid-shift export, or geocentric WKT2 export.
