### PR TITLE
Preserve meridian-qualified polar axis metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,9 @@ mvn verify -Pbenchmarks
 This generates `target/benchmark_report.md` containing:
 1. **Speedup vs pyproj**: Performance comparison table
 2. **Correctness vs pyproj**: Error statistics (max/avg error per category)
-3. **Parity coverage**: Every generated transform, grid, parser, and serializer case
-   is reported as compared, explicitly skipped with a reason, or failed
+3. **Parity coverage**: Every generated transform, grid, parser, serializer, and
+   exhaustive active-EPSG meridian-axis case is reported as compared, explicitly
+   skipped with a reason, or failed
 
 The correctness pass is a build gate, not a best-effort benchmark. Missing or duplicate
 reference rows, non-finite results, parse/serialization errors, stale skip or tolerance

--- a/docs/crs-formats.md
+++ b/docs/crs-formats.md
@@ -237,12 +237,19 @@ preserves PROJ-specific operation parameters that WKT1, WKT2, and PROJJSON canno
 encode, but legacy PROJ CRS strings cannot preserve all standard CRS metadata.
 For example, WKT2 and PROJJSON can distinguish two polar horizontal axes using
 meridian metadata, while `+axis` cannot represent two axes that both point north
-or south. When a non-PROJ definition at a polar origin parses to `nnu` or `ssu`,
-`toProjString()` therefore omits `+axis`. The same duplicate permutations supplied
-in raw PROJ input, and all other invalid axis permutations, are rejected with
+or south. Proj4Sedona retains each such axis's name, abbreviation, direction,
+order, linear unit, and meridian when parsing WKT2 or PROJJSON, and reproduces
+that metadata in either standard format. `toProjString()` omits `+axis` only after
+the retained pair has been validated against the polar origin; WKT1 rejects the
+same input because it has no equivalent representation. Duplicate permutations
+supplied in raw PROJ input, incomplete or inconsistent meridian metadata, and all
+other invalid axis permutations are rejected with
 `UnsupportedOperationException`.
-Callers that need exact axis metadata or authority identifiers should retain the
-original WKT2 or PROJJSON definition.
+
+The retained meridians are CRS serialization metadata. Coordinate transforms keep
+proj4js-compatible axis behavior and do not interpret meridians; callers should
+leave axis enforcement disabled for `nnu` and `ssu`. Ordinary valid PROJ axis
+permutations such as `enu` and `neu` are unchanged.
 
 When a standard export would silently change coordinates, Proj4Sedona throws
 `UnsupportedOperationException` and, where the definition is representable in a

--- a/scripts/pyproj-reference/generate_all.py
+++ b/scripts/pyproj-reference/generate_all.py
@@ -7,6 +7,7 @@ This script orchestrates the generation of all reference data files:
 - parsing_reference.json: CRS parsing test cases
 - format_export_reference.json: CRS export format test cases
 - grid_transform_reference.json: Grid-based transformation test cases
+- meridian_axis_reference.json: Exhaustive projected CRS meridian-axis cases
 
 Usage:
     python generate_all.py --output-dir /path/to/output
@@ -22,6 +23,7 @@ from generate_transform_reference import generate_transform_reference
 from generate_parsing_reference import generate_parsing_reference
 from generate_format_reference import generate_format_reference
 from generate_grid_reference import generate_grid_reference
+from generate_meridian_axis_reference import generate_meridian_axis_reference
 
 
 def main():
@@ -59,6 +61,7 @@ def main():
         ("parsing_reference.json", generate_parsing_reference),
         ("format_export_reference.json", generate_format_reference),
         ("grid_transform_reference.json", generate_grid_reference),
+        ("meridian_axis_reference.json", generate_meridian_axis_reference),
     ]
     
     for filename, generator_func in generators:

--- a/scripts/pyproj-reference/generate_meridian_axis_reference.py
+++ b/scripts/pyproj-reference/generate_meridian_axis_reference.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+Generate exhaustive projected-CRS meridian-axis reference data using pyproj.
+
+The generator discovers every active EPSG projected CRS whose PROJJSON
+coordinate system contains a meridian-qualified axis. Each row embeds the full
+PROJJSON definition so the Java benchmark remains independent of online CRS
+providers after generation.
+"""
+
+import argparse
+import json
+import math
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pyproj
+from pyproj import CRS, database, network
+from pyproj.enums import PJType
+from pyproj.exceptions import CRSError
+
+
+SCHEMA_VERSION = "1.0"
+EXPECTED_FORMATS = ["wkt2", "projjson", "proj_string"]
+BASELINE_CODES = [
+    "2985", "2986", "3031", "3032", "3275", "3276", "3277", "3278",
+    "3279", "3280", "3281", "3282", "3283", "3284", "3285", "3286",
+    "3287", "3288", "3289", "3290", "3291", "3292", "3293", "3408",
+    "3409", "3411", "3412", "3413", "3571", "3572", "3573", "3574",
+    "3575", "3576", "3976", "3995", "3996", "5041", "5042", "5482",
+    "5936", "5937", "5938", "5939", "5940", "6931", "6932", "9354",
+    "27702", "32661", "32761",
+]
+
+
+def _canonical_unit_type(unit_type: Optional[str], default_type: str) -> str:
+    if not unit_type:
+        return default_type
+    canonical = {
+        "linearunit": "LinearUnit",
+        "angularunit": "AngularUnit",
+        "scaleunit": "ScaleUnit",
+        "timeunit": "TimeUnit",
+        "parametricunit": "ParametricUnit",
+        "unit": default_type,
+    }
+    return canonical.get(str(unit_type).lower(), str(unit_type))
+
+
+def _known_unit_factor(name: str) -> Optional[float]:
+    factors = {
+        "metre": 1.0,
+        "meter": 1.0,
+        "degree": math.pi / 180.0,
+        "radian": 1.0,
+        "grad": math.pi / 200.0,
+        "gon": math.pi / 200.0,
+        "arc-second": math.pi / 648000.0,
+    }
+    return factors.get(name.lower())
+
+
+def _normalize_unit(
+        value: Any,
+        default_type: str,
+        fallback_name: Optional[str] = None,
+        fallback_factor: Optional[float] = None) -> Dict[str, Any]:
+    unit_type = None
+    name = None
+    factor = None
+    if isinstance(value, dict):
+        unit_type = value.get("type")
+        name = value.get("name")
+        factor = value.get("conversion_factor")
+    elif value is not None:
+        name = str(value)
+
+    if name is None:
+        name = fallback_name
+    if name is None:
+        raise ValueError("axis unit has no name")
+    if factor is None:
+        factor = fallback_factor
+    if factor is None:
+        factor = _known_unit_factor(str(name))
+    if factor is None or not math.isfinite(float(factor)) or float(factor) <= 0:
+        raise ValueError("axis unit has no positive finite conversion factor: "
+                         + str(value))
+    return {
+        "type": _canonical_unit_type(unit_type, default_type),
+        "name": str(name),
+        "conversion_factor": float(factor),
+    }
+
+
+def _normalize_meridian(value: Any) -> Optional[Dict[str, Any]]:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("axis meridian must be an object")
+
+    longitude = value.get("longitude")
+    unit_value = value.get("unit")
+    if isinstance(longitude, dict):
+        if "unit" in longitude:
+            unit_value = longitude["unit"]
+        longitude = longitude.get("value")
+    if longitude is None or not math.isfinite(float(longitude)):
+        raise ValueError("axis meridian has no finite longitude")
+
+    unit = _normalize_unit(
+        unit_value,
+        "AngularUnit",
+        fallback_name="degree",
+        fallback_factor=math.pi / 180.0,
+    )
+    return {
+        "longitude": float(longitude),
+        "unit": unit,
+    }
+
+
+def _axis_signature(crs: CRS) -> List[Dict[str, Any]]:
+    projjson = crs.to_json_dict()
+    coordinate_system = projjson.get("coordinate_system")
+    if not isinstance(coordinate_system, dict):
+        raise ValueError("CRS has no PROJJSON coordinate_system object")
+    axes = coordinate_system.get("axis")
+    if not isinstance(axes, list) or not axes:
+        raise ValueError("CRS has no PROJJSON coordinate axes")
+
+    subtype = str(coordinate_system.get("subtype", "")).lower()
+    default_unit_type = (
+        "AngularUnit" if subtype in ("ellipsoidal", "spherical")
+        else "LinearUnit"
+    )
+    shared_unit = coordinate_system.get("unit")
+    axis_info = list(crs.axis_info)
+    normalized = []
+    for index, axis in enumerate(axes):
+        if not isinstance(axis, dict):
+            raise ValueError("coordinate axis must be an object")
+        if axis.get("name") is None or axis.get("direction") is None:
+            raise ValueError("coordinate axis lacks name or direction")
+
+        fallback_name = None
+        fallback_factor = None
+        if index < len(axis_info):
+            fallback_name = axis_info[index].unit_name
+            fallback_factor = axis_info[index].unit_conversion_factor
+        unit_value = axis.get("unit", shared_unit)
+        order = axis.get("order", index + 1)
+        try:
+            order = int(order)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("coordinate axis order is not an integer") from exc
+
+        normalized.append({
+            "name": str(axis["name"]),
+            "abbreviation": (
+                None if axis.get("abbreviation") is None
+                else str(axis["abbreviation"])
+            ),
+            "direction": str(axis["direction"]),
+            "order": order,
+            "unit": _normalize_unit(
+                unit_value,
+                default_unit_type,
+                fallback_name=fallback_name,
+                fallback_factor=fallback_factor,
+            ),
+            "meridian": _normalize_meridian(axis.get("meridian")),
+        })
+    return normalized
+
+
+def _has_meridian_axis(projjson: Dict[str, Any]) -> bool:
+    coordinate_system = projjson.get("coordinate_system")
+    if not isinstance(coordinate_system, dict):
+        return False
+    axes = coordinate_system.get("axis")
+    return isinstance(axes, list) and any(
+        isinstance(axis, dict) and axis.get("meridian") is not None
+        for axis in axes
+    )
+
+
+def _proj_string(crs: CRS) -> Optional[str]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        try:
+            value = crs.to_proj4()
+        except CRSError:
+            return None
+    if not value or not value.strip():
+        return None
+    return value
+
+
+def _discover_cases(verbose: bool) -> List[Dict[str, Any]]:
+    infos = database.query_crs_info(
+        auth_name="EPSG",
+        pj_types=PJType.PROJECTED_CRS,
+        allow_deprecated=False,
+    )
+    cases = []
+    for info in sorted(infos, key=lambda item: int(item.code)):
+        crs = CRS.from_authority(info.auth_name, info.code)
+        source_projjson = crs.to_json_dict()
+        if not _has_meridian_axis(source_projjson):
+            continue
+
+        expected_axes = _axis_signature(crs)
+        if not any(axis["meridian"] is not None for axis in expected_axes):
+            raise ValueError(
+                "EPSG:{} was selected without a normalized meridian".format(info.code)
+            )
+
+        wkt_roundtrip = CRS.from_wkt(crs.to_wkt(version="WKT2_2019"))
+        if _axis_signature(wkt_roundtrip) != expected_axes:
+            raise ValueError(
+                "EPSG:{} changes axis metadata in pyproj WKT2 round trip".format(
+                    info.code
+                )
+            )
+        json_roundtrip = CRS.from_json_dict(source_projjson)
+        if _axis_signature(json_roundtrip) != expected_axes:
+            raise ValueError(
+                "EPSG:{} changes axis metadata in pyproj PROJJSON round trip".format(
+                    info.code
+                )
+            )
+
+        legacy_proj_string = _proj_string(crs)
+        if legacy_proj_string is not None and any(
+                token.startswith("+axis=")
+                for token in legacy_proj_string.split()):
+            raise ValueError(
+                "EPSG:{} unexpectedly exports a legacy +axis token".format(info.code)
+            )
+
+        case = {
+            "case_id": "epsg_{}".format(info.code),
+            "authority": str(info.auth_name),
+            "code": str(info.code),
+            "name": str(info.name),
+            "source_projjson": source_projjson,
+            "expected_axes": expected_axes,
+            "legacy_proj_string": legacy_proj_string,
+            "pyproj_legacy_proj_exported": legacy_proj_string is not None,
+            "legacy_proj_axis_omitted": True,
+        }
+        cases.append(case)
+        if verbose:
+            print("  EPSG:{} {}".format(info.code, info.name))
+
+    discovered_codes = [case["code"] for case in cases]
+    missing_baseline = sorted(
+        set(BASELINE_CODES) - set(discovered_codes), key=int
+    )
+    if missing_baseline:
+        raise ValueError(
+            "active meridian-axis discovery lost baseline EPSG codes: "
+            + ", ".join(missing_baseline)
+        )
+    return cases
+
+
+def generate_meridian_axis_reference(
+        output_file: str, verbose: bool = False) -> None:
+    """Generate the exhaustive meridian-axis parity fixture."""
+    network.set_network_enabled(False)
+    cases = _discover_cases(verbose)
+    reference_data = {
+        "version": SCHEMA_VERSION,
+        "generator": "pyproj",
+        "pyproj_version": pyproj.__version__,
+        "proj_version": pyproj.proj_version_str,
+        "epsg_version": database.get_database_metadata("EPSG.VERSION"),
+        "epsg_date": database.get_database_metadata("EPSG.DATE"),
+        "proj_data_version": database.get_database_metadata("PROJ_DATA.VERSION"),
+        "baseline_case_count": len(BASELINE_CODES),
+        "baseline_codes": BASELINE_CODES,
+        "expected_case_count": len(cases),
+        "expected_formats": EXPECTED_FORMATS,
+        "expected_comparison_count": len(cases) * len(EXPECTED_FORMATS),
+        "test_cases": cases,
+    }
+
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as output:
+        json.dump(reference_data, output, indent=2, ensure_ascii=False)
+        output.write("\n")
+
+    if verbose:
+        print(
+            "  Generated {} active EPSG cases and {} comparisons".format(
+                len(cases), reference_data["expected_comparison_count"]
+            )
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate active EPSG meridian-axis reference data"
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="meridian_axis_reference.json",
+        help="Output JSON file",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print every discovered CRS",
+    )
+    args = parser.parse_args()
+    generate_meridian_axis_reference(args.output, verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pyproj-reference/generate_meridian_axis_reference.py
+++ b/scripts/pyproj-reference/generate_meridian_axis_reference.py
@@ -217,7 +217,8 @@ def _discover_cases(verbose: bool) -> List[Dict[str, Any]]:
                 "EPSG:{} was selected without a normalized meridian".format(info.code)
             )
 
-        wkt_roundtrip = CRS.from_wkt(crs.to_wkt(version="WKT2_2019"))
+        source_wkt2 = crs.to_wkt(version="WKT2_2019")
+        wkt_roundtrip = CRS.from_wkt(source_wkt2)
         if _axis_signature(wkt_roundtrip) != expected_axes:
             raise ValueError(
                 "EPSG:{} changes axis metadata in pyproj WKT2 round trip".format(
@@ -245,6 +246,7 @@ def _discover_cases(verbose: bool) -> List[Dict[str, Any]]:
             "authority": str(info.auth_name),
             "code": str(info.code),
             "name": str(info.name),
+            "source_wkt2": source_wkt2,
             "source_projjson": source_projjson,
             "expected_axes": expected_axes,
             "legacy_proj_string": legacy_proj_string,
@@ -284,7 +286,10 @@ def generate_meridian_axis_reference(
         "baseline_codes": BASELINE_CODES,
         "expected_case_count": len(cases),
         "expected_formats": EXPECTED_FORMATS,
-        "expected_comparison_count": len(cases) * len(EXPECTED_FORMATS),
+        "expected_comparison_count": (
+            len(cases) * len(EXPECTED_FORMATS) * 2
+        ),
+        "expected_parser_comparison_count": len(cases) * 2,
         "test_cases": cases,
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/core/CoordinateAxis.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/CoordinateAxis.java
@@ -1,0 +1,194 @@
+package org.datasyslab.proj4sedona.core;
+
+import java.util.Objects;
+
+/**
+ * Coordinate-system axis metadata retained from WKT2 and PROJJSON definitions.
+ *
+ * <p>The compact PROJ {@code +axis=} value remains the representation used by
+ * coordinate transforms. This value object keeps the richer standard-format
+ * metadata needed to reproduce axis definitions that cannot be expressed by a
+ * PROJ axis permutation, such as polar axes qualified by meridians.</p>
+ */
+public final class CoordinateAxis {
+
+    private final String name;
+    private final String abbreviation;
+    private final String direction;
+    private final Integer order;
+    private final Unit unit;
+    private final Meridian meridian;
+
+    public CoordinateAxis(
+            String name,
+            String abbreviation,
+            String direction,
+            Integer order,
+            Unit unit,
+            Meridian meridian) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.abbreviation = abbreviation;
+        this.direction = Objects.requireNonNull(direction, "direction");
+        this.order = order;
+        this.unit = unit;
+        this.meridian = meridian;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAbbreviation() {
+        return abbreviation;
+    }
+
+    public String getDirection() {
+        return direction;
+    }
+
+    public Integer getOrder() {
+        return order;
+    }
+
+    public Unit getUnit() {
+        return unit;
+    }
+
+    public Meridian getMeridian() {
+        return meridian;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof CoordinateAxis)) {
+            return false;
+        }
+        CoordinateAxis that = (CoordinateAxis) other;
+        return Objects.equals(name, that.name)
+            && Objects.equals(abbreviation, that.abbreviation)
+            && Objects.equals(direction, that.direction)
+            && Objects.equals(order, that.order)
+            && Objects.equals(unit, that.unit)
+            && Objects.equals(meridian, that.meridian);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, abbreviation, direction, order, unit, meridian);
+    }
+
+    @Override
+    public String toString() {
+        return "CoordinateAxis{"
+            + "name='" + name + '\''
+            + ", abbreviation='" + abbreviation + '\''
+            + ", direction='" + direction + '\''
+            + ", order=" + order
+            + ", unit=" + unit
+            + ", meridian=" + meridian
+            + '}';
+    }
+
+    /** Unit metadata attached to an axis or axis meridian. */
+    public static final class Unit {
+
+        private final String type;
+        private final String name;
+        private final Double conversionFactor;
+
+        public Unit(String type, String name, Double conversionFactor) {
+            this.type = type;
+            this.name = Objects.requireNonNull(name, "name");
+            this.conversionFactor = conversionFactor;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Double getConversionFactor() {
+            return conversionFactor;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof Unit)) {
+                return false;
+            }
+            Unit that = (Unit) other;
+            return Objects.equals(type, that.type)
+                && Objects.equals(name, that.name)
+                && Objects.equals(conversionFactor, that.conversionFactor);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(type, name, conversionFactor);
+        }
+
+        @Override
+        public String toString() {
+            return "Unit{"
+                + "type='" + type + '\''
+                + ", name='" + name + '\''
+                + ", conversionFactor=" + conversionFactor
+                + '}';
+        }
+    }
+
+    /** Meridian qualifying a polar axis direction. */
+    public static final class Meridian {
+
+        private final double longitude;
+        private final Unit unit;
+
+        public Meridian(double longitude, Unit unit) {
+            this.longitude = longitude;
+            this.unit = unit;
+        }
+
+        public double getLongitude() {
+            return longitude;
+        }
+
+        public Unit getUnit() {
+            return unit;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (!(other instanceof Meridian)) {
+                return false;
+            }
+            Meridian that = (Meridian) other;
+            return Double.compare(longitude, that.longitude) == 0
+                && Objects.equals(unit, that.unit);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(longitude, unit);
+        }
+
+        @Override
+        public String toString() {
+            return "Meridian{"
+                + "longitude=" + longitude
+                + ", unit=" + unit
+                + '}';
+        }
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/Proj.java
@@ -328,6 +328,8 @@ public class Proj {
         p.units = def.getUnits();
         p.fromGreenwich = def.getFromGreenwich();
         p.axis = def.getAxis() != null ? def.getAxis() : "enu";
+        p.coordinateSystemType = def.getCoordinateSystemType();
+        p.coordinateAxes = def.getCoordinateAxes();
 
         // UTM
         p.zone = def.getZone();

--- a/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/ProjectionDef.java
@@ -1,5 +1,9 @@
 package org.datasyslab.proj4sedona.core;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Projection definition - holds all parsed parameters for a coordinate system.
  * Mirrors: ProjectionDefinition type in lib/defs.js
@@ -50,6 +54,8 @@ public class ProjectionDef {
     private String units;          // Unit name: m, ft, us-ft, etc.
     private Double fromGreenwich;  // Prime meridian offset in radians
     private String axis;           // Axis order: enu, neu, etc. (default "enu")
+    private String coordinateSystemType;
+    private List<CoordinateAxis> coordinateAxes = Collections.emptyList();
 
     // UTM specific
     private Integer zone;          // UTM zone number
@@ -181,6 +187,21 @@ public class ProjectionDef {
 
     public String getAxis() { return axis; }
     public void setAxis(String axis) { this.axis = axis; }
+
+    public String getCoordinateSystemType() { return coordinateSystemType; }
+    public void setCoordinateSystemType(String coordinateSystemType) {
+        this.coordinateSystemType = coordinateSystemType;
+    }
+
+    public List<CoordinateAxis> getCoordinateAxes() { return coordinateAxes; }
+    public void setCoordinateAxes(List<CoordinateAxis> coordinateAxes) {
+        if (coordinateAxes == null || coordinateAxes.isEmpty()) {
+            this.coordinateAxes = Collections.emptyList();
+        } else {
+            this.coordinateAxes =
+                Collections.unmodifiableList(new ArrayList<>(coordinateAxes));
+        }
+    }
 
     public Integer getZone() { return zone; }
     public void setZone(Integer zone) { this.zone = zone; }

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -7,6 +7,7 @@ import org.datasyslab.proj4sedona.constants.Datum;
 import org.datasyslab.proj4sedona.constants.Ellipsoid;
 import org.datasyslab.proj4sedona.constants.Units;
 import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.CoordinateAxis;
 import org.datasyslab.proj4sedona.core.DatumParams;
 import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.defs.Defs;
@@ -209,6 +210,13 @@ public final class CRSSerializer {
     public static String toProjString(ProjectionParams params) {
         if (params == null) {
             return null;
+        }
+        if (requiresMeridianAxisValidation(params)) {
+            String axisError =
+                meridianAxisValidationError(params, effectiveAxis(params));
+            if (axisError != null) {
+                throw new UnsupportedOperationException(axisError);
+            }
         }
 
         StringBuilder sb = new StringBuilder();
@@ -941,13 +949,16 @@ public final class CRSSerializer {
 
         // Coordinate System
         sb.append("CS[Cartesian,2],");
+        boolean meridianAxes = hasMeridianAxisMetadata(params);
         if ("krovak".equals(proj) && !isKrovakNorthOrientated(params)) {
             sb.append("AXIS[\"southing\",south,ORDER[1]],");
             sb.append("AXIS[\"westing\",west,ORDER[2]],");
         } else {
-            appendWkt2HorizontalAxes(sb, params, false, true);
+            appendWkt2HorizontalAxes(sb, params, false, !meridianAxes);
         }
-        appendWkt2Unit(sb, params);
+        if (!meridianAxes) {
+            appendWkt2Unit(sb, params);
+        }
     }
 
     private static void appendWkt2Datum(StringBuilder sb, ProjectionParams params) {
@@ -1107,6 +1118,11 @@ public final class CRSSerializer {
     private static void appendWkt2HorizontalAxes(
             StringBuilder sb, ProjectionParams params, boolean geographic,
             boolean trailingComma) {
+        if (!geographic && hasMeridianAxisMetadata(params)) {
+            appendWkt2MeridianAxes(sb, params.coordinateAxes, trailingComma);
+            return;
+        }
+
         String axis = effectiveAxis(params);
         for (int i = 0; i < 2; i++) {
             if (i > 0) {
@@ -1126,6 +1142,69 @@ public final class CRSSerializer {
         if (trailingComma) {
             sb.append(",");
         }
+    }
+
+    private static void appendWkt2MeridianAxes(
+            StringBuilder sb, List<CoordinateAxis> axes, boolean trailingComma) {
+        for (int i = 0; i < axes.size(); i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            CoordinateAxis axis = axes.get(i);
+            sb.append("AXIS[\"")
+              .append(escapeWktQuotedText(wkt2AxisLabel(axis)))
+              .append("\",")
+              .append(axis.getDirection().toLowerCase(Locale.ROOT));
+
+            CoordinateAxis.Meridian meridian = axis.getMeridian();
+            if (meridian != null) {
+                sb.append(",MERIDIAN[")
+                  .append(formatAngle(meridian.getLongitude()));
+                appendWkt2CoordinateAxisUnit(
+                    sb, meridian.getUnit(), true);
+                sb.append("]");
+            }
+
+            int order = axis.getOrder() != null ? axis.getOrder() : i + 1;
+            sb.append(",ORDER[").append(order).append("]");
+            appendWkt2CoordinateAxisUnit(sb, axis.getUnit(), false);
+            sb.append("]");
+        }
+        if (trailingComma) {
+            sb.append(",");
+        }
+    }
+
+    private static String wkt2AxisLabel(CoordinateAxis axis) {
+        String name = axis.getName() != null ? axis.getName().trim() : "";
+        String abbreviation = axis.getAbbreviation() != null
+            ? axis.getAbbreviation().trim() : "";
+        if (abbreviation.isEmpty()) {
+            return name;
+        }
+        if (name.isEmpty()) {
+            return "(" + abbreviation + ")";
+        }
+        return name + " (" + abbreviation + ")";
+    }
+
+    private static String escapeWktQuotedText(String value) {
+        return value.replace("\"", "\"\"");
+    }
+
+    private static void appendWkt2CoordinateAxisUnit(
+            StringBuilder sb, CoordinateAxis.Unit unit, boolean angular) {
+        String defaultName = angular ? "degree" : "metre";
+        String name = unit != null && unit.getName() != null
+            ? unit.getName() : defaultName;
+        Double factor = unit != null ? unit.getConversionFactor() : null;
+        sb.append(",")
+          .append(angular ? "ANGLEUNIT" : "LENGTHUNIT")
+          .append("[\"")
+          .append(escapeWktQuotedText(name))
+          .append("\",")
+          .append(factor)
+          .append("]");
     }
 
     private static void appendWkt2AngleParameter(
@@ -1435,6 +1514,10 @@ public final class CRSSerializer {
     private static Map<String, Object> buildProjJsonEllipsoid(ProjectionParams params) {
         Map<String, Object> ellipsoid = new LinkedHashMap<>();
         ellipsoid.put("name", getEllipsoidName(params));
+        if (params.a > 0.0 && params.a == params.b) {
+            ellipsoid.put("radius", params.a);
+            return ellipsoid;
+        }
         ellipsoid.put("semi_major_axis", params.a);
         // Emit the rf literal only when it is consistent with the effective
         // semi-minor axis; b is authoritative when both are present, so a stale
@@ -1622,6 +1705,15 @@ public final class CRSSerializer {
     private static Map<String, Object> buildProjJsonProjCS(ProjectionParams params) {
         Map<String, Object> cs = new LinkedHashMap<>();
         cs.put("subtype", "Cartesian");
+
+        if (hasMeridianAxisMetadata(params)) {
+            List<Map<String, Object>> axes = new ArrayList<>();
+            for (CoordinateAxis axis : params.coordinateAxes) {
+                axes.add(buildProjJsonCoordinateAxis(params, axis));
+            }
+            cs.put("axis", axes);
+            return cs;
+        }
         
         String unitName = linearUnitName(params);
         double unitToMeter = linearUnitToMeter(params);
@@ -1639,6 +1731,49 @@ public final class CRSSerializer {
             ));
         }
         return cs;
+    }
+
+    private static Map<String, Object> buildProjJsonCoordinateAxis(
+            ProjectionParams params, CoordinateAxis axis) {
+        MeridianAxisRole role = meridianAxisRole(params, axis);
+        Map<String, Object> result = new LinkedHashMap<>();
+        String name = axis.getName();
+        if (name == null || name.trim().isEmpty()) {
+            name = role == MeridianAxisRole.EASTING ? "Easting" : "Northing";
+        }
+        String abbreviation = axis.getAbbreviation();
+        if (abbreviation == null || abbreviation.trim().isEmpty()) {
+            abbreviation = role == MeridianAxisRole.EASTING ? "E" : "N";
+        }
+        result.put("name", name);
+        result.put("abbreviation", abbreviation);
+        result.put("direction", axis.getDirection().toLowerCase(Locale.ROOT));
+
+        CoordinateAxis.Meridian meridian = axis.getMeridian();
+        if (meridian != null) {
+            Map<String, Object> meridianJson = new LinkedHashMap<>();
+            Map<String, Object> longitude = new LinkedHashMap<>();
+            longitude.put("value", meridian.getLongitude());
+            longitude.put(
+                "unit",
+                buildProjJsonCoordinateAxisUnit(
+                    meridian.getUnit(), "AngularUnit"));
+            meridianJson.put("longitude", longitude);
+            result.put("meridian", meridianJson);
+        }
+        result.put(
+            "unit",
+            buildProjJsonCoordinateAxisUnit(axis.getUnit(), "LinearUnit"));
+        return result;
+    }
+
+    private static Map<String, Object> buildProjJsonCoordinateAxisUnit(
+            CoordinateAxis.Unit unit, String canonicalType) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("type", canonicalType);
+        result.put("name", unit.getName());
+        result.put("conversion_factor", unit.getConversionFactor());
+        return result;
     }
 
     private static Map<String, Object> createAxis(
@@ -1708,6 +1843,11 @@ public final class CRSSerializer {
      */
     public static String[] toAuthority(ProjectionParams params) {
         if (params == null) {
+            return null;
+        }
+        String axis = effectiveAxis(params);
+        if (requiresMeridianAxisValidation(params)
+                && meridianAxisValidationError(params, axis) != null) {
             return null;
         }
 
@@ -2226,7 +2366,7 @@ public final class CRSSerializer {
                 }
             }
 
-            if (!Objects.equals(effectiveAxis(params), effectiveAxis(refParams))
+            if (!axesMatchDefinition(params, refParams)
                     // WKT/PROJJSON describe UTM as parameterized Transverse
                     // Mercator, so zone/south are already represented by long0,
                     // y0, and the other numeric checks above.
@@ -2245,6 +2385,33 @@ public final class CRSSerializer {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    private static boolean axesMatchDefinition(
+            ProjectionParams params, ProjectionParams reference) {
+        String inputAxis = effectiveAxis(params);
+        String referenceAxis = effectiveAxis(reference);
+        if (Objects.equals(inputAxis, referenceAxis)) {
+            return true;
+        }
+        if (meridianAxisValidationError(params, inputAxis) != null
+                || referenceAxis.length() != 3 || referenceAxis.charAt(2) != 'u'
+                || params.coordinateAxes == null
+                || params.coordinateAxes.size() != 2) {
+            return false;
+        }
+        for (int i = 0; i < 2; i++) {
+            MeridianAxisRole role =
+                meridianAxisRole(params, params.coordinateAxes.get(i));
+            char referenceDirection = referenceAxis.charAt(i);
+            if ((role == MeridianAxisRole.EASTING && referenceDirection != 'e')
+                    || (role == MeridianAxisRole.NORTHING
+                        && referenceDirection != 'n')
+                    || role == MeridianAxisRole.UNKNOWN) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean isUtmTmercPair(String left, String right) {
@@ -2543,6 +2710,9 @@ public final class CRSSerializer {
      * when they conflict, and 0 for spheres, per WKT convention.
      */
     private static double effectiveRf(ProjectionParams params) {
+        if (params.a > 0.0 && params.a == params.b) {
+            return 0.0;
+        }
         if (params.b > 0 && !rfConsistentWithB(params)) {
             return params.a == params.b ? 0 : params.a / (params.a - params.b);
         }
@@ -3181,8 +3351,7 @@ public final class CRSSerializer {
      * @param proj pre-normalized projection short name (from normalizeProjName)
      */
     private static boolean isPolarStereographic(String proj, ProjectionParams params) {
-        return "stere".equals(proj) && params.lat0 != null
-                && Math.abs(Math.cos(params.lat0)) <= Values.EPSLN;
+        return "stere".equals(proj) && isPolarLatitude(params.lat0);
     }
 
     private static boolean hasNonGreenwichPrimeMeridian(ProjectionParams params) {
@@ -3202,12 +3371,43 @@ public final class CRSSerializer {
 
     private static boolean isMeridianQualifiedPolarAxis(
             ProjectionParams params, String axis) {
-        if (params.projStr != null
-                || (!"nnu".equals(axis) && !"ssu".equals(axis))
-                || params.lat0 == null) {
+        return meridianAxisValidationError(params, axis) == null;
+    }
+
+    private static boolean hasMeridianAxisMetadata(ProjectionParams params) {
+        if (params.coordinateAxes == null) {
             return false;
         }
-        return Math.abs(Math.cos(params.lat0)) <= Values.EPSLN;
+        for (CoordinateAxis axis : params.coordinateAxes) {
+            if (axis != null && axis.getMeridian() != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasRetainedPolarCoordinateSystem(
+            ProjectionParams params) {
+        return params.coordinateSystemType != null
+            && isPolarLatitude(params.lat0)
+            && !"longlat".equals(normalizeProjName(params.projName))
+            && !isGeocentric(params);
+    }
+
+    private static boolean isPolarLatitude(Double latitude) {
+        return latitude != null
+            && Double.isFinite(latitude)
+            && Math.abs(Math.abs(latitude) - Values.HALF_PI) <= Values.EPSLN;
+    }
+
+    private static boolean requiresMeridianAxisValidation(
+            ProjectionParams params) {
+        String axis = effectiveAxis(params);
+        return hasMeridianAxisMetadata(params)
+            || "nnu".equals(axis)
+            || "ssu".equals(axis)
+            || (hasRetainedPolarCoordinateSystem(params)
+                && parseAuthorityCode(params.srsCode) != null);
     }
 
     private static boolean isValidProjAxisPermutation(String axis) {
@@ -3235,6 +3435,16 @@ public final class CRSSerializer {
     private static void validateStandardAxis(
             ProjectionParams params, String proj, StandardFormat format) {
         String axis = effectiveAxis(params);
+        if (requiresMeridianAxisValidation(params)) {
+            String error = meridianAxisValidationError(params, axis);
+            if (format != StandardFormat.WKT1 && error == null) {
+                return;
+            }
+            if (error == null) {
+                error = "Meridian-qualified polar axes cannot be represented by WKT1";
+            }
+            throw unsupportedStandardParameter(error);
+        }
         if ("krovak".equals(proj)) {
             if ("enu".equals(axis) || "swu".equals(axis)) {
                 return;
@@ -3262,6 +3472,173 @@ public final class CRSSerializer {
                 "Axis " + axis + " cannot be represented by a two-dimensional "
                     + formatName(format) + " CRS");
         }
+    }
+
+    private static String meridianAxisValidationError(
+            ProjectionParams params, String axisOrder) {
+        if (!"nnu".equals(axisOrder) && !"ssu".equals(axisOrder)) {
+            return "Meridian-qualified axes require two matching north or south directions";
+        }
+        if (params.coordinateAxes == null || params.coordinateAxes.size() != 2) {
+            return "Axis " + axisOrder
+                + " requires two retained meridian-qualified horizontal axes";
+        }
+        if (params.coordinateSystemType == null
+                || !"Cartesian".equalsIgnoreCase(params.coordinateSystemType)) {
+            return "Meridian-qualified projected axes require a Cartesian coordinate system";
+        }
+        if (!isPolarLatitude(params.lat0)) {
+            return "Meridian-qualified horizontal axes require a polar latitude of origin";
+        }
+
+        boolean northPole = params.lat0 > 0.0;
+        String expectedDirection = northPole ? "south" : "north";
+        boolean anyOrder = false;
+        boolean allOrder = true;
+        MeridianAxisRole firstRole = null;
+        MeridianAxisRole secondRole = null;
+        double expectedLinearFactor = linearUnitToMeter(params);
+
+        for (int i = 0; i < params.coordinateAxes.size(); i++) {
+            CoordinateAxis coordinateAxis = params.coordinateAxes.get(i);
+            if (coordinateAxis == null || coordinateAxis.getDirection() == null
+                    || !expectedDirection.equalsIgnoreCase(
+                        coordinateAxis.getDirection())) {
+                return "Polar axis directions must both be " + expectedDirection
+                    + " at the " + (northPole ? "north" : "south") + " pole";
+            }
+
+            char parsedDirection = mapStandardAxisDirection(
+                coordinateAxis.getDirection());
+            if (parsedDirection != axisOrder.charAt(i)) {
+                return "Retained coordinate-axis order does not match axis "
+                    + axisOrder;
+            }
+
+            Integer order = coordinateAxis.getOrder();
+            anyOrder |= order != null;
+            allOrder &= order != null;
+            if (order != null && order != i + 1) {
+                return "WKT axis ORDER must match its position in the coordinate system";
+            }
+
+            CoordinateAxis.Unit linearUnit = coordinateAxis.getUnit();
+            String linearUnitError = validateCoordinateAxisUnit(
+                linearUnit, "LinearUnit", "horizontal axis");
+            if (linearUnitError != null) {
+                return linearUnitError;
+            }
+            double linearFactor = linearUnit.getConversionFactor();
+            if (!sameUnitFactor(linearFactor, expectedLinearFactor)) {
+                return "Horizontal-axis units must match the projected CRS unit";
+            }
+
+            CoordinateAxis.Meridian meridian = coordinateAxis.getMeridian();
+            if (meridian == null || !Double.isFinite(meridian.getLongitude())) {
+                return "Each duplicate polar axis requires a finite meridian";
+            }
+            String angularUnitError = validateCoordinateAxisUnit(
+                meridian.getUnit(), "AngularUnit", "axis meridian");
+            if (angularUnitError != null) {
+                return angularUnitError;
+            }
+
+            MeridianAxisRole role = meridianAxisRole(params, coordinateAxis);
+            if (role == MeridianAxisRole.UNKNOWN) {
+                return "Axis meridians must identify one easting and one northing axis";
+            }
+            if (i == 0) {
+                firstRole = role;
+            } else {
+                secondRole = role;
+            }
+
+        }
+
+        if (anyOrder != allOrder) {
+            return "WKT axis ORDER must be present on every axis or none";
+        }
+        if (firstRole == secondRole) {
+            return "Polar axes must identify one easting and one northing axis";
+        }
+        return null;
+    }
+
+    private static String validateCoordinateAxisUnit(
+            CoordinateAxis.Unit unit, String expectedType, String label) {
+        if (unit == null || unit.getConversionFactor() == null
+                || !Double.isFinite(unit.getConversionFactor())
+                || unit.getConversionFactor() <= 0.0) {
+            return "The " + label + " requires a positive finite unit factor";
+        }
+        if (unit.getType() != null
+                && !expectedType.equalsIgnoreCase(unit.getType())) {
+            return "The " + label + " must use a " + expectedType;
+        }
+        if (unit.getName() == null || unit.getName().trim().isEmpty()) {
+            return "The " + label + " requires a unit name";
+        }
+        return null;
+    }
+
+    private static boolean sameUnitFactor(double left, double right) {
+        return Math.abs(left - right)
+            <= 1e-12 * Math.max(Math.max(Math.abs(left), Math.abs(right)), 1.0);
+    }
+
+    private static boolean sameLongitude(double left, double right) {
+        return Math.abs(Math.IEEEremainder(left - right, 2.0 * Math.PI))
+            <= Values.EPSLN;
+    }
+
+    private static char mapStandardAxisDirection(String direction) {
+        if ("north".equalsIgnoreCase(direction)) {
+            return 'n';
+        }
+        if ("south".equalsIgnoreCase(direction)) {
+            return 's';
+        }
+        if ("east".equalsIgnoreCase(direction)) {
+            return 'e';
+        }
+        if ("west".equalsIgnoreCase(direction)) {
+            return 'w';
+        }
+        return '\0';
+    }
+
+    private static MeridianAxisRole meridianAxisRole(
+            ProjectionParams params, CoordinateAxis axis) {
+        if (axis == null || axis.getMeridian() == null
+                || axis.getMeridian().getUnit() == null
+                || axis.getMeridian().getUnit().getConversionFactor() == null
+                || !isPolarLatitude(params.lat0)) {
+            return MeridianAxisRole.UNKNOWN;
+        }
+        CoordinateAxis.Meridian meridian = axis.getMeridian();
+        double actual = meridian.getLongitude()
+            * meridian.getUnit().getConversionFactor();
+        if (!Double.isFinite(actual)) {
+            return MeridianAxisRole.UNKNOWN;
+        }
+        double central = params.long0 != null ? params.long0 : 0.0;
+        double easting = central + Values.HALF_PI;
+        double northing = central + (params.lat0 > 0.0 ? Math.PI : 0.0);
+        boolean matchesEasting = sameLongitude(actual, easting);
+        boolean matchesNorthing = sameLongitude(actual, northing);
+        if (matchesEasting && !matchesNorthing) {
+            return MeridianAxisRole.EASTING;
+        }
+        if (matchesNorthing && !matchesEasting) {
+            return MeridianAxisRole.NORTHING;
+        }
+        return MeridianAxisRole.UNKNOWN;
+    }
+
+    private enum MeridianAxisRole {
+        EASTING,
+        NORTHING,
+        UNKNOWN
     }
 
     private static boolean isEastWest(char direction) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -1846,7 +1846,7 @@ public final class CRSSerializer {
             return null;
         }
         String axis = effectiveAxis(params);
-        if (requiresMeridianAxisValidation(params)
+        if (requiresMeridianAxisAuthorityValidation(params)
                 && meridianAxisValidationError(params, axis) != null) {
             return null;
         }
@@ -3405,7 +3405,12 @@ public final class CRSSerializer {
         String axis = effectiveAxis(params);
         return hasMeridianAxisMetadata(params)
             || "nnu".equals(axis)
-            || "ssu".equals(axis)
+            || "ssu".equals(axis);
+    }
+
+    private static boolean requiresMeridianAxisAuthorityValidation(
+            ProjectionParams params) {
+        return requiresMeridianAxisValidation(params)
             || (hasRetainedPolarCoordinateSystem(params)
                 && parseAuthorityCode(params.srsCode) != null);
     }
@@ -3437,13 +3442,14 @@ public final class CRSSerializer {
         String axis = effectiveAxis(params);
         if (requiresMeridianAxisValidation(params)) {
             String error = meridianAxisValidationError(params, axis);
-            if (format != StandardFormat.WKT1 && error == null) {
+            if (error != null) {
+                throw new UnsupportedOperationException(error);
+            }
+            if (format != StandardFormat.WKT1) {
                 return;
             }
-            if (error == null) {
-                error = "Meridian-qualified polar axes cannot be represented by WKT1";
-            }
-            throw unsupportedStandardParameter(error);
+            throw unsupportedStandardParameter(
+                "Meridian-qualified polar axes cannot be represented by WKT1");
         }
         if ("krovak".equals(proj)) {
             if ("enu".equals(axis) || "swu".equals(axis)) {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -773,8 +773,8 @@ public final class ProjJsonBuilder {
         if (unitNode == null || unitNode.size() < 3) {
             return null;
         }
-        double factor = parseDouble(unitNode.get(2));
-        return factor > 0 ? factor : null;
+        Double factor = parseDouble(unitNode.get(2));
+        return factor != null && Double.isFinite(factor) && factor > 0 ? factor : null;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonBuilder.java
@@ -5,7 +5,10 @@ import org.datasyslab.proj4sedona.constants.Values;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Converts WKT2 AST (List structure) to PROJJSON-like Map structure.
@@ -18,6 +21,9 @@ import java.util.Map;
  * into ProjectionDef objects.
  */
 public final class ProjJsonBuilder {
+
+    private static final Pattern AXIS_NAME_WITH_ABBREVIATION =
+        Pattern.compile("^(.*?)\\s*\\(([^()]*)\\)$");
 
     private ProjJsonBuilder() {
         // Utility class
@@ -161,6 +167,8 @@ public final class ProjJsonBuilder {
                 coordSystem.put("unit", unit);
             }
         }
+
+        applySimplifiedConversionUnits(result);
 
         // Find ID
         Map<String, Object> id = getId(node);
@@ -428,6 +436,76 @@ public final class ProjJsonBuilder {
         if (id != null) {
             result.put("id", id);
         }
+    }
+
+    /**
+     * WKT2 SIMPLIFIED omits each conversion parameter's local unit. Angular
+     * parameters inherit the base geographic CRS unit, linear parameters inherit
+     * the projected coordinate-system unit, and scale parameters use unity.
+     */
+    @SuppressWarnings("unchecked")
+    private static void applySimplifiedConversionUnits(Map<String, Object> projectedCrs) {
+        Object conversionValue = projectedCrs.get("conversion");
+        if (!(conversionValue instanceof Map)) {
+            return;
+        }
+        Object parametersValue =
+            ((Map<String, Object>) conversionValue).get("parameters");
+        if (!(parametersValue instanceof List)) {
+            return;
+        }
+
+        Object angularUnit = coordinateSystemUnit(projectedCrs.get("base_crs"));
+        Object linearUnit = coordinateSystemUnit(projectedCrs);
+        for (Object parameterValue : (List<?>) parametersValue) {
+            if (!(parameterValue instanceof Map)) {
+                continue;
+            }
+            Map<String, Object> parameter = (Map<String, Object>) parameterValue;
+            if (parameter.containsKey("unit") || parameter.get("name") == null) {
+                continue;
+            }
+            String name =
+                parameter.get("name").toString().toLowerCase(Locale.ROOT);
+            if (isAngularConversionParameter(name) && angularUnit != null) {
+                parameter.put("unit", angularUnit);
+            } else if (isLinearConversionParameter(name) && linearUnit != null) {
+                parameter.put("unit", linearUnit);
+            } else if (name.contains("scale factor")) {
+                Map<String, Object> scaleUnit = new HashMap<>();
+                scaleUnit.put("type", "ScaleUnit");
+                scaleUnit.put("name", "unity");
+                scaleUnit.put("conversion_factor", 1.0);
+                parameter.put("unit", scaleUnit);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object coordinateSystemUnit(Object crsValue) {
+        if (!(crsValue instanceof Map)) {
+            return null;
+        }
+        Object coordinateSystem =
+            ((Map<String, Object>) crsValue).get("coordinate_system");
+        if (!(coordinateSystem instanceof Map)) {
+            return null;
+        }
+        return ((Map<String, Object>) coordinateSystem).get("unit");
+    }
+
+    private static boolean isAngularConversionParameter(String name) {
+        return name.contains("latitude")
+            || name.contains("longitude")
+            || name.contains("azimuth")
+            || name.contains("angle")
+            || name.contains("co-latitude");
+    }
+
+    private static boolean isLinearConversionParameter(String name) {
+        return name.contains("easting")
+            || name.contains("northing")
+            || name.contains("height");
     }
 
     /**
@@ -705,55 +783,38 @@ public final class ProjJsonBuilder {
     @SuppressWarnings("unchecked")
     private static Map<String, Object> convertAxisNode(List<Object> node) {
         Map<String, Object> axis = new HashMap<>();
-        
-        String name = node.size() > 1 ? node.get(1).toString() : "Unknown";
+
+        String rawName = node.size() > 1 ? node.get(1).toString() : "Unknown";
+        String name = rawName;
+        String abbreviation = null;
+        Matcher nameMatcher = AXIS_NAME_WITH_ABBREVIATION.matcher(rawName);
+        if (nameMatcher.matches()) {
+            name = nameMatcher.group(1).trim();
+            abbreviation = nameMatcher.group(2);
+        }
         axis.put("name", name);
+        if (abbreviation != null) {
+            axis.put("abbreviation", abbreviation);
+        }
 
         // Determine direction
         String direction;
-        // Check for abbreviation pattern like "(E)" or "(N)"
-        if (name.matches("^\\([A-Za-z]\\)$")) {
-            String abbrev = name.substring(1, 2).toUpperCase();
-            switch (abbrev) {
-                case "E": direction = "east"; break;
-                case "N": direction = "north"; break;
-                case "U": direction = "up"; break;
-                case "W": direction = "west"; break;
-                case "S": direction = "south"; break;
-                default:
-                    // Not a well-known abbreviation (e.g. "(X)" on geocentric axes):
-                    // fall back to the explicit direction token, as wkt-parser does.
-                    if (node.size() > 2) {
-                        direction = node.get(2).toString();
-                    } else {
-                        throw new IllegalArgumentException("Unknown axis abbreviation: " + abbrev);
-                    }
-                    break;
-            }
-        } else if (node.size() > 2) {
+        if (node.size() > 2 && !(node.get(2) instanceof List)) {
             // Preserve the token's case (wkt-parser 1.5.5): the PROJJSON direction
             // enum is camelCase for geocentricX/Y/Z, so lowercasing produced
-            // schema-invalid values in the exposed intermediate PROJJSON. The
-            // transformer lowercases at lookup, so parsing tolerance is unchanged.
+            // schema-invalid values in the exposed intermediate PROJJSON. It is
+            // also authoritative over the abbreviation: a polar "(E)" axis may
+            // legitimately point south and be qualified by a meridian.
             direction = node.get(2).toString();
         } else {
-            direction = "unknown";
+            direction = inferAxisDirection(abbreviation);
         }
         axis.put("direction", direction);
 
         // Find ORDER
         List<Object> orderNode = findNode(node, "ORDER");
         if (orderNode != null && orderNode.size() > 1) {
-            Object orderVal = orderNode.get(1);
-            if (orderVal instanceof Number) {
-                axis.put("order", ((Number) orderVal).intValue());
-            } else {
-                try {
-                    axis.put("order", Integer.parseInt(orderVal.toString()));
-                } catch (NumberFormatException e) {
-                    // Ignore
-                }
-            }
+            axis.put("order", parseAxisOrder(orderNode.get(1)));
         }
 
         // Find unit
@@ -762,7 +823,65 @@ public final class ProjJsonBuilder {
             axis.put("unit", convertUnit(unitNode));
         }
 
+        // A polar north/south direction is qualified by a meridian. PROJJSON
+        // represents a non-default angular unit inside longitude's value-and-unit
+        // object rather than as a sibling of longitude.
+        List<Object> meridianNode = findNode(node, "MERIDIAN");
+        if (meridianNode != null) {
+            if (meridianNode.size() <= 1) {
+                throw new IllegalArgumentException(
+                    "Axis MERIDIAN requires a longitude");
+            }
+            Double longitude = parseDouble(meridianNode.get(1));
+            if (longitude == null || !Double.isFinite(longitude)) {
+                throw new IllegalArgumentException(
+                    "Axis MERIDIAN longitude must be a finite number");
+            }
+            List<Object> meridianUnitNode =
+                findNodeAny(meridianNode, "ANGLEUNIT", "UNIT");
+            if (meridianUnitNode == null) {
+                throw new IllegalArgumentException(
+                    "Axis MERIDIAN requires ANGLEUNIT or UNIT");
+            }
+            Double meridianUnitFactor = angularUnitFactor(meridianUnitNode);
+            if (meridianUnitFactor == null || !Double.isFinite(meridianUnitFactor)) {
+                throw new IllegalArgumentException(
+                    "Axis MERIDIAN unit requires a positive finite conversion factor");
+            }
+            Map<String, Object> valueAndUnit = new HashMap<>();
+            valueAndUnit.put("value", longitude);
+            valueAndUnit.put("unit", convertUnit(meridianUnitNode));
+            Map<String, Object> meridian = new HashMap<>();
+            meridian.put("longitude", valueAndUnit);
+            axis.put("meridian", meridian);
+        }
+
         return axis;
+    }
+
+    private static String inferAxisDirection(String abbreviation) {
+        if (abbreviation == null || abbreviation.length() != 1) {
+            return "unknown";
+        }
+        switch (Character.toUpperCase(abbreviation.charAt(0))) {
+            case 'E': return "east";
+            case 'N': return "north";
+            case 'U': return "up";
+            case 'W': return "west";
+            case 'S': return "south";
+            default: return "unknown";
+        }
+    }
+
+    private static int parseAxisOrder(Object value) {
+        Double numeric = parseDouble(value);
+        if (numeric == null || !Double.isFinite(numeric)
+                || numeric != Math.rint(numeric)
+                || numeric < Integer.MIN_VALUE || numeric > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                "Axis ORDER must be an integer: " + value);
+        }
+        return numeric.intValue();
     }
 
     /**
@@ -779,14 +898,9 @@ public final class ProjJsonBuilder {
                 }
             }
         }
-        // Sort by order if present
-        axes.sort((a, b) -> {
-            Integer orderA = (Integer) a.get("order");
-            Integer orderB = (Integer) b.get("order");
-            if (orderA == null) orderA = 0;
-            if (orderB == null) orderB = 0;
-            return orderA.compareTo(orderB);
-        });
+        // Array position is coordinate order. Retain ORDER as metadata but do not
+        // normalize malformed WKT by sorting it: WKT2 requires ORDER to agree with
+        // lexical position, and the serializer can then reject a mismatch.
         return axes;
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -44,19 +44,7 @@ public final class ProjJsonTransformer {
             return new ProjectionDef();
         }
 
-        if ("ProjectedCRS".equals(projjson.get("type"))
-                && (projjson.containsKey("id") || projjson.containsKey("ids"))) {
-            Object coordinateSystem = projjson.get("coordinate_system");
-            if (!(coordinateSystem instanceof Map)) {
-                throw new IllegalArgumentException(
-                    "Identified ProjectedCRS requires a coordinate_system");
-            }
-            validateIdentifiedProjectedCoordinateSystem(
-                (Map<String, Object>) coordinateSystem);
-        }
-
         ProjectionDef def = new ProjectionDef();
-        
         // Handle BoundCRS specially - recurse into source_crs
         if ("BoundCRS".equals(projjson.get("type"))) {
             Object sourceCrs = projjson.get("source_crs");
@@ -98,31 +86,6 @@ public final class ProjJsonTransformer {
         WktUtils.applyProjectionDefaults(def);
 
         return def;
-    }
-
-    private static void validateIdentifiedProjectedCoordinateSystem(
-            Map<String, Object> coordinateSystem) {
-        Object subtype = coordinateSystem.get("subtype");
-        if (subtype == null || subtype.toString().trim().isEmpty()) {
-            throw new IllegalArgumentException(
-                "Identified ProjectedCRS coordinate_system requires a subtype");
-        }
-        Object axisValue = coordinateSystem.get("axis");
-        if (!(axisValue instanceof List)) {
-            throw new IllegalArgumentException(
-                "Identified ProjectedCRS coordinate_system requires an axis array");
-        }
-        List<?> axes = (List<?>) axisValue;
-        if (axes.size() < 2 || axes.size() > 3) {
-            throw new IllegalArgumentException(
-                "Identified ProjectedCRS requires two or three coordinate axes");
-        }
-        for (Object axis : axes) {
-            if (!(axis instanceof Map)) {
-                throw new IllegalArgumentException(
-                    "Identified ProjectedCRS coordinate axes must be objects");
-            }
-        }
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -2,8 +2,10 @@ package org.datasyslab.proj4sedona.parser;
 
 import org.datasyslab.proj4sedona.constants.Datum;
 import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.CoordinateAxis;
 import org.datasyslab.proj4sedona.core.ProjectionDef;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -40,6 +42,13 @@ public final class ProjJsonTransformer {
     public static ProjectionDef transform(Map<String, Object> projjson) {
         if (projjson == null) {
             return new ProjectionDef();
+        }
+
+        if ("ProjectedCRS".equals(projjson.get("type"))
+                && (projjson.containsKey("id") || projjson.containsKey("ids"))
+                && !(projjson.get("coordinate_system") instanceof Map)) {
+            throw new IllegalArgumentException(
+                "Identified ProjectedCRS requires a coordinate_system");
         }
 
         ProjectionDef def = new ProjectionDef();
@@ -367,9 +376,24 @@ public final class ProjJsonTransformer {
      */
     @SuppressWarnings("unchecked")
     private static void processCoordinateSystem(Map<String, Object> coordSys, ProjectionDef def) {
+        Object subtypeValue = coordSys.get("subtype");
+        String subtype = subtypeValue == null ? null : subtypeValue.toString();
+        def.setCoordinateSystemType(subtype);
+
         Object axisList = coordSys.get("axis");
         if (axisList instanceof List) {
-            List<Map<String, Object>> axes = (List<Map<String, Object>>) axisList;
+            List<?> axisValues = (List<?>) axisList;
+            List<Map<String, Object>> axes = new ArrayList<>();
+            List<CoordinateAxis> coordinateAxes = new ArrayList<>();
+            Object sharedUnit = coordSys.get("unit");
+            for (Object axisValue : axisValues) {
+                if (axisValue instanceof Map) {
+                    Map<String, Object> axis = (Map<String, Object>) axisValue;
+                    axes.add(axis);
+                    coordinateAxes.add(parseCoordinateAxis(axis, sharedUnit, subtype));
+                }
+            }
+            def.setCoordinateAxes(coordinateAxes);
 
             // Mirrors wkt-parser's transformPROJJSON direction map: the axis string is
             // set only when every direction maps (all-or-nothing), preserving the
@@ -395,9 +419,8 @@ public final class ProjJsonTransformer {
             }
 
             // Process units from coordinate system
-            Object unit = coordSys.get("unit");
-            if (unit != null) {
-                processUnit(unit, def);
+            if (sharedUnit != null) {
+                processUnit(sharedUnit, def);
             } else if (!axes.isEmpty()) {
                 // Try to get unit from first axis
                 Object axisUnit = axes.get(0).get("unit");
@@ -405,6 +428,204 @@ public final class ProjJsonTransformer {
                     processUnit(axisUnit, def);
                 }
             }
+        }
+    }
+
+    private static CoordinateAxis parseCoordinateAxis(
+            Map<String, Object> axis, Object sharedUnit, String subtype) {
+        Object nameValue = axis.get("name");
+        String name = nameValue == null ? "Unknown" : nameValue.toString();
+        Object abbreviationValue = axis.get("abbreviation");
+        String abbreviation =
+            abbreviationValue == null ? null : abbreviationValue.toString();
+        Object directionValue = axis.get("direction");
+        String direction =
+            directionValue == null ? "unknown" : directionValue.toString();
+        Integer order = axis.containsKey("order")
+            ? parseRequiredAxisOrder(axis.get("order")) : null;
+        Object unitValue = axis.containsKey("unit") ? axis.get("unit") : sharedUnit;
+        CoordinateAxis.Unit unit = parseAxisUnit(unitValue, subtype);
+        CoordinateAxis.Meridian meridian = axis.containsKey("meridian")
+            ? parseAxisMeridian(axis.get("meridian")) : null;
+        return new CoordinateAxis(
+            name, abbreviation, direction, order, unit, meridian);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CoordinateAxis.Unit parseAxisUnit(Object unitValue, String subtype) {
+        if (unitValue == null) {
+            return null;
+        }
+
+        String type = null;
+        String name;
+        Double conversionFactor = null;
+        if (unitValue instanceof Map) {
+            Map<String, Object> unit = (Map<String, Object>) unitValue;
+            Object nameValue = unit.get("name");
+            if (nameValue == null) {
+                return null;
+            }
+            name = nameValue.toString();
+            Object typeValue = unit.get("type");
+            if (typeValue != null) {
+                type = canonicalUnitType(typeValue.toString());
+            }
+            if (unit.containsKey("conversion_factor")) {
+                conversionFactor =
+                    parseOptionalDouble(unit.get("conversion_factor"));
+                if (conversionFactor == null) {
+                    throw new IllegalArgumentException(
+                        "Axis unit conversion factor must be numeric");
+                }
+            }
+        } else {
+            name = unitValue.toString();
+        }
+
+        if (type == null || "Unit".equals(type)) {
+            type = inferAxisUnitType(subtype, name);
+        }
+        if (conversionFactor == null) {
+            conversionFactor = knownUnitFactor(name);
+        }
+        return new CoordinateAxis.Unit(type, name, conversionFactor);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CoordinateAxis.Meridian parseAxisMeridian(Object meridianValue) {
+        if (!(meridianValue instanceof Map)) {
+            throw new IllegalArgumentException(
+                "Axis meridian must be an object");
+        }
+        Map<String, Object> meridian = (Map<String, Object>) meridianValue;
+        if (!meridian.containsKey("longitude")) {
+            throw new IllegalArgumentException(
+                "Axis meridian requires longitude");
+        }
+        Object longitudeValue = meridian.get("longitude");
+        Object unitValue = meridian.get("unit");
+        boolean unitSpecified = meridian.containsKey("unit");
+        if (longitudeValue instanceof Map) {
+            Map<String, Object> valueAndUnit = (Map<String, Object>) longitudeValue;
+            if (!valueAndUnit.containsKey("value")
+                    || !valueAndUnit.containsKey("unit")) {
+                throw new IllegalArgumentException(
+                    "Axis meridian longitude object requires value and unit");
+            }
+            longitudeValue = valueAndUnit.get("value");
+            unitValue = valueAndUnit.get("unit");
+            unitSpecified = true;
+        }
+
+        Double longitude = parseOptionalDouble(longitudeValue);
+        if (longitude == null || !Double.isFinite(longitude)) {
+            throw new IllegalArgumentException(
+                "Axis meridian longitude must be a finite number");
+        }
+        CoordinateAxis.Unit unit;
+        if (!unitSpecified) {
+            unit = new CoordinateAxis.Unit("AngularUnit", "degree", Values.D2R);
+        } else {
+            unit = parseAxisUnit(unitValue, "ellipsoidal");
+        }
+        if (unit == null
+                || !"AngularUnit".equals(unit.getType())
+                || unit.getConversionFactor() == null
+                || !Double.isFinite(unit.getConversionFactor())
+                || unit.getConversionFactor() <= 0) {
+            throw new IllegalArgumentException(
+                "Axis meridian requires a positive finite angular unit");
+        }
+        return new CoordinateAxis.Meridian(longitude, unit);
+    }
+
+    private static String canonicalUnitType(String type) {
+        if ("linearunit".equalsIgnoreCase(type)) {
+            return "LinearUnit";
+        }
+        if ("angularunit".equalsIgnoreCase(type)) {
+            return "AngularUnit";
+        }
+        if ("scaleunit".equalsIgnoreCase(type)) {
+            return "ScaleUnit";
+        }
+        if ("unit".equalsIgnoreCase(type)) {
+            return "Unit";
+        }
+        return type;
+    }
+
+    private static String inferAxisUnitType(String subtype, String name) {
+        if (isNamedUnit(name, "degree", "grad", "gon", "radian")) {
+            return "AngularUnit";
+        }
+        if (isNamedUnit(name, "metre", "meter", "m")) {
+            return "LinearUnit";
+        }
+        if (isNamedUnit(name, "unity")) {
+            return "ScaleUnit";
+        }
+        if (subtype != null
+                && ("ellipsoidal".equalsIgnoreCase(subtype)
+                    || "spherical".equalsIgnoreCase(subtype))) {
+            return "AngularUnit";
+        }
+        if (subtype != null
+                && ("cartesian".equalsIgnoreCase(subtype)
+                    || "vertical".equalsIgnoreCase(subtype))) {
+            return "LinearUnit";
+        }
+        return "Unit";
+    }
+
+    private static Double knownUnitFactor(String name) {
+        if (isNamedUnit(name, "degree")) {
+            return Values.D2R;
+        }
+        if (isNamedUnit(name, "grad", "gon")) {
+            return Math.PI / 200.0;
+        }
+        if (isNamedUnit(name, "radian")) {
+            return 1.0;
+        }
+        if (isNamedUnit(name, "metre", "meter", "m", "unity")) {
+            return 1.0;
+        }
+        return null;
+    }
+
+    private static boolean isNamedUnit(String actual, String... names) {
+        for (String name : names) {
+            if (name.equalsIgnoreCase(actual)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Integer parseRequiredAxisOrder(Object value) {
+        Double numeric = parseOptionalDouble(value);
+        if (numeric == null || !Double.isFinite(numeric)
+                || numeric != Math.rint(numeric)
+                || numeric < Integer.MIN_VALUE || numeric > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                "Axis order must be an integer: " + value);
+        }
+        return numeric.intValue();
+    }
+
+    private static Double parseOptionalDouble(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        try {
+            return Double.parseDouble(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
         }
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/ProjJsonTransformer.java
@@ -45,10 +45,14 @@ public final class ProjJsonTransformer {
         }
 
         if ("ProjectedCRS".equals(projjson.get("type"))
-                && (projjson.containsKey("id") || projjson.containsKey("ids"))
-                && !(projjson.get("coordinate_system") instanceof Map)) {
-            throw new IllegalArgumentException(
-                "Identified ProjectedCRS requires a coordinate_system");
+                && (projjson.containsKey("id") || projjson.containsKey("ids"))) {
+            Object coordinateSystem = projjson.get("coordinate_system");
+            if (!(coordinateSystem instanceof Map)) {
+                throw new IllegalArgumentException(
+                    "Identified ProjectedCRS requires a coordinate_system");
+            }
+            validateIdentifiedProjectedCoordinateSystem(
+                (Map<String, Object>) coordinateSystem);
         }
 
         ProjectionDef def = new ProjectionDef();
@@ -94,6 +98,31 @@ public final class ProjJsonTransformer {
         WktUtils.applyProjectionDefaults(def);
 
         return def;
+    }
+
+    private static void validateIdentifiedProjectedCoordinateSystem(
+            Map<String, Object> coordinateSystem) {
+        Object subtype = coordinateSystem.get("subtype");
+        if (subtype == null || subtype.toString().trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                "Identified ProjectedCRS coordinate_system requires a subtype");
+        }
+        Object axisValue = coordinateSystem.get("axis");
+        if (!(axisValue instanceof List)) {
+            throw new IllegalArgumentException(
+                "Identified ProjectedCRS coordinate_system requires an axis array");
+        }
+        List<?> axes = (List<?>) axisValue;
+        if (axes.size() < 2 || axes.size() > 3) {
+            throw new IllegalArgumentException(
+                "Identified ProjectedCRS requires two or three coordinate axes");
+        }
+        for (Object axis : axes) {
+            if (!(axis instanceof Map)) {
+                throw new IllegalArgumentException(
+                    "Identified ProjectedCRS coordinate axes must be objects");
+            }
+        }
     }
 
     /**
@@ -174,14 +203,18 @@ public final class ProjJsonTransformer {
 
             case "id":
                 if (value instanceof Map) {
-                    Map<String, Object> id = (Map<String, Object>) value;
-                    Object authority = id.get("authority");
-                    Object code = id.get("code");
-                    if (authority != null && code != null) {
-                        String authorityCode = authority.toString() + ":" + toIntString(code);
-                        def.setTitle(authorityCode);
-                        // Store authority:code in srsCode for toEpsgCode()/toAuthority() lookup
-                        def.setSrsCode(authorityCode);
+                    processAuthorityId((Map<String, Object>) value, def);
+                }
+                break;
+
+            case "ids":
+                if (value instanceof List) {
+                    for (Object id : (List<?>) value) {
+                        if (id instanceof Map
+                                && processAuthorityId(
+                                    (Map<String, Object>) id, def)) {
+                            break;
+                        }
                     }
                 }
                 break;
@@ -266,6 +299,21 @@ public final class ProjJsonTransformer {
         }
     }
 
+    private static boolean processAuthorityId(
+            Map<String, Object> id, ProjectionDef def) {
+        Object authority = id.get("authority");
+        Object code = id.get("code");
+        if (authority == null || code == null) {
+            return false;
+        }
+        String authorityCode =
+            authority.toString() + ":" + toIntString(code);
+        def.setTitle(authorityCode);
+        // Store authority:code for toEpsgCode()/toAuthority() lookup.
+        def.setSrsCode(authorityCode);
+        return true;
+    }
+
     /**
      * Process datum/datum_ensemble node.
      */
@@ -328,11 +376,10 @@ public final class ProjJsonTransformer {
     /**
      * Calculate ellipsoid parameters.
      */
-    @SuppressWarnings("unchecked")
     private static void calculateEllipsoid(Map<String, Object> ellipsoid, ProjectionDef def) {
         Object radius = ellipsoid.get("radius");
         if (radius != null) {
-            double r = toDouble(radius);
+            double r = lengthInMetres(radius);
             def.setA(r);
             def.setRf(0.0);
             return;
@@ -340,22 +387,7 @@ public final class ProjJsonTransformer {
 
         Object sma = ellipsoid.get("semi_major_axis");
         if (sma != null) {
-            double a;
-            if (sma instanceof Map) {
-                // Handle { value: x, unit: { conversion_factor: y } }
-                Map<String, Object> smaMap = (Map<String, Object>) sma;
-                double value = toDouble(smaMap.get("value"));
-                Object unit = smaMap.get("unit");
-                if (unit instanceof Map) {
-                    Object cf = ((Map<String, Object>) unit).get("conversion_factor");
-                    if (cf != null) {
-                        value *= toDouble(cf);
-                    }
-                }
-                a = value;
-            } else {
-                a = toDouble(sma);
-            }
+            double a = lengthInMetres(sma);
             def.setA(a);
 
             Object invFlat = ellipsoid.get("inverse_flattening");
@@ -364,11 +396,32 @@ public final class ProjJsonTransformer {
             } else {
                 Object smb = ellipsoid.get("semi_minor_axis");
                 if (smb != null) {
-                    double b = toDouble(smb);
-                    def.setRf(a / (a - b));
+                    double b = lengthInMetres(smb);
+                    def.setRf(a == b ? 0.0 : a / (a - b));
                 }
             }
         }
+    }
+
+    /**
+     * Decode a PROJJSON value_in_metre_or_value_and_unit value.
+     */
+    @SuppressWarnings("unchecked")
+    private static double lengthInMetres(Object length) {
+        if (!(length instanceof Map)) {
+            return toDouble(length);
+        }
+        Map<String, Object> valueAndUnit = (Map<String, Object>) length;
+        double value = toDouble(valueAndUnit.get("value"));
+        Object unit = valueAndUnit.get("unit");
+        if (unit instanceof Map) {
+            Object conversionFactor =
+                ((Map<String, Object>) unit).get("conversion_factor");
+            if (conversionFactor != null) {
+                value *= toDouble(conversionFactor);
+            }
+        }
+        return value;
     }
 
     /**

--- a/src/main/java/org/datasyslab/proj4sedona/projection/LambertAzimuthalEqualArea.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/LambertAzimuthalEqualArea.java
@@ -14,7 +14,10 @@ import org.datasyslab.proj4sedona.core.Point;
 public class LambertAzimuthalEqualArea implements Projection {
 
     private static final String[] NAMES = {
-        "Lambert Azimuthal Equal Area", "Lambert_Azimuthal_Equal_Area", "laea"
+        "Lambert Azimuthal Equal Area",
+        "Lambert Azimuthal Equal Area (Spherical)",
+        "Lambert_Azimuthal_Equal_Area",
+        "laea"
     };
 
     private static final int S_POLE = 1, N_POLE = 2, EQUIT = 3, OBLIQ = 4;

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -1,5 +1,8 @@
 package org.datasyslab.proj4sedona.projection;
 
+import java.util.Collections;
+import java.util.List;
+import org.datasyslab.proj4sedona.core.CoordinateAxis;
 import org.datasyslab.proj4sedona.core.DatumParams;
 
 /**
@@ -123,6 +126,12 @@ public class ProjectionParams {
     
     /** Axis order string (+axis), defaults to "enu" (east-north-up) */
     public String axis = "enu";
+
+    /** Coordinate-system subtype retained from WKT2/PROJJSON (for example Cartesian). */
+    public String coordinateSystemType;
+
+    /** Detailed WKT2/PROJJSON coordinate-axis metadata, when available. */
+    public List<CoordinateAxis> coordinateAxes = Collections.emptyList();
 
     // ==================== UTM Specific ====================
     

--- a/src/test/java/org/datasyslab/proj4sedona/benchmark/MeridianAxisParityTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/benchmark/MeridianAxisParityTest.java
@@ -1,0 +1,618 @@
+package org.datasyslab.proj4sedona.benchmark;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.datasyslab.proj4sedona.core.CoordinateAxis;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Consumes the generated active-EPSG meridian-axis fixture.
+ *
+ * <p>The benchmark profile invokes this suite through {@link SpeedBenchmark}
+ * after its pre-integration-test generator has created the fixture.</p>
+ */
+final class MeridianAxisParityTest {
+
+    static final String SUITE = "meridian-axis";
+    private static final String SCHEMA_VERSION = "1.0";
+    private static final double ANGLE_TOLERANCE = Math.toRadians(1e-9);
+    private static final List<String> FORMATS = Arrays.asList(
+        "wkt2", "projjson", "proj_string");
+
+    private MeridianAxisParityTest() {
+    }
+
+    static void run(ParityCheck parity) throws IOException {
+        Path refFile = Paths.get(
+            "target/pyproj-reference/meridian_axis_reference.json");
+        if (!Files.exists(refFile)) {
+            parity.infrastructureFailure(SUITE,
+                "reference file is missing: " + refFile);
+            return;
+        }
+
+        JsonObject root = readReference(refFile);
+        if (!"pyproj".equals(requiredString(
+                root, "generator", "meridian-axis root"))) {
+            parity.infrastructureFailure(SUITE, "generator must be pyproj");
+        }
+        requiredString(root, "pyproj_version", "meridian-axis root");
+        requiredString(root, "proj_version", "meridian-axis root");
+        requiredString(root, "epsg_version", "meridian-axis root");
+        requiredString(root, "epsg_date", "meridian-axis root");
+        requiredString(root, "proj_data_version", "meridian-axis root");
+
+        List<String> declaredFormats = stringList(
+            requiredArray(root, "expected_formats", "meridian-axis root"),
+            "meridian-axis formats");
+        if (!declaredFormats.equals(FORMATS)) {
+            parity.infrastructureFailure(SUITE,
+                "expected_formats must be exactly " + FORMATS
+                    + ", but was " + declaredFormats);
+        }
+
+        List<String> baselineCodes = stringList(
+            requiredArray(root, "baseline_codes", "meridian-axis root"),
+            "meridian-axis baseline codes");
+        int baselineCount = requiredInt(
+            root, "baseline_case_count", "meridian-axis root");
+        if (baselineCount != baselineCodes.size()) {
+            parity.infrastructureFailure(SUITE,
+                "baseline_case_count declares " + baselineCount + ", but "
+                    + baselineCodes.size() + " baseline codes were present");
+        }
+        if (new LinkedHashSet<>(baselineCodes).size() != baselineCodes.size()) {
+            parity.infrastructureFailure(SUITE,
+                "baseline_codes contains duplicate entries");
+        }
+
+        JsonArray cases = requiredArray(
+            root, "test_cases", "meridian-axis root");
+        parity.reconcileCount(SUITE, "test-cases",
+            requiredInt(root, "expected_case_count", "meridian-axis root"),
+            cases.size());
+        Set<String> discoveredCodes = new LinkedHashSet<>();
+
+        for (int caseIndex = 0; caseIndex < cases.size(); caseIndex++) {
+            consumeCase(parity, cases, caseIndex, discoveredCodes);
+        }
+
+        Set<String> missingBaseline = new LinkedHashSet<>(baselineCodes);
+        missingBaseline.removeAll(discoveredCodes);
+        if (!missingBaseline.isEmpty()) {
+            parity.infrastructureFailure(SUITE,
+                "fixture is missing baseline EPSG codes: " + missingBaseline);
+        }
+        if (discoveredCodes.size() != cases.size()) {
+            parity.infrastructureFailure(SUITE,
+                "test_cases contains duplicate EPSG codes");
+        }
+        parity.reconcileCount(SUITE, "comparisons",
+            requiredInt(
+                root, "expected_comparison_count", "meridian-axis root"),
+            cases.size() * FORMATS.size());
+        System.out.println("   Meridian-axis correctness: "
+            + (cases.size() * FORMATS.size()) + " comparisons");
+    }
+
+    private static void consumeCase(
+            ParityCheck parity,
+            JsonArray cases,
+            int caseIndex,
+            Set<String> discoveredCodes) {
+        JsonObject testCase = requiredObject(cases.get(caseIndex),
+            "meridian-axis case " + caseIndex);
+        String caseContext = "meridian-axis case " + caseIndex;
+        String caseId = requiredString(testCase, "case_id", caseContext);
+        String authority = requiredString(
+            testCase, "authority", caseContext);
+        String code = requiredString(testCase, "code", caseContext);
+        requiredString(testCase, "name", caseContext);
+        JsonObject sourceProjjson = requiredObject(
+            testCase, "source_projjson", caseContext);
+        String projectionMethod = requiredString(
+            requiredObject(
+                requiredObject(
+                    sourceProjjson, "conversion", caseContext + " source"),
+                "method", caseContext + " source conversion"),
+            "name", caseContext + " source method");
+        JsonArray expectedAxes = requiredArray(
+            testCase, "expected_axes", caseContext);
+        boolean legacyAxisOmitted = requiredBoolean(
+            testCase, "legacy_proj_axis_omitted", caseContext);
+        boolean pyprojLegacyExported = requiredBoolean(
+            testCase, "pyproj_legacy_proj_exported", caseContext);
+        String referenceProjString = optionalString(
+            testCase, "legacy_proj_string", null);
+
+        discoveredCodes.add(code);
+        String caseError = null;
+        if (!"EPSG".equals(authority)) {
+            caseError = joinErrors(caseError,
+                "authority must be EPSG, but was " + authority);
+        }
+        if (!caseId.equals("epsg_" + code)) {
+            caseError = joinErrors(caseError,
+                "case_id does not match EPSG code " + code);
+        }
+        if (ProjectionRegistry.resolveProjCode(projectionMethod) == null) {
+            caseError = joinErrors(caseError,
+                "unsupported projection method " + projectionMethod
+                    + "; axis metadata was not evaluated");
+        }
+        if (expectedAxes.size() == 0) {
+            caseError = joinErrors(caseError,
+                "expected_axes must not be empty");
+        }
+        if (!legacyAxisOmitted) {
+            caseError = joinErrors(caseError,
+                "legacy_proj_axis_omitted must be true");
+        }
+        if (pyprojLegacyExported) {
+            if (referenceProjString == null
+                    || referenceProjString.trim().isEmpty()) {
+                caseError = joinErrors(caseError,
+                    "pyproj legacy export is declared but missing");
+            } else if (containsProjAxisToken(referenceProjString)) {
+                caseError = joinErrors(caseError,
+                    "pyproj legacy export unexpectedly contains +axis");
+            }
+        } else if (referenceProjString != null) {
+            caseError = joinErrors(caseError,
+                "pyproj legacy export is present despite being unavailable");
+        }
+
+        Proj original = null;
+        if (caseError == null) {
+            try {
+                original = new Proj(sourceProjjson.toString());
+                caseError = coordinateAxisDifference(
+                    expectedAxes, original.getParams().coordinateAxes);
+                if (caseError != null) {
+                    caseError = "source PROJJSON axis mismatch: " + caseError;
+                }
+            } catch (Exception e) {
+                caseError = "Java source PROJJSON parse failed: "
+                    + describeException(e);
+            }
+        }
+
+        for (String format : FORMATS) {
+            consumeFormat(
+                parity, caseId, format, caseError, original, expectedAxes);
+        }
+    }
+
+    private static void consumeFormat(
+            ParityCheck parity,
+            String caseId,
+            String format,
+            String caseError,
+            Proj original,
+            JsonArray expectedAxes) {
+        String id = caseId + "/" + format;
+        parity.expect(SUITE, id);
+        if (caseError != null) {
+            parity.failed(SUITE, id, caseError);
+            return;
+        }
+
+        try {
+            String serialized = serialize(original, format);
+            if (serialized == null || serialized.trim().isEmpty()) {
+                parity.failed(SUITE, id,
+                    "Java " + format + " export is empty");
+                return;
+            }
+
+            if ("proj_string".equals(format)) {
+                String legacyError = legacyProjAxisDifference(serialized);
+                if (legacyError != null) {
+                    parity.failed(SUITE, id, legacyError);
+                    return;
+                }
+                parity.compared(SUITE, id, 0.0, 0.0);
+                return;
+            }
+
+            Proj firstRoundTrip = new Proj(serialized);
+            String semanticError = joinErrors(
+                SpeedBenchmark.serializerSemanticDifference(
+                    original, firstRoundTrip),
+                coordinateAxisDifference(
+                    expectedAxes,
+                    firstRoundTrip.getParams().coordinateAxes));
+            if (semanticError != null) {
+                parity.failed(SUITE, id,
+                    "Java " + format
+                        + " round-trip changed CRS semantics: "
+                        + semanticError);
+                return;
+            }
+
+            String secondSerialized = serialize(firstRoundTrip, format);
+            Proj secondRoundTrip = new Proj(secondSerialized);
+            semanticError = joinErrors(
+                SpeedBenchmark.serializerSemanticDifference(
+                    original, secondRoundTrip),
+                coordinateAxisDifference(
+                    expectedAxes,
+                    secondRoundTrip.getParams().coordinateAxes));
+            if (semanticError != null) {
+                parity.failed(SUITE, id,
+                    "Java " + format
+                        + " repeated round-trip changed CRS semantics: "
+                        + semanticError);
+                return;
+            }
+            parity.compared(SUITE, id, 0.0, 0.0);
+        } catch (Exception e) {
+            parity.failed(SUITE, id,
+                "Java " + format + " round-trip failed: "
+                    + describeException(e));
+        }
+    }
+
+    private static String serialize(Proj projection, String format) {
+        switch (format) {
+            case "wkt2":
+                return CRSSerializer.toWkt2(projection);
+            case "proj_string":
+                return CRSSerializer.toProjString(projection);
+            case "projjson":
+                return CRSSerializer.toProjJson(projection);
+            default:
+                throw new IllegalArgumentException(
+                    "Unsupported serializer format: " + format);
+        }
+    }
+
+    private static String legacyProjAxisDifference(String serialized) {
+        if (containsProjAxisToken(serialized)) {
+            return "Java legacy PROJ export unexpectedly contains +axis";
+        }
+        try {
+            Proj reparsed = new Proj(serialized);
+            List<CoordinateAxis> axes = reparsed.getParams().coordinateAxes;
+            if (axes != null && !axes.isEmpty()) {
+                return "Java legacy PROJ round-trip retained coordinate-axis metadata";
+            }
+        } catch (Exception e) {
+            return "Java legacy PROJ round-trip failed: " + describeException(e);
+        }
+        return null;
+    }
+
+    private static boolean containsProjAxisToken(String projString) {
+        for (String token : projString.trim().split("\\s+")) {
+            if (token.startsWith("+axis=")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String coordinateAxisDifference(
+            JsonArray expectedAxes, List<CoordinateAxis> actualAxes) {
+        if (actualAxes == null) {
+            return "coordinate axes are null";
+        }
+        if (expectedAxes.size() != actualAxes.size()) {
+            return "coordinate axis count " + expectedAxes.size()
+                + " -> " + actualAxes.size();
+        }
+
+        for (int index = 0; index < expectedAxes.size(); index++) {
+            String label = "axis " + (index + 1);
+            JsonObject expected = requiredObject(
+                expectedAxes.get(index), label);
+            CoordinateAxis actual = actualAxes.get(index);
+            if (actual == null) {
+                return label + " is null";
+            }
+
+            String expectedName = requiredString(expected, "name", label);
+            if (!expectedName.equals(actual.getName())) {
+                return label + " name " + expectedName + " -> "
+                    + actual.getName();
+            }
+            String expectedAbbreviation = optionalString(
+                expected, "abbreviation", null);
+            if (!Objects.equals(
+                    expectedAbbreviation, actual.getAbbreviation())) {
+                return label + " abbreviation " + expectedAbbreviation + " -> "
+                    + actual.getAbbreviation();
+            }
+            String expectedDirection = requiredString(
+                expected, "direction", label);
+            if (!expectedDirection.equals(actual.getDirection())) {
+                return label + " direction " + expectedDirection + " -> "
+                    + actual.getDirection();
+            }
+
+            int expectedOrder = requiredInt(expected, "order", label);
+            int actualOrder = actual.getOrder() == null
+                ? index + 1 : actual.getOrder();
+            if (expectedOrder != actualOrder) {
+                return label + " order " + expectedOrder + " -> "
+                    + actualOrder;
+            }
+
+            String unitError = coordinateUnitDifference(
+                label + " unit",
+                requiredObject(expected, "unit", label),
+                actual.getUnit());
+            if (unitError != null) {
+                return unitError;
+            }
+
+            JsonObject expectedMeridian = optionalObject(
+                expected, "meridian");
+            CoordinateAxis.Meridian actualMeridian = actual.getMeridian();
+            if (expectedMeridian == null) {
+                if (actualMeridian != null) {
+                    return label + " gained a meridian";
+                }
+                continue;
+            }
+            if (actualMeridian == null) {
+                return label + " lost its meridian";
+            }
+
+            JsonObject expectedMeridianUnit = requiredObject(
+                expectedMeridian, "unit", label + " meridian");
+            unitError = coordinateUnitDifference(
+                label + " meridian unit",
+                expectedMeridianUnit,
+                actualMeridian.getUnit());
+            if (unitError != null) {
+                return unitError;
+            }
+
+            double expectedLongitude = requiredDouble(
+                expectedMeridian, "longitude", label + " meridian");
+            double expectedFactor = requiredDouble(
+                expectedMeridianUnit,
+                "conversion_factor",
+                label + " meridian unit");
+            Double actualFactor = actualMeridian.getUnit()
+                .getConversionFactor();
+            if (actualFactor == null || !Double.isFinite(actualFactor)) {
+                return label + " meridian has no finite unit factor";
+            }
+            double expectedRadians = expectedLongitude * expectedFactor;
+            double actualRadians =
+                actualMeridian.getLongitude() * actualFactor;
+            if (!semanticModuloAngleEquals(
+                    expectedRadians, actualRadians)) {
+                return label + " meridian " + expectedRadians + " -> "
+                    + actualRadians + " radians";
+            }
+        }
+        return null;
+    }
+
+    private static String coordinateUnitDifference(
+            String label,
+            JsonObject expected,
+            CoordinateAxis.Unit actual) {
+        if (actual == null) {
+            return label + " is missing";
+        }
+        String expectedType = requiredString(expected, "type", label);
+        if (!expectedType.equals(actual.getType())) {
+            return label + " type " + expectedType + " -> "
+                + actual.getType();
+        }
+        String expectedName = requiredString(expected, "name", label);
+        if (!expectedName.equals(actual.getName())) {
+            return label + " name " + expectedName + " -> "
+                + actual.getName();
+        }
+        double expectedFactor = requiredDouble(
+            expected, "conversion_factor", label);
+        Double actualFactor = actual.getConversionFactor();
+        if (actualFactor == null || !Double.isFinite(actualFactor)) {
+            return label + " has no finite conversion factor";
+        }
+        if (!semanticDoubleEquals(expectedFactor, actualFactor)) {
+            return label + " conversion factor " + expectedFactor + " -> "
+                + actualFactor;
+        }
+        return null;
+    }
+
+    private static boolean semanticModuloAngleEquals(
+            double first, double second) {
+        if (!Double.isFinite(first) || !Double.isFinite(second)) {
+            return false;
+        }
+        double difference = Math.IEEEremainder(
+            first - second, 2.0 * Math.PI);
+        return Math.abs(difference) <= ANGLE_TOLERANCE;
+    }
+
+    private static boolean semanticDoubleEquals(
+            double first, double second) {
+        if (!Double.isFinite(first) || !Double.isFinite(second)) {
+            return Double.doubleToLongBits(first)
+                == Double.doubleToLongBits(second);
+        }
+        double scale = Math.max(
+            1.0, Math.max(Math.abs(first), Math.abs(second)));
+        return Math.abs(first - second) <= 1e-12 * scale;
+    }
+
+    private static JsonObject readReference(Path path) throws IOException {
+        JsonObject root;
+        try (Reader reader = Files.newBufferedReader(path)) {
+            root = new Gson().fromJson(reader, JsonObject.class);
+        }
+        if (root == null) {
+            throw new IllegalArgumentException("reference root is null");
+        }
+        String version = requiredString(
+            root, "version", "meridian-axis root");
+        if (!SCHEMA_VERSION.equals(version)) {
+            throw new IllegalArgumentException(
+                "unsupported reference schema " + version + " (expected "
+                    + SCHEMA_VERSION + ")");
+        }
+        return root;
+    }
+
+    private static JsonObject requiredObject(
+            JsonElement value, String context) {
+        if (value == null || value.isJsonNull() || !value.isJsonObject()) {
+            throw new IllegalArgumentException(
+                context + " must be a JSON object");
+        }
+        return value.getAsJsonObject();
+    }
+
+    private static JsonObject requiredObject(
+            JsonObject owner, String field, String context) {
+        return requiredObject(
+            owner == null ? null : owner.get(field),
+            context + "." + field);
+    }
+
+    private static JsonObject optionalObject(
+            JsonObject owner, String field) {
+        if (owner == null) {
+            return null;
+        }
+        JsonElement value = owner.get(field);
+        return value == null || value.isJsonNull() || !value.isJsonObject()
+            ? null : value.getAsJsonObject();
+    }
+
+    private static JsonArray requiredArray(
+            JsonObject owner, String field, String context) {
+        JsonElement value = owner == null ? null : owner.get(field);
+        if (value == null || value.isJsonNull() || !value.isJsonArray()) {
+            throw new IllegalArgumentException(context + "." + field
+                + " must be a JSON array");
+        }
+        return value.getAsJsonArray();
+    }
+
+    private static String requiredString(
+            JsonObject owner, String field, String context) {
+        String value = optionalString(owner, field, null);
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(context + "." + field
+                + " must be a non-empty string");
+        }
+        return value;
+    }
+
+    private static String optionalString(
+            JsonObject owner, String field, String defaultValue) {
+        if (owner == null) {
+            return defaultValue;
+        }
+        JsonElement value = owner.get(field);
+        if (value == null || value.isJsonNull() || !value.isJsonPrimitive()) {
+            return defaultValue;
+        }
+        try {
+            return value.getAsString();
+        } catch (RuntimeException e) {
+            return defaultValue;
+        }
+    }
+
+    private static int requiredInt(
+            JsonObject owner, String field, String context) {
+        JsonElement value = owner == null ? null : owner.get(field);
+        try {
+            if (value == null || value.isJsonNull() || !value.isJsonPrimitive()
+                    || !value.getAsJsonPrimitive().isNumber()) {
+                throw new IllegalArgumentException();
+            }
+            return value.getAsBigDecimal().intValueExact();
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(context + "." + field
+                + " must be an integer", e);
+        }
+    }
+
+    private static double requiredDouble(
+            JsonObject owner, String field, String context) {
+        JsonElement value = owner == null ? null : owner.get(field);
+        try {
+            if (value == null || value.isJsonNull()
+                    || !value.isJsonPrimitive()) {
+                throw new IllegalArgumentException();
+            }
+            double number = value.getAsDouble();
+            if (!Double.isFinite(number)) {
+                throw new IllegalArgumentException();
+            }
+            return number;
+        } catch (RuntimeException e) {
+            throw new IllegalArgumentException(context + "." + field
+                + " must be a finite number", e);
+        }
+    }
+
+    private static boolean requiredBoolean(
+            JsonObject owner, String field, String context) {
+        JsonElement value = owner == null ? null : owner.get(field);
+        if (value == null || value.isJsonNull() || !value.isJsonPrimitive()
+                || !value.getAsJsonPrimitive().isBoolean()) {
+            throw new IllegalArgumentException(context + "." + field
+                + " must be a boolean");
+        }
+        return value.getAsBoolean();
+    }
+
+    private static List<String> stringList(
+            JsonArray values, String context) {
+        List<String> result = new ArrayList<>();
+        for (int index = 0; index < values.size(); index++) {
+            JsonElement value = values.get(index);
+            if (value == null || value.isJsonNull()
+                    || !value.isJsonPrimitive()) {
+                throw new IllegalArgumentException(
+                    context + " entry " + index + " must be a string");
+            }
+            result.add(value.getAsString());
+        }
+        return result;
+    }
+
+    private static String joinErrors(String first, String second) {
+        if (first == null || first.trim().isEmpty()) {
+            return second == null || second.trim().isEmpty() ? null : second;
+        }
+        if (second == null || second.trim().isEmpty()) {
+            return first;
+        }
+        return first + "; " + second;
+    }
+
+    private static String describeException(Exception exception) {
+        String message = exception.getMessage();
+        return exception.getClass().getSimpleName()
+            + (message == null || message.trim().isEmpty()
+                ? "" : ": " + message);
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/benchmark/MeridianAxisParityTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/benchmark/MeridianAxisParityTest.java
@@ -6,7 +6,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import org.datasyslab.proj4sedona.core.CoordinateAxis;
 import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.core.ProjectionDef;
 import org.datasyslab.proj4sedona.parser.CRSSerializer;
+import org.datasyslab.proj4sedona.parser.WktParser;
 import org.datasyslab.proj4sedona.projection.ProjectionRegistry;
 
 import java.io.IOException;
@@ -18,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -34,6 +37,8 @@ final class MeridianAxisParityTest {
     private static final double ANGLE_TOLERANCE = Math.toRadians(1e-9);
     private static final List<String> FORMATS = Arrays.asList(
         "wkt2", "projjson", "proj_string");
+    private static final Set<String> UNSUPPORTED_METHOD_CASES =
+        new LinkedHashSet<>(Arrays.asList("epsg_2985", "epsg_2986"));
 
     private MeridianAxisParityTest() {
     }
@@ -106,9 +111,16 @@ final class MeridianAxisParityTest {
         parity.reconcileCount(SUITE, "comparisons",
             requiredInt(
                 root, "expected_comparison_count", "meridian-axis root"),
-            cases.size() * FORMATS.size());
+            cases.size() * FORMATS.size() * 2);
+        parity.reconcileCount(SUITE, "parser-comparisons",
+            requiredInt(
+                root, "expected_parser_comparison_count",
+                "meridian-axis root"),
+            cases.size() * 2);
         System.out.println("   Meridian-axis correctness: "
-            + (cases.size() * FORMATS.size()) + " comparisons");
+            + cases.size() + " CRSs, "
+            + (cases.size() * 2) + " parser comparisons and "
+            + (cases.size() * FORMATS.size() * 2) + " export outcomes");
     }
 
     private static void consumeCase(
@@ -124,6 +136,8 @@ final class MeridianAxisParityTest {
             testCase, "authority", caseContext);
         String code = requiredString(testCase, "code", caseContext);
         requiredString(testCase, "name", caseContext);
+        String sourceWkt2 = requiredString(
+            testCase, "source_wkt2", caseContext);
         JsonObject sourceProjjson = requiredObject(
             testCase, "source_projjson", caseContext);
         String projectionMethod = requiredString(
@@ -151,10 +165,25 @@ final class MeridianAxisParityTest {
             caseError = joinErrors(caseError,
                 "case_id does not match EPSG code " + code);
         }
-        if (ProjectionRegistry.resolveProjCode(projectionMethod) == null) {
+        String resolvedMethod =
+            ProjectionRegistry.resolveProjCode(projectionMethod);
+        boolean expectedUnsupported =
+            UNSUPPORTED_METHOD_CASES.contains(caseId);
+        if (resolvedMethod == null && !expectedUnsupported) {
             caseError = joinErrors(caseError,
-                "unsupported projection method " + projectionMethod
-                    + "; axis metadata was not evaluated");
+                "unexpected unsupported projection method "
+                    + projectionMethod);
+        } else if (resolvedMethod != null && expectedUnsupported) {
+            caseError = joinErrors(caseError,
+                "stale unsupported-method declaration for "
+                    + projectionMethod);
+        } else if (expectedUnsupported
+                && !"Polar Stereographic (variant C)".equals(
+                    projectionMethod)) {
+            caseError = joinErrors(caseError,
+                "unsupported-method declaration expected Polar "
+                    + "Stereographic (variant C), but found "
+                    + projectionMethod);
         }
         if (expectedAxes.size() == 0) {
             caseError = joinErrors(caseError,
@@ -178,38 +207,121 @@ final class MeridianAxisParityTest {
                 "pyproj legacy export is present despite being unavailable");
         }
 
+        String parserError = parseAxisMetadata(
+            sourceWkt2, sourceProjjson, expectedAxes, caseId, parity);
+        caseError = joinErrors(caseError, parserError);
+
+        consumeSourceFormats(
+            parity, caseId, "projjson_source", sourceProjjson.toString(),
+            caseError, expectedUnsupported, projectionMethod, expectedAxes);
+        consumeSourceFormats(
+            parity, caseId, "wkt2_source", sourceWkt2,
+            caseError, expectedUnsupported, projectionMethod, expectedAxes);
+    }
+
+    private static void consumeSourceFormats(
+            ParityCheck parity,
+            String caseId,
+            String sourceFormat,
+            String source,
+            String caseError,
+            boolean expectedUnsupported,
+            String projectionMethod,
+            JsonArray expectedAxes) {
         Proj original = null;
-        if (caseError == null) {
+        String sourceError = caseError;
+        if (sourceError == null && !expectedUnsupported) {
             try {
-                original = new Proj(sourceProjjson.toString());
-                caseError = coordinateAxisDifference(
+                original = new Proj(source);
+                String axisError = coordinateAxisDifference(
                     expectedAxes, original.getParams().coordinateAxes);
-                if (caseError != null) {
-                    caseError = "source PROJJSON axis mismatch: " + caseError;
+                if (axisError != null) {
+                    sourceError = sourceFormat + " axis mismatch: " + axisError;
                 }
             } catch (Exception e) {
-                caseError = "Java source PROJJSON parse failed: "
+                sourceError = "Java " + sourceFormat + " parse failed: "
                     + describeException(e);
             }
         }
 
         for (String format : FORMATS) {
             consumeFormat(
-                parity, caseId, format, caseError, original, expectedAxes);
+                parity, caseId, sourceFormat, format, sourceError,
+                expectedUnsupported, projectionMethod, original, expectedAxes);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String parseAxisMetadata(
+            String sourceWkt2,
+            JsonObject sourceProjjson,
+            JsonArray expectedAxes,
+            String caseId,
+            ParityCheck parity) {
+        String combinedError = null;
+        String projjsonId = caseId + "/projjson_parse";
+        parity.expect(SUITE, projjsonId);
+        try {
+            Map<String, Object> source = new Gson().fromJson(
+                sourceProjjson, Map.class);
+            ProjectionDef definition = WktParser.parse(source);
+            String error = coordinateAxisDifference(
+                expectedAxes, definition.getCoordinateAxes());
+            if (error == null) {
+                parity.compared(SUITE, projjsonId, 0.0, 0.0);
+            } else {
+                parity.failed(SUITE, projjsonId, error);
+                combinedError = "source PROJJSON axis mismatch: " + error;
+            }
+        } catch (Exception e) {
+            String error = "source PROJJSON parse failed: "
+                + describeException(e);
+            parity.failed(SUITE, projjsonId, error);
+            combinedError = error;
+        }
+
+        String wkt2Id = caseId + "/wkt2_parse";
+        parity.expect(SUITE, wkt2Id);
+        try {
+            ProjectionDef definition = WktParser.parse(sourceWkt2);
+            String error = coordinateAxisDifference(
+                expectedAxes, definition.getCoordinateAxes());
+            if (error == null) {
+                parity.compared(SUITE, wkt2Id, 0.0, 0.0);
+            } else {
+                parity.failed(SUITE, wkt2Id, error);
+                combinedError = joinErrors(
+                    combinedError, "source WKT2 axis mismatch: " + error);
+            }
+        } catch (Exception e) {
+            String error = "source WKT2 parse failed: "
+                + describeException(e);
+            parity.failed(SUITE, wkt2Id, error);
+            combinedError = joinErrors(combinedError, error);
+        }
+        return combinedError;
     }
 
     private static void consumeFormat(
             ParityCheck parity,
             String caseId,
+            String sourceFormat,
             String format,
             String caseError,
+            boolean expectedUnsupported,
+            String projectionMethod,
             Proj original,
             JsonArray expectedAxes) {
-        String id = caseId + "/" + format;
+        String id = caseId + "/" + sourceFormat + "/" + format;
         parity.expect(SUITE, id);
         if (caseError != null) {
             parity.failed(SUITE, id, caseError);
+            return;
+        }
+        if (expectedUnsupported) {
+            parity.skipped(SUITE, id,
+                projectionMethod + " is not implemented; its WKT2 and "
+                    + "PROJJSON axis metadata passed parser parity");
             return;
         }
 
@@ -328,9 +440,12 @@ final class MeridianAxisParityTest {
             }
 
             String expectedName = requiredString(expected, "name", label);
-            if (!expectedName.equals(actual.getName())) {
+            String actualName = actual.getName();
+            if (actualName == null
+                    || (!actualName.trim().isEmpty()
+                        && !expectedName.equalsIgnoreCase(actualName))) {
                 return label + " name " + expectedName + " -> "
-                    + actual.getName();
+                    + actualName;
             }
             String expectedAbbreviation = optionalString(
                 expected, "abbreviation", null);

--- a/src/test/java/org/datasyslab/proj4sedona/benchmark/SpeedBenchmark.java
+++ b/src/test/java/org/datasyslab/proj4sedona/benchmark/SpeedBenchmark.java
@@ -289,6 +289,9 @@ public class SpeedBenchmark {
         runParitySuite("grid", this::runGridParity);
         runParitySuite("parser", this::runParserParity);
         runParitySuite("serializer", this::runSerializerParity);
+        runParitySuite(
+            MeridianAxisParityTest.SUITE,
+            () -> MeridianAxisParityTest.run(parity));
 
         parity.auditDeclaredUses(
             "transform", "skip", TRANSFORM_SKIPS.keySet(), usedTransformSkips);

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -898,6 +898,32 @@ class CRSSerializerTest {
         
         String json = CRSSerializer.toProjJson(proj);
         assertTrue(json.contains("6370997"));
+        assertTrue(json.contains("\"radius\""), json);
+
+        String compact = proj.toProjJson(false);
+        String firstRoundTrip = new Proj(compact).toProjJson(false);
+        assertEquals(
+            firstRoundTrip,
+            new Proj(firstRoundTrip).toProjJson(false));
+    }
+
+    @Test
+    @DisplayName("PROJJSON equal ellipsoid axes reparse as a sphere")
+    void testEqualEllipsoidAxesRoundTripAsSphere() {
+        Proj sphere = new Proj(
+            "+proj=merc +R=6371228 +lat_ts=0 +lon_0=0 "
+                + "+x_0=0 +y_0=0 +k=1 +units=m");
+        String radiusJson = sphere.toProjJson(false);
+        String equalAxesJson = radiusJson.replaceFirst(
+            "\"radius\":([0-9.Ee+\\-]+)",
+            "\"semi_major_axis\":$1,\"semi_minor_axis\":$1");
+
+        assertNotEquals(radiusJson, equalAxesJson);
+        String firstRoundTrip = new Proj(equalAxesJson).toProjJson(false);
+        assertTrue(firstRoundTrip.contains("\"radius\""), firstRoundTrip);
+        assertEquals(
+            firstRoundTrip,
+            new Proj(firstRoundTrip).toProjJson(false));
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerTest.java
@@ -672,6 +672,45 @@ class CRSSerializerTest {
     }
 
     @Test
+    @DisplayName("identified ProjectedCRS remains usable without coordinate_system")
+    void testIdentifiedProjectedCrsWithoutCoordinateSystem() {
+        String utmWithoutCoordinateSystem =
+            "{\"type\":\"ProjectedCRS\",\"name\":\"WGS 84 / UTM zone 32N\","
+            + "\"base_crs\":{\"name\":\"WGS 84\",\"datum\":{"
+            + "\"type\":\"GeodeticReferenceFrame\","
+            + "\"name\":\"World Geodetic System 1984\","
+            + "\"ellipsoid\":{\"name\":\"WGS 84\","
+            + "\"semi_major_axis\":6378137,"
+            + "\"inverse_flattening\":298.257223563}}},"
+            + "\"conversion\":{\"name\":\"UTM zone 32N\","
+            + "\"method\":{\"name\":\"Transverse Mercator\"},"
+            + "\"parameters\":["
+            + "{\"name\":\"Latitude of natural origin\","
+            + "\"value\":0,\"unit\":\"degree\"},"
+            + "{\"name\":\"Longitude of natural origin\","
+            + "\"value\":9,\"unit\":\"degree\"},"
+            + "{\"name\":\"Scale factor at natural origin\",\"value\":0.9996},"
+            + "{\"name\":\"False easting\",\"value\":500000},"
+            + "{\"name\":\"False northing\",\"value\":0}]},"
+            + "\"id\":{\"authority\":\"EPSG\",\"code\":32632}}";
+
+        Proj proj = new Proj(utmWithoutCoordinateSystem);
+        Point projected = Proj4.proj4(
+            "+proj=longlat +datum=WGS84",
+            utmWithoutCoordinateSystem,
+            new Point(9, 50));
+
+        assertEquals("Transverse Mercator", proj.getParams().projName);
+        assertEquals(500000.0, projected.x, 1e-4);
+        assertEquals(5538630.7029, projected.y, 1e-4);
+        assertDoesNotThrow(proj::toProjString);
+        assertDoesNotThrow(proj::toWkt2);
+        assertDoesNotThrow(() -> proj.toProjJson());
+        assertArrayEquals(
+            new String[]{"EPSG", "32632"}, proj.toAuthority());
+    }
+
+    @Test
     @DisplayName("toEpsgCode: No id field with unknown datum returns null (not 4326)")
     void testToEpsgCodeNoIdGrs80() {
         String noId = "{\"type\":\"GeographicCRS\",\"name\":\"Unknown CRS\","

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CoordinateAxisParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CoordinateAxisParserTest.java
@@ -173,6 +173,22 @@ class CoordinateAxisParserTest {
             () -> WktParser.parse(object(
                 "type", "ProjectedCRS",
                 "id", object("authority", "EPSG", "code", 32661))));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(object(
+                "type", "ProjectedCRS",
+                "coordinate_system", object(
+                    "subtype", "Cartesian", "axis", Arrays.asList()),
+                "id", object("authority", "EPSG", "code", 5041))));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(object(
+                "type", "ProjectedCRS",
+                "coordinate_system", object(
+                    "axis", Arrays.asList(
+                        object("name", "X", "direction", "east"),
+                        object("name", "Y", "direction", "north"))),
+                "id", object("authority", "EPSG", "code", 5041))));
 
         Map<String, Object> fractionalOrder = object(
             "name", "Northing", "direction", "north", "order", 1.5);
@@ -206,6 +222,13 @@ class CoordinateAxisParserTest {
         assertThrows(
             IllegalArgumentException.class,
             () -> WktParser.parse(missingWktMeridianUnit));
+
+        String malformedWktMeridianUnit = upsNorthSimplifiedWkt2().replace(
+            "MERIDIAN[180,UNIT[\"degree\",0.0174532925199433]]",
+            "MERIDIAN[180,UNIT[\"degree\",\"bogus\"]]");
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(malformedWktMeridianUnit));
     }
 
     private static void assertAxis(

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CoordinateAxisParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CoordinateAxisParserTest.java
@@ -168,28 +168,6 @@ class CoordinateAxisParserTest {
 
     @Test
     void rejectsMalformedExplicitAxisMetadata() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> WktParser.parse(object(
-                "type", "ProjectedCRS",
-                "id", object("authority", "EPSG", "code", 32661))));
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> WktParser.parse(object(
-                "type", "ProjectedCRS",
-                "coordinate_system", object(
-                    "subtype", "Cartesian", "axis", Arrays.asList()),
-                "id", object("authority", "EPSG", "code", 5041))));
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> WktParser.parse(object(
-                "type", "ProjectedCRS",
-                "coordinate_system", object(
-                    "axis", Arrays.asList(
-                        object("name", "X", "direction", "east"),
-                        object("name", "Y", "direction", "north"))),
-                "id", object("authority", "EPSG", "code", 5041))));
-
         Map<String, Object> fractionalOrder = object(
             "name", "Northing", "direction", "north", "order", 1.5);
         assertThrows(

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CoordinateAxisParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CoordinateAxisParserTest.java
@@ -1,0 +1,327 @@
+package org.datasyslab.proj4sedona.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.CoordinateAxis;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.datasyslab.proj4sedona.core.ProjectionDef;
+import org.junit.jupiter.api.Test;
+
+class CoordinateAxisParserTest {
+
+    @Test
+    void retainsPolarAxisMetadataFromWkt2AndPropagatesToProjectionParams() {
+        ProjectionDef def = WktParser.parse(upsNorthWkt2());
+        List<CoordinateAxis> axes = def.getCoordinateAxes();
+
+        assertEquals(2, axes.size());
+        assertAxis(
+            axes.get(0), "northing", "N", "south", 1,
+            "LinearUnit", "metre", 1.0, 180.0, "degree", Values.D2R);
+        assertAxis(
+            axes.get(1), "easting", "E", "south", 2,
+            "LinearUnit", "metre", 1.0, 90.0, "degree", Values.D2R);
+        assertEquals("ssu", def.getAxis());
+        assertEquals("Cartesian", def.getCoordinateSystemType());
+
+        Proj proj = new Proj(upsNorthWkt2());
+        assertEquals(axes, proj.getParams().coordinateAxes);
+        assertEquals("Cartesian", proj.getParams().coordinateSystemType);
+    }
+
+    @Test
+    void retainsProjJsonNonDegreeMeridiansAndBareUnits() {
+        Map<String, Object> grad = object(
+            "type", "AngularUnit",
+            "name", "grad",
+            "conversion_factor", Math.PI / 200.0);
+        Map<String, Object> foot = object(
+            "type", "LinearUnit",
+            "name", "foot",
+            "conversion_factor", 0.3048);
+        Map<String, Object> firstAxis = object(
+            "name", "Grid north",
+            "abbreviation", "Gn",
+            "direction", "north",
+            "order", 1.0,
+            "unit", foot,
+            "meridian", object(
+                "longitude", object("value", 100.0, "unit", grad)));
+        Map<String, Object> secondAxis = object(
+            "name", "Grid east",
+            "abbreviation", "Ge",
+            "direction", "north",
+            "unit", "metre",
+            "meridian", object("longitude", 90.0));
+        Map<String, Object> projjson = object(
+            "coordinate_system", object(
+                "subtype", "Cartesian",
+                "axis", Arrays.asList(firstAxis, secondAxis)));
+
+        ProjectionDef def = WktParser.parse(projjson);
+        List<CoordinateAxis> axes = def.getCoordinateAxes();
+
+        assertEquals("nnu", def.getAxis());
+        assertAxis(
+            axes.get(0), "Grid north", "Gn", "north", 1,
+            "LinearUnit", "foot", 0.3048,
+            100.0, "grad", Math.PI / 200.0);
+        assertAxis(
+            axes.get(1), "Grid east", "Ge", "north", null,
+            "LinearUnit", "metre", 1.0,
+            90.0, "degree", Values.D2R);
+    }
+
+    @Test
+    void appliesSimplifiedCoordinateSystemUnitToEveryAxis() {
+        String wkt = "GEODCRS[\"NTF (Paris)\","
+            + "DATUM[\"Nouvelle Triangulation Francaise (Paris)\","
+            + "ELLIPSOID[\"Clarke 1880 (IGN)\",6378249.2,293.466021293627]],"
+            + "PRIMEM[\"Paris\",2.5969213],CS[ellipsoidal,2],"
+            + "AXIS[\"geodetic latitude (Lat)\",north],"
+            + "AXIS[\"geodetic longitude (Lon)\",east],"
+            + "UNIT[\"grad\",0.0157079632679489],ID[\"EPSG\",4807]]";
+
+        List<CoordinateAxis> axes = WktParser.parse(wkt).getCoordinateAxes();
+
+        assertEquals(2, axes.size());
+        assertEquals("geodetic latitude", axes.get(0).getName());
+        assertEquals("Lat", axes.get(0).getAbbreviation());
+        assertEquals("geodetic longitude", axes.get(1).getName());
+        assertEquals("Lon", axes.get(1).getAbbreviation());
+        for (CoordinateAxis axis : axes) {
+            assertUnit(
+                axis.getUnit(), "AngularUnit", "grad", 0.0157079632679489);
+        }
+    }
+
+    @Test
+    void resolvesUpsNorthSimplifiedConversionParameterUnits() {
+        ProjectionDef def = WktParser.parse(upsNorthSimplifiedWkt2());
+
+        assertEquals(90.0 * Values.D2R, def.getLat0(), 1e-15);
+        assertNull(def.getLatTs());
+        assertEquals(0.0, def.getLong0(), 0.0);
+        assertEquals(0.994, def.getK0(), 0.0);
+        assertEquals(2_000_000.0, def.getX0(), 0.0);
+        assertEquals(2_000_000.0, def.getY0(), 0.0);
+        assertEquals("ssu", def.getAxis());
+        assertAxis(
+            def.getCoordinateAxes().get(0), "northing", "N", "south", null,
+            "LinearUnit", "metre", 1.0, 180.0, "degree", Values.D2R);
+    }
+
+    @Test
+    void resolvesAntarcticSimplifiedConversionParameterUnits() {
+        ProjectionDef def = WktParser.parse(antarcticSimplifiedWkt2());
+
+        assertEquals(-90.0 * Values.D2R, def.getLat0(), 1e-15);
+        assertEquals(-71.0 * Values.D2R, def.getLatTs(), 1e-15);
+        assertNull(def.getLat1());
+        assertEquals(0.0, def.getLong0(), 0.0);
+        assertEquals(0.0, def.getX0(), 0.0);
+        assertEquals(0.0, def.getY0(), 0.0);
+        assertEquals("nnu", def.getAxis());
+        assertAxis(
+            def.getCoordinateAxes().get(0), "", "E", "north", null,
+            "LinearUnit", "metre", 1.0, 90.0, "degree", Values.D2R);
+        assertAxis(
+            def.getCoordinateAxes().get(1), "", "N", "north", null,
+            "LinearUnit", "metre", 1.0, 0.0, "degree", Values.D2R);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void preservesLexicalAxisOrderWhenOrderMetadataDisagrees() {
+        String wkt = "GEOGCRS[\"Reversed metadata\","
+            + "DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563]],"
+            + "PRIMEM[\"Greenwich\",0],CS[ellipsoidal,2],"
+            + "AXIS[\"longitude (Lon)\",east,ORDER[2],"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "AXIS[\"latitude (Lat)\",north,ORDER[1],"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433]]]";
+
+        Map<String, Object> projjson = WktParser.parseWkt2ToProjJson(wkt);
+        Map<String, Object> cs =
+            (Map<String, Object>) projjson.get("coordinate_system");
+        List<Map<String, Object>> axes =
+            (List<Map<String, Object>>) cs.get("axis");
+
+        assertEquals("longitude", axes.get(0).get("name"));
+        assertEquals(2, axes.get(0).get("order"));
+        assertEquals("latitude", axes.get(1).get("name"));
+        assertEquals(1, axes.get(1).get("order"));
+
+        ProjectionDef def = WktParser.parse(wkt);
+        assertEquals("enu", def.getAxis());
+        assertEquals(Integer.valueOf(2), def.getCoordinateAxes().get(0).getOrder());
+        assertEquals(Integer.valueOf(1), def.getCoordinateAxes().get(1).getOrder());
+    }
+
+    @Test
+    void rejectsMalformedExplicitAxisMetadata() {
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(object(
+                "type", "ProjectedCRS",
+                "id", object("authority", "EPSG", "code", 32661))));
+
+        Map<String, Object> fractionalOrder = object(
+            "name", "Northing", "direction", "north", "order", 1.5);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(projJsonWithAxis(fractionalOrder)));
+
+        Map<String, Object> missingLongitude = object(
+            "name", "Northing", "direction", "north",
+            "meridian", object("type", "Meridian"));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(projJsonWithAxis(missingLongitude)));
+
+        Map<String, Object> malformedUnit = object(
+            "name", "Northing", "direction", "north",
+            "meridian", object(
+                "longitude", object(
+                    "value", 90,
+                    "unit", object(
+                        "type", "AngularUnit",
+                        "name", "degree",
+                        "conversion_factor", "invalid"))));
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(projJsonWithAxis(malformedUnit)));
+
+        String missingWktMeridianUnit = upsNorthSimplifiedWkt2().replace(
+            "MERIDIAN[180,UNIT[\"degree\",0.0174532925199433]]",
+            "MERIDIAN[180]");
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> WktParser.parse(missingWktMeridianUnit));
+    }
+
+    private static void assertAxis(
+            CoordinateAxis axis,
+            String name,
+            String abbreviation,
+            String direction,
+            Integer order,
+            String unitType,
+            String unitName,
+            double unitFactor,
+            double meridianLongitude,
+            String meridianUnitName,
+            double meridianUnitFactor) {
+        assertEquals(name, axis.getName());
+        assertEquals(abbreviation, axis.getAbbreviation());
+        assertEquals(direction, axis.getDirection());
+        assertEquals(order, axis.getOrder());
+        assertUnit(axis.getUnit(), unitType, unitName, unitFactor);
+        assertEquals(meridianLongitude, axis.getMeridian().getLongitude(), 0.0);
+        assertUnit(
+            axis.getMeridian().getUnit(),
+            "AngularUnit",
+            meridianUnitName,
+            meridianUnitFactor);
+    }
+
+    private static void assertUnit(
+            CoordinateAxis.Unit unit,
+            String type,
+            String name,
+            double conversionFactor) {
+        assertEquals(type, unit.getType());
+        assertEquals(name, unit.getName());
+        assertEquals(conversionFactor, unit.getConversionFactor(), 1e-15);
+    }
+
+    private static Map<String, Object> object(Object... values) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (int i = 0; i < values.length; i += 2) {
+            result.put(values[i].toString(), values[i + 1]);
+        }
+        return result;
+    }
+
+    private static Map<String, Object> projJsonWithAxis(Map<String, Object> axis) {
+        return object(
+            "coordinate_system", object(
+                "subtype", "Cartesian",
+                "axis", Arrays.asList(axis)));
+    }
+
+    private static String upsNorthWkt2() {
+        return "PROJCRS[\"WGS 84 / UPS North (N,E)\","
+            + "BASEGEOGCRS[\"WGS 84\",DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563]],"
+            + "PRIMEM[\"Greenwich\",0]],"
+            + "CONVERSION[\"Universal Polar Stereographic North\","
+            + "METHOD[\"Polar Stereographic (variant A)\"],"
+            + "PARAMETER[\"Latitude of natural origin\",90,"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "PARAMETER[\"Longitude of natural origin\",0,"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "PARAMETER[\"Scale factor at natural origin\",0.994,"
+            + "SCALEUNIT[\"unity\",1]],"
+            + "PARAMETER[\"False easting\",2000000,LENGTHUNIT[\"metre\",1]],"
+            + "PARAMETER[\"False northing\",2000000,LENGTHUNIT[\"metre\",1]]],"
+            + "CS[Cartesian,2],"
+            + "AXIS[\"northing (N)\",south,MERIDIAN[180,"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "ORDER[1],LENGTHUNIT[\"metre\",1]],"
+            + "AXIS[\"easting (E)\",south,MERIDIAN[90,"
+            + "ANGLEUNIT[\"degree\",0.0174532925199433]],"
+            + "ORDER[2],LENGTHUNIT[\"metre\",1]],"
+            + "ID[\"EPSG\",32661]]";
+    }
+
+    private static String upsNorthSimplifiedWkt2() {
+        return "PROJCRS[\"WGS 84 / UPS North (N,E)\","
+            + simplifiedWgs84Base()
+            + ",CONVERSION[\"Universal Polar Stereographic North\","
+            + "METHOD[\"Polar Stereographic (variant A)\"],"
+            + "PARAMETER[\"Latitude of natural origin\",90],"
+            + "PARAMETER[\"Longitude of natural origin\",0],"
+            + "PARAMETER[\"Scale factor at natural origin\",0.994],"
+            + "PARAMETER[\"False easting\",2000000],"
+            + "PARAMETER[\"False northing\",2000000]],"
+            + "CS[Cartesian,2],"
+            + "AXIS[\"northing (N)\",south,MERIDIAN[180,"
+            + "UNIT[\"degree\",0.0174532925199433]]],"
+            + "AXIS[\"easting (E)\",south,MERIDIAN[90,"
+            + "UNIT[\"degree\",0.0174532925199433]]],"
+            + "UNIT[\"metre\",1],ID[\"EPSG\",32661]]";
+    }
+
+    private static String antarcticSimplifiedWkt2() {
+        return "PROJCRS[\"WGS 84 / Antarctic Polar Stereographic\","
+            + simplifiedWgs84Base()
+            + ",CONVERSION[\"Antarctic Polar Stereographic\","
+            + "METHOD[\"Polar Stereographic (variant B)\"],"
+            + "PARAMETER[\"Latitude of standard parallel\",-71],"
+            + "PARAMETER[\"Longitude of origin\",0],"
+            + "PARAMETER[\"False easting\",0],"
+            + "PARAMETER[\"False northing\",0]],"
+            + "CS[Cartesian,2],"
+            + "AXIS[\"(E)\",north,MERIDIAN[90,"
+            + "UNIT[\"degree\",0.0174532925199433]]],"
+            + "AXIS[\"(N)\",north,MERIDIAN[0,"
+            + "UNIT[\"degree\",0.0174532925199433]]],"
+            + "UNIT[\"metre\",1],ID[\"EPSG\",3031]]";
+    }
+
+    private static String simplifiedWgs84Base() {
+        return "BASEGEOGCRS[\"WGS 84\","
+            + "DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563]],"
+            + "UNIT[\"degree\",0.0174532925199433]]";
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/parser/MeridianAxisSerializationTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/MeridianAxisSerializationTest.java
@@ -1,5 +1,6 @@
 package org.datasyslab.proj4sedona.parser;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -44,7 +45,11 @@ class MeridianAxisSerializationTest {
         String jsonFromWkt = new Proj(wkt2).toProjJson(false);
         assertEquals(jsonFromWkt, new Proj(jsonFromWkt).toProjJson(false));
 
-        assertThrows(UnsupportedOperationException.class, proj::toWkt1);
+        UnsupportedOperationException wkt1Error = assertThrows(
+            UnsupportedOperationException.class, proj::toWkt1);
+        assertTrue(
+            wkt1Error.getMessage().contains("use toProjString instead"),
+            wkt1Error.getMessage());
         assertEquals("EPSG:" + code, proj.toEpsgCode());
     }
 
@@ -259,6 +264,47 @@ class MeridianAxisSerializationTest {
         assertEquals(Integer.toString(code), proj.toAuthority()[1]);
     }
 
+    @ParameterizedTest(name = "EPSG:{0}")
+    @MethodSource("ordinaryPolarCrs")
+    void ordinaryPolarAxesRemainExportableWithoutUnverifiedAuthority(int code) {
+        Proj reparsed = new Proj(new Proj("EPSG:" + code).toWkt2());
+
+        assertEquals("enu", reparsed.getParams().axis);
+        assertNull(reparsed.toAuthority());
+        assertDoesNotThrow(reparsed::toProjString);
+        assertDoesNotThrow(reparsed::toWkt1);
+        assertDoesNotThrow(reparsed::toWkt2);
+        assertFalse(
+            CRSSerializer.toProjJsonMap(reparsed.getParams()).containsKey("id"));
+    }
+
+    @Test
+    void malformedMeridianAxesDoNotAdvertiseAnUnavailableProjFallback() {
+        String definition = polarCrs(
+            6931,
+            "Lambert Azimuthal Equal Area",
+            naturalOriginParameters(90, 0),
+            axis(
+                "Easting", "X", "south", null,
+                "\"metre\"", null),
+            axis(
+                "Northing", "Y", "south", meridian(180),
+                "\"metre\"", null));
+        Proj proj = new Proj(definition);
+
+        UnsupportedOperationException projError = assertThrows(
+            UnsupportedOperationException.class, proj::toProjString);
+        UnsupportedOperationException wkt2Error = assertThrows(
+            UnsupportedOperationException.class, proj::toWkt2);
+
+        assertFalse(
+            projError.getMessage().contains("use toProjString instead"),
+            projError.getMessage());
+        assertFalse(
+            wkt2Error.getMessage().contains("use toProjString instead"),
+            wkt2Error.getMessage());
+    }
+
     private static Stream<Arguments> sedonaPolarCrs() {
         return Stream.of(
             Arguments.of(
@@ -343,6 +389,10 @@ class MeridianAxisSerializationTest {
                         "\"metre\"", null))));
     }
 
+    private static Stream<Arguments> ordinaryPolarCrs() {
+        return Stream.of(Arguments.of(5041), Arguments.of(5042));
+    }
+
     private static Stream<Arguments> invalidPolarMetadata() {
         String parameters = naturalOriginParameters(90, 0);
         String validEasting =
@@ -353,14 +403,6 @@ class MeridianAxisSerializationTest {
             + "\"conversion_factor\":0.3048}";
 
         return Stream.of(
-            Arguments.of(
-                "ordinary east/north directions omit required polar meridians",
-                polarCrs(
-                    6931,
-                    "Lambert Azimuthal Equal Area",
-                    parameters,
-                    axis("Easting", "X", "east", null, "\"metre\"", null),
-                    axis("Northing", "Y", "north", null, "\"metre\"", null))),
             Arguments.of(
                 "one meridian is missing",
                 polarCrs(

--- a/src/test/java/org/datasyslab/proj4sedona/parser/MeridianAxisSerializationTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/MeridianAxisSerializationTest.java
@@ -1,0 +1,532 @@
+package org.datasyslab.proj4sedona.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.CoordinateAxis;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MeridianAxisSerializationTest {
+
+    private static final double GRAD_TO_RAD = Math.PI / 200.0;
+
+    @ParameterizedTest(name = "EPSG:{0}")
+    @MethodSource("sedonaPolarCrs")
+    void roundTripsPolarAxesThroughBothStandardFormats(
+            int code, String definition, String compactAxis) {
+        Proj proj = new Proj(definition);
+
+        assertEquals(compactAxis, proj.getParams().axis);
+        assertEquals(2, proj.getParams().coordinateAxes.size());
+
+        String legacyProj = proj.toProjString();
+        assertFalse(legacyProj.contains("+axis="), legacyProj);
+
+        String wkt2 = proj.toWkt2();
+        assertTrue(wkt2.contains("MERIDIAN["), wkt2);
+        assertFalse(wkt2.contains(",]"), wkt2);
+        assertEquals(wkt2, new Proj(wkt2).toWkt2());
+
+        String projJson = proj.toProjJson(false);
+        assertTrue(projJson.contains("\"meridian\""), projJson);
+        assertEquals(projJson, new Proj(projJson).toProjJson(false));
+
+        String jsonFromWkt = new Proj(wkt2).toProjJson(false);
+        assertEquals(jsonFromWkt, new Proj(jsonFromWkt).toProjJson(false));
+
+        assertThrows(UnsupportedOperationException.class, proj::toWkt1);
+        assertEquals("EPSG:" + code, proj.toEpsgCode());
+    }
+
+    @Test
+    void preservesNonDegreeAxisMeridianUnits() {
+        String degreeLongitude = "\"meridian\":{\"longitude\":90}";
+        String gradLongitude =
+            "\"meridian\":{\"longitude\":{\"value\":100,\"unit\":{"
+                + "\"type\":\"AngularUnit\",\"name\":\"grad\","
+                + "\"conversion_factor\":" + GRAD_TO_RAD + "}}}";
+        String definition = polarCrs(
+            3031,
+            "Polar Stereographic (variant B)",
+            polarVariantBParameters(-71, 0),
+            axis("Easting", "E", "north", degreeLongitude, "\"metre\"", null),
+            axis("Northing", "N", "north", meridian(0), "\"metre\"", null))
+            .replace(degreeLongitude, gradLongitude);
+
+        Proj proj = new Proj(definition);
+        String wkt2 = proj.toWkt2();
+        String projJson = proj.toProjJson(false);
+
+        assertTrue(
+            wkt2.contains(
+                "MERIDIAN[100,ANGLEUNIT[\"grad\"," + GRAD_TO_RAD + "]]"),
+            wkt2);
+        assertTrue(projJson.contains("\"name\":\"grad\""), projJson);
+        assertEquals(wkt2, new Proj(wkt2).toWkt2());
+        assertEquals(projJson, new Proj(projJson).toProjJson(false));
+    }
+
+    @Test
+    void preservesCustomDegreeEquivalentMeridianUnitName() {
+        String customDegree =
+            "\"meridian\":{\"longitude\":{\"value\":90,\"unit\":{"
+                + "\"type\":\"AngularUnit\",\"name\":\"arc degree\","
+                + "\"conversion_factor\":" + Values.D2R + "}}}";
+        String definition = polarCrs(
+            3031,
+            "Polar Stereographic (variant B)",
+            polarVariantBParameters(-71, 0),
+            axis(
+                "Easting", "E", "north", customDegree,
+                "\"metre\"", null),
+            axis(
+                "Northing", "N", "north", meridian(0),
+                "\"metre\"", null));
+
+        String projJson = new Proj(definition).toProjJson(false);
+
+        assertTrue(projJson.contains("\"name\":\"arc degree\""), projJson);
+        assertEquals(projJson, new Proj(projJson).toProjJson(false));
+    }
+
+    @Test
+    void canonicalizesPublicModelUnitTypesInProjJson() {
+        Proj proj = new Proj(polarCrs(
+            6931,
+            "Lambert Azimuthal Equal Area",
+            naturalOriginParameters(90, 0),
+            axis(
+                "Easting", "E", "south", meridian(90),
+                "\"metre\"", null),
+            axis(
+                "Northing", "N", "south", meridian(180),
+                "\"metre\"", null)));
+        CoordinateAxis.Unit metre =
+            new CoordinateAxis.Unit(null, "metre", 1.0);
+        CoordinateAxis.Unit degree =
+            new CoordinateAxis.Unit("angularunit", "degree", Values.D2R);
+        proj.getParams().coordinateAxes = Arrays.asList(
+            new CoordinateAxis(
+                "Easting", "E", "south", null, metre,
+                new CoordinateAxis.Meridian(90.0, degree)),
+            new CoordinateAxis(
+                "Northing", "N", "south", null, metre,
+                new CoordinateAxis.Meridian(180.0, degree)));
+
+        String projJson = proj.toProjJson(false);
+
+        assertTrue(projJson.contains("\"type\":\"LinearUnit\""), projJson);
+        assertTrue(projJson.contains("\"type\":\"AngularUnit\""), projJson);
+        assertEquals(projJson, new Proj(projJson).toProjJson(false));
+    }
+
+    @Test
+    void retainsAuthorityFromPluralProjJsonIds() {
+        String definition = polarCrs(
+            3031,
+            "Polar Stereographic (variant B)",
+            polarVariantBParameters(-71, 0),
+            axis(
+                "Easting", "E", "north", meridian(90),
+                "\"metre\"", null),
+            axis(
+                "Northing", "N", "north", meridian(0),
+                "\"metre\"", null))
+            .replace(
+                "\"id\":{\"authority\":\"EPSG\",\"code\":3031}",
+                "\"ids\":[{\"authority\":\"EPSG\",\"code\":3031}]");
+
+        Proj proj = new Proj(definition);
+
+        assertEquals("EPSG:3031", proj.toEpsgCode());
+        assertTrue(proj.toProjJson(false).contains(
+            "\"id\":{\"authority\":\"EPSG\",\"code\":3031}"));
+    }
+
+    @Test
+    void derivesAxisRolesFromMeridiansInsteadOfDisplayLabels() {
+        String definition = polarCrs(
+            6931,
+            "Lambert Azimuthal Equal Area",
+            naturalOriginParameters(90, 0),
+            axis(
+                "First grid coordinate", "A", "south", meridian(90),
+                "\"metre\"", null),
+            axis(
+                "Second grid coordinate", "B", "south", meridian(180),
+                "\"metre\"", null));
+
+        Proj proj = new Proj(definition);
+        String wkt2 = proj.toWkt2();
+        String projJson = proj.toProjJson(false);
+
+        assertTrue(wkt2.contains("\"First grid coordinate (A)\""), wkt2);
+        assertTrue(wkt2.contains("\"Second grid coordinate (B)\""), wkt2);
+        assertTrue(projJson.contains("\"abbreviation\":\"A\""), projJson);
+        assertTrue(projJson.contains("\"abbreviation\":\"B\""), projJson);
+        assertEquals(wkt2, new Proj(wkt2).toWkt2());
+        assertEquals(projJson, new Proj(projJson).toProjJson(false));
+    }
+
+    @Test
+    void escapesRetainedAxisAndUnitLabelsInWkt2() {
+        String quotedMetre = "{\"type\":\"LinearUnit\","
+            + "\"name\":\"metre \\\"quoted\\\"\",\"conversion_factor\":1}";
+        String quotedDegree = "{\"type\":\"AngularUnit\","
+            + "\"name\":\"degree \\\"quoted\\\"\","
+            + "\"conversion_factor\":" + Values.D2R + "}";
+        String eastingMeridian =
+            "\"meridian\":{\"longitude\":{\"value\":90,\"unit\":"
+                + quotedDegree + "}}";
+        String definition = polarCrs(
+            6931,
+            "Lambert Azimuthal Equal Area",
+            naturalOriginParameters(90, 0),
+            axis(
+                "Easting \\\"quoted\\\"", "E", "south", eastingMeridian,
+                quotedMetre, null),
+            axis(
+                "Northing", "N", "south", meridian(180),
+                quotedMetre, null));
+
+        String wkt2 = new Proj(definition).toWkt2();
+
+        assertTrue(
+            wkt2.contains("AXIS[\"Easting \"\"quoted\"\" (E)\""),
+            wkt2);
+        assertTrue(wkt2.contains("LENGTHUNIT[\"metre \"\"quoted\"\"\",1"), wkt2);
+        assertTrue(
+            wkt2.contains("ANGLEUNIT[\"degree \"\"quoted\"\"\","),
+            wkt2);
+        assertEquals(wkt2, new Proj(wkt2).toWkt2());
+    }
+
+    @Test
+    void rejectsMeridianMetadataBeforeKrovakAxisSpecialCase() {
+        Proj proj = new Proj(
+            "+proj=krovak +ellps=bessel +units=m +axis=swu +no_defs");
+        CoordinateAxis.Unit metre =
+            new CoordinateAxis.Unit("LinearUnit", "metre", 1.0);
+        CoordinateAxis.Unit degree =
+            new CoordinateAxis.Unit("AngularUnit", "degree", Values.D2R);
+        proj.getParams().coordinateSystemType = "Cartesian";
+        proj.getParams().coordinateAxes = Arrays.asList(
+            new CoordinateAxis(
+                "Southing", "S", "south", 1, metre,
+                new CoordinateAxis.Meridian(0.0, degree)),
+            new CoordinateAxis(
+                "Westing", "W", "west", 2, metre, null));
+
+        assertThrows(UnsupportedOperationException.class, proj::toProjString);
+        assertThrows(UnsupportedOperationException.class, proj::toWkt1);
+        assertThrows(UnsupportedOperationException.class, proj::toWkt2);
+        assertThrows(UnsupportedOperationException.class, proj::toProjJson);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidPolarMetadata")
+    void rejectsMalformedPolarMetadataAtEveryExportBoundary(
+            String description, String definition) {
+        Proj proj = new Proj(definition);
+
+        assertNull(proj.toAuthority(), description);
+        assertThrows(
+            UnsupportedOperationException.class, proj::toProjString, description);
+        assertThrows(
+            UnsupportedOperationException.class, proj::toWkt2, description);
+        assertThrows(
+            UnsupportedOperationException.class, proj::toProjJson, description);
+    }
+
+    @ParameterizedTest(name = "EPSG:{0}")
+    @MethodSource("bundledUpsCrs")
+    void retainsBundledUpsAuthorityWithMeridianAxes(
+            int code, String definition) {
+        Proj proj = new Proj(definition);
+
+        assertEquals("EPSG:" + code, proj.toEpsgCode());
+        assertEquals("EPSG", proj.toAuthority()[0]);
+        assertEquals(Integer.toString(code), proj.toAuthority()[1]);
+    }
+
+    private static Stream<Arguments> sedonaPolarCrs() {
+        return Stream.of(
+            Arguments.of(
+                3031,
+                polarCrs(
+                    3031,
+                    "Polar Stereographic (variant B)",
+                    polarVariantBParameters(-71, 0),
+                    axis(
+                        "Easting", "E", "north", meridian(90),
+                        "\"metre\"", null),
+                    axis(
+                        "Northing", "N", "north", meridian(0),
+                        "\"metre\"", null)),
+                "nnu"),
+            Arguments.of(
+                32661,
+                polarCrs(
+                    32661,
+                    "Polar Stereographic (variant A)",
+                    polarVariantAParameters(90, 0),
+                    axis(
+                        "Northing", "N", "south", meridian(180),
+                        "\"metre\"", null),
+                    axis(
+                        "Easting", "E", "south", meridian(90),
+                        "\"metre\"", null)),
+                "ssu"),
+            Arguments.of(
+                3413,
+                polarCrs(
+                    3413,
+                    "Polar Stereographic (variant B)",
+                    polarVariantBParameters(70, -45),
+                    axis(
+                        "Easting", "X", "south", meridian(45),
+                        "\"metre\"", null),
+                    axis(
+                        "Northing", "Y", "south", meridian(135),
+                        "\"metre\"", null)),
+                "ssu"),
+            Arguments.of(
+                6931,
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    naturalOriginParameters(90, 0),
+                    axis(
+                        "Easting", "X", "south", meridian(90),
+                        "\"metre\"", null),
+                    axis(
+                        "Northing", "Y", "south", meridian(180),
+                        "\"metre\"", null)),
+                "ssu"));
+    }
+
+    private static Stream<Arguments> bundledUpsCrs() {
+        return Stream.of(
+            Arguments.of(
+                5041,
+                polarCrs(
+                    5041,
+                    "Polar Stereographic (variant A)",
+                    polarVariantAParameters(90, 0),
+                    axis(
+                        "Easting", "E", "south", meridian(90),
+                        "\"metre\"", null),
+                    axis(
+                        "Northing", "N", "south", meridian(180),
+                        "\"metre\"", null))),
+            Arguments.of(
+                5042,
+                polarCrs(
+                    5042,
+                    "Polar Stereographic (variant A)",
+                    polarVariantAParameters(-90, 0),
+                    axis(
+                        "Easting", "E", "north", meridian(90),
+                        "\"metre\"", null),
+                    axis(
+                        "Northing", "N", "north", meridian(0),
+                        "\"metre\"", null))));
+    }
+
+    private static Stream<Arguments> invalidPolarMetadata() {
+        String parameters = naturalOriginParameters(90, 0);
+        String validEasting =
+            axis("Easting", "X", "south", meridian(90), "\"metre\"", null);
+        String validNorthing =
+            axis("Northing", "Y", "south", meridian(180), "\"metre\"", null);
+        String foot = "{\"type\":\"LinearUnit\",\"name\":\"foot\","
+            + "\"conversion_factor\":0.3048}";
+
+        return Stream.of(
+            Arguments.of(
+                "ordinary east/north directions omit required polar meridians",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    axis("Easting", "X", "east", null, "\"metre\"", null),
+                    axis("Northing", "Y", "north", null, "\"metre\"", null))),
+            Arguments.of(
+                "one meridian is missing",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    axis("Easting", "X", "south", null, "\"metre\"", null),
+                    validNorthing)),
+            Arguments.of(
+                "easting meridian disagrees with the projection origin",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    axis(
+                        "Easting", "X", "south", meridian(91),
+                        "\"metre\"", null),
+                    validNorthing)),
+            Arguments.of(
+                "directions disagree with the pole hemisphere",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    axis(
+                        "Easting", "X", "north", meridian(90),
+                        "\"metre\"", null),
+                    axis(
+                        "Northing", "Y", "north", meridian(180),
+                        "\"metre\"", null))),
+            Arguments.of(
+                "both meridians identify the easting role",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    axis(
+                        "First", "A", "south", meridian(90),
+                        "\"metre\"", null),
+                    axis(
+                        "Second", "B", "south", meridian(90),
+                        "\"metre\"", null))),
+            Arguments.of(
+                "horizontal units disagree",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    axis(
+                        "Easting", "X", "south", meridian(90), foot, null),
+                    validNorthing)),
+            Arguments.of(
+                "ORDER is only present on one axis",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    axis(
+                        "Easting", "X", "south", meridian(90),
+                        "\"metre\"", 1),
+                    validNorthing)),
+            Arguments.of(
+                "coordinate system is not Cartesian",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    parameters,
+                    validEasting,
+                    validNorthing)
+                    .replace("\"subtype\":\"Cartesian\"",
+                        "\"subtype\":\"ellipsoidal\"")),
+            Arguments.of(
+                "periodic latitude alias is outside the valid pole range",
+                polarCrs(
+                    6931,
+                    "Lambert Azimuthal Equal Area",
+                    naturalOriginParameters(270, 0),
+                    validEasting,
+                    validNorthing)));
+    }
+
+    private static String polarCrs(
+            int code,
+            String method,
+            String parameters,
+            String firstAxis,
+            String secondAxis) {
+        return "{"
+            + "\"type\":\"ProjectedCRS\","
+            + "\"name\":\"EPSG:" + code + "\","
+            + "\"base_crs\":{"
+            + "\"type\":\"GeographicCRS\","
+            + "\"name\":\"WGS 84\","
+            + "\"datum\":{"
+            + "\"type\":\"GeodeticReferenceFrame\","
+            + "\"name\":\"World Geodetic System 1984\","
+            + "\"ellipsoid\":{"
+            + "\"name\":\"WGS 84\","
+            + "\"semi_major_axis\":6378137,"
+            + "\"inverse_flattening\":298.257223563}}},"
+            + "\"conversion\":{"
+            + "\"name\":\"unnamed\","
+            + "\"method\":{\"name\":\"" + method + "\"},"
+            + "\"parameters\":[" + parameters + "]},"
+            + "\"coordinate_system\":{"
+            + "\"subtype\":\"Cartesian\","
+            + "\"axis\":[" + firstAxis + "," + secondAxis + "]},"
+            + "\"id\":{\"authority\":\"EPSG\",\"code\":" + code + "}}";
+    }
+
+    private static String polarVariantAParameters(
+            double latitude, double longitude) {
+        return naturalOriginAngles(latitude, longitude)
+            + ",{\"name\":\"Scale factor at natural origin\","
+            + "\"value\":0.994,\"unit\":\"unity\"}"
+            + ",{\"name\":\"False easting\",\"value\":2000000,"
+            + "\"unit\":\"metre\"}"
+            + ",{\"name\":\"False northing\",\"value\":2000000,"
+            + "\"unit\":\"metre\"}";
+    }
+
+    private static String polarVariantBParameters(
+            double latitudeOfStandardParallel, double longitude) {
+        return "{\"name\":\"Latitude of standard parallel\","
+            + "\"value\":" + latitudeOfStandardParallel + ",\"unit\":\"degree\"},"
+            + angularParameter("Longitude of origin", longitude)
+            + ",{\"name\":\"False easting\",\"value\":0,\"unit\":\"metre\"}"
+            + ",{\"name\":\"False northing\",\"value\":0,\"unit\":\"metre\"}";
+    }
+
+    private static String naturalOriginParameters(
+            double latitude, double longitude) {
+        return naturalOriginAngles(latitude, longitude)
+            + ",{\"name\":\"False easting\",\"value\":0,\"unit\":\"metre\"}"
+            + ",{\"name\":\"False northing\",\"value\":0,\"unit\":\"metre\"}";
+    }
+
+    private static String naturalOriginAngles(
+            double latitude, double longitude) {
+        return angularParameter("Latitude of natural origin", latitude)
+            + "," + angularParameter("Longitude of natural origin", longitude);
+    }
+
+    private static String angularParameter(String name, double value) {
+        return "{\"name\":\"" + name + "\",\"value\":" + value
+            + ",\"unit\":\"degree\"}";
+    }
+
+    private static String axis(
+            String name,
+            String abbreviation,
+            String direction,
+            String meridian,
+            String unit,
+            Integer order) {
+        return "{"
+            + "\"name\":\"" + name + "\","
+            + "\"abbreviation\":\"" + abbreviation + "\","
+            + "\"direction\":\"" + direction + "\","
+            + (meridian != null ? meridian + "," : "")
+            + "\"unit\":" + unit
+            + (order != null ? ",\"order\":" + order : "")
+            + "}";
+    }
+
+    private static String meridian(double longitude) {
+        return "\"meridian\":{\"longitude\":" + longitude + "}";
+    }
+}

--- a/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/WktParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
 import org.datasyslab.proj4sedona.constants.Values;
 import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
 import org.datasyslab.proj4sedona.core.ProjectionDef;
 
 import java.util.HashMap;
@@ -374,6 +375,43 @@ class WktParserTest {
         assertEquals("longlat", def.getProjName());
         assertEquals(6378137.0, def.getA(), 0.1);
         assertEquals(298.257223563, def.getRf(), 1e-6);
+    }
+
+    @Test
+    @DisplayName("Parse PROJJSON ellipsoid radius with an explicit length unit")
+    void testParseProjJsonRadiusWithUnit() {
+        String projjson = "{"
+            + "\"type\":\"GeographicCRS\","
+            + "\"datum\":{\"ellipsoid\":{"
+            + "\"name\":\"Sphere\","
+            + "\"radius\":{\"value\":6371.228,\"unit\":{"
+            + "\"type\":\"LinearUnit\",\"name\":\"kilometre\","
+            + "\"conversion_factor\":1000}}}}}";
+
+        Proj proj = new Proj(projjson);
+
+        assertEquals(6371228.0, proj.getA(), 0.0);
+        assertEquals(6371228.0, proj.getB(), 0.0);
+    }
+
+    @Test
+    @DisplayName("Parse PROJJSON ellipsoid semi-minor axis with an explicit length unit")
+    void testParseProjJsonSemiMinorAxisWithUnit() {
+        String projjson = "{"
+            + "\"type\":\"GeographicCRS\","
+            + "\"datum\":{\"ellipsoid\":{"
+            + "\"name\":\"WGS 84\","
+            + "\"semi_major_axis\":{\"value\":6378.137,\"unit\":{"
+            + "\"type\":\"LinearUnit\",\"name\":\"kilometre\","
+            + "\"conversion_factor\":1000}},"
+            + "\"semi_minor_axis\":{\"value\":6356.752314245,\"unit\":{"
+            + "\"type\":\"LinearUnit\",\"name\":\"kilometre\","
+            + "\"conversion_factor\":1000}}}}}";
+
+        Proj proj = new Proj(projjson);
+
+        assertEquals(6378137.0, proj.getA(), 0.0);
+        assertEquals(6356752.314245, proj.getB(), 1e-6);
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/projection/AllProjectionsTest.java
@@ -133,6 +133,50 @@ class AllProjectionsTest {
     void testLAEARegisteredNames() {
         assertNotNull(ProjectionRegistry.get("laea"));
         assertNotNull(ProjectionRegistry.get("Lambert_Azimuthal_Equal_Area"));
+        assertEquals(
+            "laea",
+            ProjectionRegistry.resolveProjCode(
+                "Lambert Azimuthal Equal Area (Spherical)"));
+    }
+
+    @Test
+    void testSphericalLAEAMatchesProjAtBothPoles() {
+        // pyproj 3.7.1 / PROJ 9.5.1, using EPSG:3408 and EPSG:3409
+        // (sphere radius 6,371,228 metres).
+        double[][] inputs = {
+            {-45, 80}, {30, 75}, {-120, -80}, {40, -70}
+        };
+        double[][] northExpected = {
+            {-785297.3883560896, -785297.3883560897},
+            {831612.1306057743, -1440394.4623998066},
+            {-10993297.990217209, 6346983.553933673},
+            {8066257.80524404, -9612991.718190672}
+        };
+        double[][] southExpected = {
+            {-8975990.22213199, 8975990.222131992},
+            {6316721.261240939, 10940882.161719866},
+            {-961788.9489063293, -555289.1085546761},
+            {1422298.8844147713, 1695029.8052440411}
+        };
+
+        assertSphericalLaeaMatchesReference(90, inputs, northExpected);
+        assertSphericalLaeaMatchesReference(-90, inputs, southExpected);
+    }
+
+    private static void assertSphericalLaeaMatchesReference(
+            double latitudeOfOrigin,
+            double[][] inputs,
+            double[][] expected) {
+        Converter converter = Proj4.proj4(
+            "+proj=longlat +R=6371228 +no_defs",
+            "+proj=laea +lat_0=" + latitudeOfOrigin
+                + " +lon_0=0 +x_0=0 +y_0=0 +R=6371228 +units=m +no_defs");
+        for (int i = 0; i < inputs.length; i++) {
+            Point projected =
+                converter.forward(new Point(inputs[i][0], inputs[i][1]));
+            assertEquals(expected[i][0], projected.x, 1e-8);
+            assertEquals(expected[i][1], projected.y, 1e-8);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- retain typed coordinate-axis metadata from WKT2 and PROJJSON
- round-trip meridian-qualified polar axes through WKT2 and PROJJSON
- validate meridian-qualified polar axis pairs before authority recovery or export
- keep legacy behavior explicit: validated pairs omit `+axis` in PROJ output, while WKT1 rejects metadata it cannot represent
- add exhaustive pyproj-generated coverage for every EPSG CRS currently using axis meridians

## Motivation

A compact PROJ `+axis` value can describe direction permutations, but it cannot distinguish two polar axes that point in the same direction and are qualified by different meridians. The parser previously reduced these definitions to the compact representation and discarded the information required to reconstruct valid WKT2 or PROJJSON.

This change carries the standard-format metadata alongside the operational axis value. Exporters reproduce the retained axis names, abbreviations, directions, order, units, and meridians. Strict preflight validation prevents malformed retained metadata from being authorized or serialized.

The exhaustive sweep also exposed two adjacent format gaps needed by real meridian-axis CRSs: PROJJSON spherical ellipsoids now round-trip through `radius`, and the spherical Lambert Azimuthal Equal Area method spelling is recognized.

## Review fixes

- keep authority trust separate from serialization: ordinary polar axes remain exportable, while an unverified polar identifier is omitted
- accept an executable `ProjectedCRS` without `coordinate_system`, matching main and proj4js
- advertise `toProjString()` as a fallback only where it actually succeeds
- pin the EPSG:5041 and EPSG:5042 self-round trips and the sparse UTM transformation with regression tests

## Validation

- `mvn verify -Pbenchmarks`: 1,145 tests passed
- generated meridian-axis parity: 408 outcomes accounted for
  - 396 comparisons passed
  - 12 explicit skips for EPSG:2985 and EPSG:2986 because Polar Stereographic variant C is not implemented
  - parser parity still passes for both skipped CRSs from WKT2 and PROJJSON
- installed PROJ accepted all 147 generated WKT2/PROJJSON artifacts for the 49 supported CRSs
- numeric round trips through PROJ were exact, including axis order with native axis handling enabled
- Apache Sedona current master with this local 0.1.3 build:
  - `FunctionsProj4Test`: 43/43 passed
  - `CRSTransformProj4Test`: 36/36 passed
  - `CrsRoundTripComplianceTest`: 80/81 unchanged; the remaining test expects EPSG:2163 PROJJSON re-import to fail
  - replacing that obsolete negative assertion with the positive round-trip assertion gives 81/81

## Sedona adoption note

The EPSG:2163 behavior is an intentional improvement: spherical PROJJSON now re-imports successfully. Sedona should update `testProjJsonRoundTrip_LambertAzimuthalEqualArea_Spherical_2163_importFails` to use its normal positive PROJJSON round-trip helper when it adopts this version.

## Axis-enforcement note

For EPSG:3031 parsed from WKT2, the operational axis changes from the previous accidental `enu` result to the standards-correct `nnu`. Default transformations are numerically unchanged. The existing `enforceAxis=true` path does not support duplicate-direction `nnu`/`ssu` axes; callers should continue to leave axis enforcement disabled for these polar CRSs until that separate transform limitation is addressed.
