### PR TITLE
Snap polar latitude of origin in PROJ output

### DIFF
--- a/docs/crs-formats.md
+++ b/docs/crs-formats.md
@@ -235,6 +235,12 @@ String[] auth = proj.toAuthority();   // {"EPSG", "32618"}
 No single export is lossless for every supported definition. `toProjString()`
 preserves PROJ-specific operation parameters that WKT1, WKT2, and PROJJSON cannot
 encode, but legacy PROJ CRS strings cannot preserve all standard CRS metadata.
+For polar origins affected only by angular-unit conversion noise,
+`toProjString()` emits an exact `+lat_0=90` or `+lat_0=-90` because PROJ rejects
+values outside that range. WKT2 and PROJJSON preserve the parsed value instead,
+since those formats have no equivalent restriction; the in-memory latitude is
+not normalized.
+
 For example, WKT2 and PROJJSON can distinguish two polar horizontal axes using
 meridian metadata, while `+axis` cannot represent two axes that both point north
 or south. Proj4Sedona retains each such axis's name, abbreviation, direction,

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -3766,6 +3766,11 @@ public final class CRSSerializer {
      * Convert {@code +lat_0} to degrees while removing only pole-sized conversion
      * noise. PROJ's rounded degree conversion factor can move a parsed pole by a
      * few ULPs, and PROJ rejects the resulting value just outside ±90 degrees.
+     *
+     * <p>This is deliberately an output-only normalization. Snapping during
+     * parsing would mutate user-supplied data and change the value exposed by
+     * {@code getParams().lat0}; WKT2 and PROJJSON can preserve that parsed value
+     * without producing an invalid definition.</p>
      */
     private static double projLatitudeOfOriginDegrees(double radians) {
         if (Double.isFinite(radians)

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -45,6 +45,8 @@ public final class CRSSerializer {
     private static final double DEG_TO_RAD = Math.PI / 180.0;
     private static final double ARC_SECOND_TO_RAD = DEG_TO_RAD / 3600.0;
     private static final double PARTS_PER_MILLION_TO_SCALE = 1e-6;
+    private static final double POLE_SERIALIZATION_TOLERANCE =
+        4.0 * Math.ulp(Values.HALF_PI);
     private static final String DEG_TO_RAD_STR = Double.toString(DEG_TO_RAD);
     private static final String TOWGS84_TRANSFORMATION_NAME = "Transformation to WGS 84";
 
@@ -261,7 +263,8 @@ public final class CRSSerializer {
         if (isKrovak) {
             sb.append(" +lat_0=").append(formatAngle(krovakLatitudeOfCentre(params) * RAD_TO_DEG));
         } else if (params.lat0 != null && params.lat0 != 0.0) {
-            sb.append(" +lat_0=").append(formatAngle(params.lat0 * RAD_TO_DEG));
+            sb.append(" +lat_0=").append(formatAngle(
+                projLatitudeOfOriginDegrees(params.lat0)));
         }
 
         // Central meridian
@@ -3757,6 +3760,20 @@ public final class CRSSerializer {
             return String.valueOf((int) degrees);
         }
         return String.valueOf(degrees);
+    }
+
+    /**
+     * Convert {@code +lat_0} to degrees while removing only pole-sized conversion
+     * noise. PROJ's rounded degree conversion factor can move a parsed pole by a
+     * few ULPs, and PROJ rejects the resulting value just outside ±90 degrees.
+     */
+    private static double projLatitudeOfOriginDegrees(double radians) {
+        if (Double.isFinite(radians)
+                && Math.abs(Math.abs(radians) - Values.HALF_PI)
+                    <= POLE_SERIALIZATION_TOLERANCE) {
+            return Math.copySign(90.0, radians);
+        }
+        return radians * RAD_TO_DEG;
     }
 
     private static String formatNumber(double value) {

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
@@ -212,6 +212,50 @@ class CRSSerializerRoundTripSafetyTest {
     }
 
     @Test
+    void standardPolarRoundTripsEmitAnExactProjLatitudeOfOrigin() {
+        for (int pole : new int[]{-90, 90}) {
+            Proj original = new Proj(
+                "+proj=stere +lat_0=" + pole
+                    + " +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 "
+                    + "+datum=WGS84 +units=m +no_defs");
+            // PROJ 9.x writes this rounded degree conversion factor in both
+            // standards, producing a few ULPs of drift when the pole is parsed.
+            String projDegreeFactor = "0.0174532925199433";
+            String sourceWkt2 = CRSSerializer.toWkt2(original).replace(
+                Double.toString(Math.PI / 180.0), projDegreeFactor);
+            String sourceProjJson = CRSSerializer.toProjJson(original, false)
+                .replace(
+                    Double.toString(Math.PI / 180.0), projDegreeFactor);
+            assertTrue(sourceWkt2.contains(projDegreeFactor), sourceWkt2);
+            assertTrue(sourceProjJson.contains(projDegreeFactor), sourceProjJson);
+
+            String fromWkt2 = new Proj(sourceWkt2).toProjString();
+            String fromProjJson = new Proj(sourceProjJson).toProjString();
+
+            assertEquals(Integer.toString(pole),
+                projParameter(fromWkt2, "lat_0"), fromWkt2);
+            assertEquals(Integer.toString(pole),
+                projParameter(fromProjJson, "lat_0"), fromProjJson);
+        }
+    }
+
+    @Test
+    void genuineNearPoleLatitudeIsNotSnappedDuringProjSerialization() {
+        Proj projected = new Proj(
+            "+proj=stere +lat_0=90 +datum=WGS84 +units=m +no_defs");
+        double latitude = Math.PI / 2.0 - 1e-12;
+        projected.getParams().lat0 = latitude;
+
+        String serialized = CRSSerializer.toProjString(projected);
+        double serializedDegrees = Double.parseDouble(
+            projParameter(serialized, "lat_0"));
+
+        assertEquals(latitude * 180.0 / Math.PI, serializedDegrees, 0.0,
+            serialized);
+        assertTrue(serializedDegrees < 90.0, serialized);
+    }
+
+    @Test
     void geographicProjectionAliasesUseGeographicStandardRoots() {
         for (String alias : new String[]{"identity", "LongLat"}) {
             Proj original = new Proj(
@@ -369,6 +413,17 @@ class CRSSerializerRoundTripSafetyTest {
         assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toWkt1(proj));
         assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toWkt2(proj));
         assertThrows(UnsupportedOperationException.class, () -> CRSSerializer.toProjJson(proj));
+    }
+
+    private static String projParameter(String projString, String name) {
+        String prefix = "+" + name + "=";
+        for (String token : projString.split("\\s+")) {
+            if (token.startsWith(prefix)) {
+                return token.substring(prefix.length());
+            }
+        }
+        fail("Missing " + prefix + " in " + projString);
+        return null;
     }
 
 }


### PR DESCRIPTION
## Summary

- Snap serialization noise within four ULPs of either pole when writing the non-Krovak PROJ `+lat_0` parameter.
- Keep genuine near-pole latitudes, Krovak output, WKT2, PROJJSON, and every other angular parameter unchanged.
- Add north/south regressions for PROJ-style WKT2 and PROJJSON angular-unit factors.

## Why

PROJ 9.x writes the rounded degree conversion factor `0.0174532925199433`.
Parsing a latitude of origin at either pole through WKT2 or PROJJSON can therefore
produce `+lat_0=90.00000000000003` (or its southern equivalent). PROJ rejects a
latitude of origin outside ±90 degrees, so the resulting PROJ string is not
executable.

The fix recognizes only floating-point conversion noise immediately around
±π/2. The four-ULP window is approximately `5.1e-14` degrees.

## Impact

Polar CRS definitions can round-trip from WKT2 or PROJJSON to an executable PROJ
string without changing projection math or rounding legitimate near-pole input.

## Validation

- `mvn verify -Pbenchmarks`: 1,147 tests passed.
- The regression fails on `main` with `±90.00000000000003`.
- PROJ 9.5.1 accepts the corrected north/south definitions and rejects the old
  out-of-range form.
