### PR TITLE
Honor meridian-qualified polar axes during enforced transforms

### DIFF
--- a/docs/coordinate-transformations.md
+++ b/docs/coordinate-transformations.md
@@ -184,6 +184,14 @@ Point result1 = conv.forward(new Point(-77.0, 38.9));
 Point result2 = conv.forward(new Point(38.9, -77.0), true);
 ```
 
+Polar CRSs can declare both horizontal axes with the same `north` or `south`
+direction and qualify each one by a meridian. When such metadata is retained
+from WKT2 or PROJJSON, `enforceAxis=true` uses the meridians to distinguish
+easting from northing, including northing-first UPS definitions. The default
+`enforceAxis=false` behavior remains traditional easting/northing order.
+Malformed or incomplete duplicate-direction metadata cannot be enforced and
+causes the transformation to fail instead of silently dropping a coordinate.
+
 ## Choosing the Right Method
 
 | Method | Best for | Notes |

--- a/docs/crs-formats.md
+++ b/docs/crs-formats.md
@@ -252,10 +252,14 @@ supplied in raw PROJ input, incomplete or inconsistent meridian metadata, and al
 other invalid axis permutations are rejected with
 `UnsupportedOperationException`.
 
-The retained meridians are CRS serialization metadata. Coordinate transforms keep
-proj4js-compatible axis behavior and do not interpret meridians; callers should
-leave axis enforcement disabled for `nnu` and `ssu`. Ordinary valid PROJ axis
-permutations such as `enu` and `neu` are unchanged.
+The retained meridians also make duplicate-direction polar axes enforceable.
+With `enforceAxis=true`, coordinate transforms resolve each `nnu` or `ssu`
+horizontal coordinate to its positive easting or northing role from the axis
+meridian and projection origin. This supports both easting-first and
+northing-first definitions without treating the shared north/south direction as
+a sign inversion. Missing, malformed, or drifted metadata fails safely instead
+of dropping a coordinate. The default `enforceAxis=false` behavior and ordinary
+valid PROJ permutations such as `enu` and `neu` are unchanged.
 
 When a standard export would silently change coordinates, Proj4Sedona throws
 `UnsupportedOperationException` and, where the definition is representable in a

--- a/src/main/java/org/datasyslab/proj4sedona/common/MeridianAxisResolver.java
+++ b/src/main/java/org/datasyslab/proj4sedona/common/MeridianAxisResolver.java
@@ -31,8 +31,7 @@ public final class MeridianAxisResolver {
      */
     public static boolean requiresResolution(ProjectionParams params) {
         String axis = effectiveAxis(params);
-        return hasMeridianMetadata(params)
-            || "nnu".equals(axis)
+        return "nnu".equals(axis)
             || "ssu".equals(axis);
     }
 

--- a/src/main/java/org/datasyslab/proj4sedona/common/MeridianAxisResolver.java
+++ b/src/main/java/org/datasyslab/proj4sedona/common/MeridianAxisResolver.java
@@ -1,0 +1,331 @@
+package org.datasyslab.proj4sedona.common;
+
+import java.util.List;
+import java.util.Locale;
+import org.datasyslab.proj4sedona.constants.Units;
+import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.core.CoordinateAxis;
+import org.datasyslab.proj4sedona.projection.ProjectionParams;
+
+/**
+ * Validates meridian-qualified polar axes and resolves their coordinate roles.
+ *
+ * <p>A compact PROJ axis string cannot distinguish two horizontal axes that
+ * both point north or both point south. The retained WKT2/PROJJSON meridians do:
+ * relative to the projection's central meridian, they identify which native
+ * coordinate is easting and which is northing. This class is the shared policy
+ * used by both serialization and optional axis enforcement.</p>
+ */
+public final class MeridianAxisResolver {
+
+    private MeridianAxisResolver() {
+        // Utility class.
+    }
+
+    /**
+     * Whether the CRS needs its retained meridian metadata resolved.
+     *
+     * <p>Ordinary coordinate-axis metadata alone does not trigger this path.
+     * This keeps conventional polar CRSs, whose axes are representable as a
+     * normal PROJ permutation, on the ordinary axis-handling path.</p>
+     */
+    public static boolean requiresResolution(ProjectionParams params) {
+        String axis = effectiveAxis(params);
+        return hasMeridianMetadata(params)
+            || "nnu".equals(axis)
+            || "ssu".equals(axis);
+    }
+
+    /** Return whether at least one retained horizontal axis has a meridian. */
+    public static boolean hasMeridianMetadata(ProjectionParams params) {
+        if (params.coordinateAxes == null) {
+            return false;
+        }
+        for (CoordinateAxis axis : params.coordinateAxes) {
+            if (axis != null && axis.getMeridian() != null) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Resolve using the compact axis value stored on the projection. */
+    public static Resolution resolve(ProjectionParams params) {
+        return resolve(params, effectiveAxis(params));
+    }
+
+    /**
+     * Validate and resolve a duplicate-direction polar axis definition.
+     *
+     * @param params projection parameters containing retained axis metadata
+     * @param axisOrder compact PROJ axis string to verify against the metadata
+     * @return a valid conventional permutation, or a descriptive validation error
+     */
+    public static Resolution resolve(
+            ProjectionParams params, String axisOrder) {
+        String normalizedAxis = axisOrder == null
+            ? "enu" : axisOrder.toLowerCase(Locale.ROOT);
+        if (!"nnu".equals(normalizedAxis) && !"ssu".equals(normalizedAxis)) {
+            return Resolution.invalid(
+                "Meridian-qualified axes require two matching north or south directions");
+        }
+        List<CoordinateAxis> axes = params.coordinateAxes;
+        if (axes == null || axes.size() != 2) {
+            return Resolution.invalid(
+                "Axis " + normalizedAxis
+                    + " requires two retained meridian-qualified horizontal axes");
+        }
+        if (params.coordinateSystemType == null
+                || !"Cartesian".equalsIgnoreCase(params.coordinateSystemType)) {
+            return Resolution.invalid(
+                "Meridian-qualified projected axes require a Cartesian coordinate system");
+        }
+        if (!isPolarLatitude(params.lat0)) {
+            return Resolution.invalid(
+                "Meridian-qualified horizontal axes require a polar latitude of origin");
+        }
+
+        boolean northPole = params.lat0 > 0.0;
+        String expectedDirection = northPole ? "south" : "north";
+        boolean anyOrder = false;
+        boolean allOrder = true;
+        Role firstRole = null;
+        Role secondRole = null;
+        double expectedLinearFactor;
+        try {
+            expectedLinearFactor = projectedUnitToMeter(params);
+        } catch (IllegalArgumentException error) {
+            return Resolution.invalid(error.getMessage());
+        }
+
+        for (int i = 0; i < axes.size(); i++) {
+            CoordinateAxis coordinateAxis = axes.get(i);
+            if (coordinateAxis == null || coordinateAxis.getDirection() == null
+                    || !expectedDirection.equalsIgnoreCase(
+                        coordinateAxis.getDirection())) {
+                return Resolution.invalid(
+                    "Polar axis directions must both be " + expectedDirection
+                        + " at the " + (northPole ? "north" : "south") + " pole");
+            }
+
+            char parsedDirection =
+                mapStandardAxisDirection(coordinateAxis.getDirection());
+            if (parsedDirection != normalizedAxis.charAt(i)) {
+                return Resolution.invalid(
+                    "Retained coordinate-axis order does not match axis "
+                        + normalizedAxis);
+            }
+
+            Integer order = coordinateAxis.getOrder();
+            anyOrder |= order != null;
+            allOrder &= order != null;
+            if (order != null && order != i + 1) {
+                return Resolution.invalid(
+                    "WKT axis ORDER must match its position in the coordinate system");
+            }
+
+            CoordinateAxis.Unit linearUnit = coordinateAxis.getUnit();
+            String linearUnitError = validateCoordinateAxisUnit(
+                linearUnit, "LinearUnit", "horizontal axis");
+            if (linearUnitError != null) {
+                return Resolution.invalid(linearUnitError);
+            }
+            double linearFactor = linearUnit.getConversionFactor();
+            if (!sameUnitFactor(linearFactor, expectedLinearFactor)) {
+                return Resolution.invalid(
+                    "Horizontal-axis units must match the projected CRS unit");
+            }
+
+            CoordinateAxis.Meridian meridian = coordinateAxis.getMeridian();
+            if (meridian == null || !Double.isFinite(meridian.getLongitude())) {
+                return Resolution.invalid(
+                    "Each duplicate polar axis requires a finite meridian");
+            }
+            String angularUnitError = validateCoordinateAxisUnit(
+                meridian.getUnit(), "AngularUnit", "axis meridian");
+            if (angularUnitError != null) {
+                return Resolution.invalid(angularUnitError);
+            }
+
+            Role role = role(params, coordinateAxis);
+            if (role == Role.UNKNOWN) {
+                return Resolution.invalid(
+                    "Axis meridians must identify one easting and one northing axis");
+            }
+            if (i == 0) {
+                firstRole = role;
+            } else {
+                secondRole = role;
+            }
+        }
+
+        if (anyOrder != allOrder) {
+            return Resolution.invalid(
+                "WKT axis ORDER must be present on every axis or none");
+        }
+        if (firstRole == secondRole) {
+            return Resolution.invalid(
+                "Polar axes must identify one easting and one northing axis");
+        }
+
+        char first = firstRole == Role.EASTING ? 'e' : 'n';
+        char second = secondRole == Role.EASTING ? 'e' : 'n';
+        return Resolution.valid(
+            new String(new char[]{first, second, normalizedAxis.charAt(2)}));
+    }
+
+    /**
+     * Determine an individual horizontal axis role from its meridian geometry.
+     *
+     * <p>The role is positive easting/northing; the duplicate north/south
+     * direction tokens describe polar geometry and are not sign inversions.</p>
+     */
+    public static Role role(
+            ProjectionParams params, CoordinateAxis axis) {
+        if (axis == null || axis.getMeridian() == null
+                || axis.getMeridian().getUnit() == null
+                || axis.getMeridian().getUnit().getConversionFactor() == null
+                || !isPolarLatitude(params.lat0)) {
+            return Role.UNKNOWN;
+        }
+        CoordinateAxis.Meridian meridian = axis.getMeridian();
+        double actual = meridian.getLongitude()
+            * meridian.getUnit().getConversionFactor();
+        if (!Double.isFinite(actual)) {
+            return Role.UNKNOWN;
+        }
+        double central = params.long0 != null ? params.long0 : 0.0;
+        double easting = central + Values.HALF_PI;
+        double northing = central + (params.lat0 > 0.0 ? Math.PI : 0.0);
+        boolean matchesEasting = sameLongitude(actual, easting);
+        boolean matchesNorthing = sameLongitude(actual, northing);
+        if (matchesEasting && !matchesNorthing) {
+            return Role.EASTING;
+        }
+        if (matchesNorthing && !matchesEasting) {
+            return Role.NORTHING;
+        }
+        return Role.UNKNOWN;
+    }
+
+    /** Whether a latitude in radians denotes either pole within library tolerance. */
+    public static boolean isPolarLatitude(Double latitude) {
+        return latitude != null
+            && Double.isFinite(latitude)
+            && Math.abs(Math.abs(latitude) - Values.HALF_PI) <= Values.EPSLN;
+    }
+
+    /**
+     * Resolve the projected linear-unit factor using the same precedence as CRS
+     * serialization and meridian-axis validation.
+     */
+    public static double projectedUnitToMeter(ProjectionParams params) {
+        double toMeter;
+        if (params.units != null) {
+            Double registered = Units.getToMeter(params.units);
+            if (registered != null) {
+                toMeter = registered;
+            } else {
+                toMeter = params.toMeter != null ? params.toMeter : 1.0;
+            }
+        } else {
+            toMeter = params.toMeter != null ? params.toMeter : 1.0;
+        }
+        if (!Double.isFinite(toMeter) || toMeter <= 0.0) {
+            throw new IllegalArgumentException(
+                "Linear unit conversion factor must be finite and greater than zero: "
+                    + toMeter);
+        }
+        return toMeter;
+    }
+
+    private static String effectiveAxis(ProjectionParams params) {
+        return params.axis != null
+            ? params.axis.toLowerCase(Locale.ROOT) : "enu";
+    }
+
+    private static String validateCoordinateAxisUnit(
+            CoordinateAxis.Unit unit, String expectedType, String label) {
+        if (unit == null || unit.getConversionFactor() == null
+                || !Double.isFinite(unit.getConversionFactor())
+                || unit.getConversionFactor() <= 0.0) {
+            return "The " + label + " requires a positive finite unit factor";
+        }
+        if (unit.getType() != null
+                && !expectedType.equalsIgnoreCase(unit.getType())) {
+            return "The " + label + " must use a " + expectedType;
+        }
+        if (unit.getName() == null || unit.getName().trim().isEmpty()) {
+            return "The " + label + " requires a unit name";
+        }
+        return null;
+    }
+
+    private static boolean sameUnitFactor(double left, double right) {
+        return Math.abs(left - right)
+            <= 1e-12 * Math.max(Math.max(Math.abs(left), Math.abs(right)), 1.0);
+    }
+
+    private static boolean sameLongitude(double left, double right) {
+        return Math.abs(Math.IEEEremainder(left - right, 2.0 * Math.PI))
+            <= Values.EPSLN;
+    }
+
+    private static char mapStandardAxisDirection(String direction) {
+        if ("north".equalsIgnoreCase(direction)) {
+            return 'n';
+        }
+        if ("south".equalsIgnoreCase(direction)) {
+            return 's';
+        }
+        if ("east".equalsIgnoreCase(direction)) {
+            return 'e';
+        }
+        if ("west".equalsIgnoreCase(direction)) {
+            return 'w';
+        }
+        return '\0';
+    }
+
+    /** Geometric horizontal-coordinate role. */
+    public enum Role {
+        EASTING,
+        NORTHING,
+        UNKNOWN
+    }
+
+    /** Validated conventional axis permutation or a validation error. */
+    public static final class Resolution {
+
+        private final String conventionalAxis;
+        private final String error;
+
+        private Resolution(String conventionalAxis, String error) {
+            this.conventionalAxis = conventionalAxis;
+            this.error = error;
+        }
+
+        private static Resolution valid(String conventionalAxis) {
+            return new Resolution(conventionalAxis, null);
+        }
+
+        private static Resolution invalid(String error) {
+            return new Resolution(null, error);
+        }
+
+        public boolean isValid() {
+            return error == null;
+        }
+
+        /**
+         * Return an ordinary PROJ permutation such as {@code enu} or {@code neu}.
+         */
+        public String getConventionalAxis() {
+            return conventionalAxis;
+        }
+
+        public String getError() {
+            return error;
+        }
+    }
+}

--- a/src/main/java/org/datasyslab/proj4sedona/core/CoordinateAxis.java
+++ b/src/main/java/org/datasyslab/proj4sedona/core/CoordinateAxis.java
@@ -5,10 +5,12 @@ import java.util.Objects;
 /**
  * Coordinate-system axis metadata retained from WKT2 and PROJJSON definitions.
  *
- * <p>The compact PROJ {@code +axis=} value remains the representation used by
- * coordinate transforms. This value object keeps the richer standard-format
- * metadata needed to reproduce axis definitions that cannot be expressed by a
- * PROJ axis permutation, such as polar axes qualified by meridians.</p>
+ * <p>The compact PROJ {@code +axis=} value remains the operational
+ * representation for ordinary coordinate systems. This value object keeps the
+ * richer standard-format metadata needed to reproduce axis definitions that
+ * cannot be expressed by a PROJ axis permutation. When axis enforcement is
+ * requested for meridian-qualified polar axes, their retained meridians also
+ * distinguish the easting and northing coordinate roles.</p>
  */
 public final class CoordinateAxis {
 

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -3382,7 +3382,8 @@ public final class CRSSerializer {
 
     private static boolean requiresMeridianAxisValidation(
             ProjectionParams params) {
-        return MeridianAxisResolver.requiresResolution(params);
+        return hasMeridianAxisMetadata(params)
+            || MeridianAxisResolver.requiresResolution(params);
     }
 
     private static boolean requiresMeridianAxisAuthorityValidation(

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -2,6 +2,8 @@ package org.datasyslab.proj4sedona.parser;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.datasyslab.proj4sedona.common.MeridianAxisResolver;
+import org.datasyslab.proj4sedona.common.MeridianAxisResolver.Role;
 import org.datasyslab.proj4sedona.common.ProjMath;
 import org.datasyslab.proj4sedona.constants.Datum;
 import org.datasyslab.proj4sedona.constants.Ellipsoid;
@@ -767,22 +769,7 @@ public final class CRSSerializer {
      * else metres.
      */
     private static double linearUnitToMeter(ProjectionParams params) {
-        double toMeter;
-        if (params.units != null) {
-            Double tm = Units.getToMeter(params.units);
-            if (tm != null) {
-                toMeter = tm;
-            } else {
-                toMeter = params.toMeter != null ? params.toMeter : 1.0;
-            }
-        } else {
-            toMeter = params.toMeter != null ? params.toMeter : 1.0;
-        }
-        if (!Double.isFinite(toMeter) || toMeter <= 0) {
-            throw new IllegalArgumentException(
-                "Linear unit conversion factor must be finite and greater than zero: " + toMeter);
-        }
-        return toMeter;
+        return MeridianAxisResolver.projectedUnitToMeter(params);
     }
 
     private static String linearUnitName(ProjectionParams params) {
@@ -1738,15 +1725,15 @@ public final class CRSSerializer {
 
     private static Map<String, Object> buildProjJsonCoordinateAxis(
             ProjectionParams params, CoordinateAxis axis) {
-        MeridianAxisRole role = meridianAxisRole(params, axis);
+        Role role = meridianAxisRole(params, axis);
         Map<String, Object> result = new LinkedHashMap<>();
         String name = axis.getName();
         if (name == null || name.trim().isEmpty()) {
-            name = role == MeridianAxisRole.EASTING ? "Easting" : "Northing";
+            name = role == Role.EASTING ? "Easting" : "Northing";
         }
         String abbreviation = axis.getAbbreviation();
         if (abbreviation == null || abbreviation.trim().isEmpty()) {
-            abbreviation = role == MeridianAxisRole.EASTING ? "E" : "N";
+            abbreviation = role == Role.EASTING ? "E" : "N";
         }
         result.put("name", name);
         result.put("abbreviation", abbreviation);
@@ -2404,13 +2391,13 @@ public final class CRSSerializer {
             return false;
         }
         for (int i = 0; i < 2; i++) {
-            MeridianAxisRole role =
+            Role role =
                 meridianAxisRole(params, params.coordinateAxes.get(i));
             char referenceDirection = referenceAxis.charAt(i);
-            if ((role == MeridianAxisRole.EASTING && referenceDirection != 'e')
-                    || (role == MeridianAxisRole.NORTHING
+            if ((role == Role.EASTING && referenceDirection != 'e')
+                    || (role == Role.NORTHING
                         && referenceDirection != 'n')
-                    || role == MeridianAxisRole.UNKNOWN) {
+                    || role == Role.UNKNOWN) {
                 return false;
             }
         }
@@ -3378,15 +3365,7 @@ public final class CRSSerializer {
     }
 
     private static boolean hasMeridianAxisMetadata(ProjectionParams params) {
-        if (params.coordinateAxes == null) {
-            return false;
-        }
-        for (CoordinateAxis axis : params.coordinateAxes) {
-            if (axis != null && axis.getMeridian() != null) {
-                return true;
-            }
-        }
-        return false;
+        return MeridianAxisResolver.hasMeridianMetadata(params);
     }
 
     private static boolean hasRetainedPolarCoordinateSystem(
@@ -3398,17 +3377,12 @@ public final class CRSSerializer {
     }
 
     private static boolean isPolarLatitude(Double latitude) {
-        return latitude != null
-            && Double.isFinite(latitude)
-            && Math.abs(Math.abs(latitude) - Values.HALF_PI) <= Values.EPSLN;
+        return MeridianAxisResolver.isPolarLatitude(latitude);
     }
 
     private static boolean requiresMeridianAxisValidation(
             ProjectionParams params) {
-        String axis = effectiveAxis(params);
-        return hasMeridianAxisMetadata(params)
-            || "nnu".equals(axis)
-            || "ssu".equals(axis);
+        return MeridianAxisResolver.requiresResolution(params);
     }
 
     private static boolean requiresMeridianAxisAuthorityValidation(
@@ -3485,169 +3459,12 @@ public final class CRSSerializer {
 
     private static String meridianAxisValidationError(
             ProjectionParams params, String axisOrder) {
-        if (!"nnu".equals(axisOrder) && !"ssu".equals(axisOrder)) {
-            return "Meridian-qualified axes require two matching north or south directions";
-        }
-        if (params.coordinateAxes == null || params.coordinateAxes.size() != 2) {
-            return "Axis " + axisOrder
-                + " requires two retained meridian-qualified horizontal axes";
-        }
-        if (params.coordinateSystemType == null
-                || !"Cartesian".equalsIgnoreCase(params.coordinateSystemType)) {
-            return "Meridian-qualified projected axes require a Cartesian coordinate system";
-        }
-        if (!isPolarLatitude(params.lat0)) {
-            return "Meridian-qualified horizontal axes require a polar latitude of origin";
-        }
-
-        boolean northPole = params.lat0 > 0.0;
-        String expectedDirection = northPole ? "south" : "north";
-        boolean anyOrder = false;
-        boolean allOrder = true;
-        MeridianAxisRole firstRole = null;
-        MeridianAxisRole secondRole = null;
-        double expectedLinearFactor = linearUnitToMeter(params);
-
-        for (int i = 0; i < params.coordinateAxes.size(); i++) {
-            CoordinateAxis coordinateAxis = params.coordinateAxes.get(i);
-            if (coordinateAxis == null || coordinateAxis.getDirection() == null
-                    || !expectedDirection.equalsIgnoreCase(
-                        coordinateAxis.getDirection())) {
-                return "Polar axis directions must both be " + expectedDirection
-                    + " at the " + (northPole ? "north" : "south") + " pole";
-            }
-
-            char parsedDirection = mapStandardAxisDirection(
-                coordinateAxis.getDirection());
-            if (parsedDirection != axisOrder.charAt(i)) {
-                return "Retained coordinate-axis order does not match axis "
-                    + axisOrder;
-            }
-
-            Integer order = coordinateAxis.getOrder();
-            anyOrder |= order != null;
-            allOrder &= order != null;
-            if (order != null && order != i + 1) {
-                return "WKT axis ORDER must match its position in the coordinate system";
-            }
-
-            CoordinateAxis.Unit linearUnit = coordinateAxis.getUnit();
-            String linearUnitError = validateCoordinateAxisUnit(
-                linearUnit, "LinearUnit", "horizontal axis");
-            if (linearUnitError != null) {
-                return linearUnitError;
-            }
-            double linearFactor = linearUnit.getConversionFactor();
-            if (!sameUnitFactor(linearFactor, expectedLinearFactor)) {
-                return "Horizontal-axis units must match the projected CRS unit";
-            }
-
-            CoordinateAxis.Meridian meridian = coordinateAxis.getMeridian();
-            if (meridian == null || !Double.isFinite(meridian.getLongitude())) {
-                return "Each duplicate polar axis requires a finite meridian";
-            }
-            String angularUnitError = validateCoordinateAxisUnit(
-                meridian.getUnit(), "AngularUnit", "axis meridian");
-            if (angularUnitError != null) {
-                return angularUnitError;
-            }
-
-            MeridianAxisRole role = meridianAxisRole(params, coordinateAxis);
-            if (role == MeridianAxisRole.UNKNOWN) {
-                return "Axis meridians must identify one easting and one northing axis";
-            }
-            if (i == 0) {
-                firstRole = role;
-            } else {
-                secondRole = role;
-            }
-
-        }
-
-        if (anyOrder != allOrder) {
-            return "WKT axis ORDER must be present on every axis or none";
-        }
-        if (firstRole == secondRole) {
-            return "Polar axes must identify one easting and one northing axis";
-        }
-        return null;
+        return MeridianAxisResolver.resolve(params, axisOrder).getError();
     }
 
-    private static String validateCoordinateAxisUnit(
-            CoordinateAxis.Unit unit, String expectedType, String label) {
-        if (unit == null || unit.getConversionFactor() == null
-                || !Double.isFinite(unit.getConversionFactor())
-                || unit.getConversionFactor() <= 0.0) {
-            return "The " + label + " requires a positive finite unit factor";
-        }
-        if (unit.getType() != null
-                && !expectedType.equalsIgnoreCase(unit.getType())) {
-            return "The " + label + " must use a " + expectedType;
-        }
-        if (unit.getName() == null || unit.getName().trim().isEmpty()) {
-            return "The " + label + " requires a unit name";
-        }
-        return null;
-    }
-
-    private static boolean sameUnitFactor(double left, double right) {
-        return Math.abs(left - right)
-            <= 1e-12 * Math.max(Math.max(Math.abs(left), Math.abs(right)), 1.0);
-    }
-
-    private static boolean sameLongitude(double left, double right) {
-        return Math.abs(Math.IEEEremainder(left - right, 2.0 * Math.PI))
-            <= Values.EPSLN;
-    }
-
-    private static char mapStandardAxisDirection(String direction) {
-        if ("north".equalsIgnoreCase(direction)) {
-            return 'n';
-        }
-        if ("south".equalsIgnoreCase(direction)) {
-            return 's';
-        }
-        if ("east".equalsIgnoreCase(direction)) {
-            return 'e';
-        }
-        if ("west".equalsIgnoreCase(direction)) {
-            return 'w';
-        }
-        return '\0';
-    }
-
-    private static MeridianAxisRole meridianAxisRole(
+    private static Role meridianAxisRole(
             ProjectionParams params, CoordinateAxis axis) {
-        if (axis == null || axis.getMeridian() == null
-                || axis.getMeridian().getUnit() == null
-                || axis.getMeridian().getUnit().getConversionFactor() == null
-                || !isPolarLatitude(params.lat0)) {
-            return MeridianAxisRole.UNKNOWN;
-        }
-        CoordinateAxis.Meridian meridian = axis.getMeridian();
-        double actual = meridian.getLongitude()
-            * meridian.getUnit().getConversionFactor();
-        if (!Double.isFinite(actual)) {
-            return MeridianAxisRole.UNKNOWN;
-        }
-        double central = params.long0 != null ? params.long0 : 0.0;
-        double easting = central + Values.HALF_PI;
-        double northing = central + (params.lat0 > 0.0 ? Math.PI : 0.0);
-        boolean matchesEasting = sameLongitude(actual, easting);
-        boolean matchesNorthing = sameLongitude(actual, northing);
-        if (matchesEasting && !matchesNorthing) {
-            return MeridianAxisRole.EASTING;
-        }
-        if (matchesNorthing && !matchesEasting) {
-            return MeridianAxisRole.NORTHING;
-        }
-        return MeridianAxisRole.UNKNOWN;
-    }
-
-    private enum MeridianAxisRole {
-        EASTING,
-        NORTHING,
-        UNKNOWN
+        return MeridianAxisResolver.role(params, axis);
     }
 
     private static boolean isEastWest(char direction) {

--- a/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
+++ b/src/main/java/org/datasyslab/proj4sedona/projection/ProjectionParams.java
@@ -130,7 +130,10 @@ public class ProjectionParams {
     /** Coordinate-system subtype retained from WKT2/PROJJSON (for example Cartesian). */
     public String coordinateSystemType;
 
-    /** Detailed WKT2/PROJJSON coordinate-axis metadata, when available. */
+    /**
+     * Detailed WKT2/PROJJSON coordinate-axis metadata, used for faithful
+     * serialization and duplicate-direction polar axis enforcement.
+     */
     public List<CoordinateAxis> coordinateAxes = Collections.emptyList();
 
     // ==================== UTM Specific ====================

--- a/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
+++ b/src/main/java/org/datasyslab/proj4sedona/transform/Transform.java
@@ -1,6 +1,7 @@
 package org.datasyslab.proj4sedona.transform;
 
 import org.datasyslab.proj4sedona.constants.Values;
+import org.datasyslab.proj4sedona.common.MeridianAxisResolver;
 import org.datasyslab.proj4sedona.core.DatumParams;
 import org.datasyslab.proj4sedona.core.Point;
 import org.datasyslab.proj4sedona.core.Proj;
@@ -155,11 +156,19 @@ public final class Transform {
             srcParams = source.getParams();
         }
 
-        // Step 2: Adjust for source axis order (e.g., "neu" to "enu")
-        if (enforceAxis && srcParams.axis != null && !"enu".equals(srcParams.axis)) {
-            p = AdjustAxis.adjustAxisToEnu(srcParams.axis, p, hasZ);
-            if (p == null) {
+        // Step 2: Adjust for source axis order (e.g., "neu" to "enu").
+        // Duplicate polar directions (nnu/ssu) are resolved from their retained
+        // axis meridians; those direction tokens are geometry, not sign changes.
+        if (enforceAxis) {
+            String sourceAxis = axisForEnforcement(srcParams);
+            if (sourceAxis == null) {
                 return null;
+            }
+            if (!"enu".equals(sourceAxis)) {
+                p = AdjustAxis.adjustAxisToEnu(sourceAxis, p, hasZ);
+                if (p == null) {
+                    return null;
+                }
             }
         }
 
@@ -228,8 +237,15 @@ public final class Transform {
         }
 
         // Step 8: Adjust for destination axis order (e.g., "enu" to "neu")
-        if (enforceAxis && destParams.axis != null && !"enu".equals(destParams.axis)) {
-            p = AdjustAxis.adjustAxisFromEnu(destParams.axis, p, hasZ || isGeocent(destParams));
+        if (enforceAxis) {
+            String destinationAxis = axisForEnforcement(destParams);
+            if (destinationAxis == null) {
+                return null;
+            }
+            if (!"enu".equals(destinationAxis)) {
+                p = AdjustAxis.adjustAxisFromEnu(
+                    destinationAxis, p, hasZ || isGeocent(destParams));
+            }
         }
 
         // Reset z if it wasn't in the original input — except when the destination is
@@ -240,6 +256,25 @@ public final class Transform {
         }
 
         return p;
+    }
+
+    /**
+     * Return the ordinary ENU permutation used by the axis adjuster.
+     *
+     * <p>Most definitions use the compact PROJ axis string directly. Polar
+     * coordinate systems with duplicate north/south directions require the
+     * richer meridian metadata to distinguish easting from northing. Invalid or
+     * drifted retained metadata returns {@code null} so enforcement fails
+     * safely instead of silently duplicating or dropping a coordinate.</p>
+     */
+    private static String axisForEnforcement(ProjectionParams params) {
+        if (!MeridianAxisResolver.requiresResolution(params)) {
+            return params.axis != null ? params.axis : "enu";
+        }
+        MeridianAxisResolver.Resolution resolution =
+            MeridianAxisResolver.resolve(params);
+        return resolution.isValid()
+            ? resolution.getConventionalAxis() : null;
     }
 
     /**

--- a/src/test/java/org/datasyslab/proj4sedona/transform/PolarAxisEnforcementTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/transform/PolarAxisEnforcementTest.java
@@ -161,6 +161,33 @@ class PolarAxisEnforcementTest {
     }
 
     @Test
+    void ordinaryAxisPermutationWithMeridiansUsesOrdinaryEnforcementPath() {
+        Proj projected = new Proj(polarCrs(
+            3031,
+            "Polar Stereographic (variant B)",
+            polarVariantBParameters(-71.0, 0.0),
+            axis("Easting", "E", "east", 90.0),
+            axis("Northing", "N", "north", 0.0)));
+        assertEquals("enu", projected.getParams().axis);
+
+        Point nativeOrder = new Converter(
+            new Proj("EPSG:4326"), projected)
+            .forward(new Point(30.0, -80.0), true);
+
+        assertNotNull(nativeOrder);
+        assertEquals(544589.7278130918, nativeOrder.x, PROJECTED_TOLERANCE);
+        assertEquals(943257.0778523809, nativeOrder.y, PROJECTED_TOLERANCE);
+
+        Point geographic = new Converter(
+            projected, new Proj("EPSG:4326"))
+            .forward(nativeOrder, true);
+
+        assertNotNull(geographic);
+        assertEquals(30.0, geographic.x, GEOGRAPHIC_TOLERANCE);
+        assertEquals(-80.0, geographic.y, GEOGRAPHIC_TOLERANCE);
+    }
+
+    @Test
     void ordinaryProjAxisPermutationsRemainUnchanged() {
         Point transformed = Transform.transform(
             new Proj("+proj=longlat +datum=WGS84 +axis=neu"),

--- a/src/test/java/org/datasyslab/proj4sedona/transform/PolarAxisEnforcementTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/transform/PolarAxisEnforcementTest.java
@@ -1,0 +1,325 @@
+package org.datasyslab.proj4sedona.transform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Stream;
+import org.datasyslab.proj4sedona.core.Point;
+import org.datasyslab.proj4sedona.core.Proj;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class PolarAxisEnforcementTest {
+
+    private static final double PROJECTED_TOLERANCE = 1e-6;
+    private static final double GEOGRAPHIC_TOLERANCE = 1e-10;
+
+    @ParameterizedTest(name = "EPSG:{0}")
+    @MethodSource("polarCrsCases")
+    void destinationUsesProjNativeAxisOrder(
+            int code,
+            String definition,
+            double longitude,
+            double latitude,
+            double easting,
+            double northing,
+            boolean northingFirst) {
+        Converter converter = new Converter(
+            new Proj("EPSG:4326"), new Proj(definition));
+
+        Point nativeOrder = converter.forward(
+            new Point(longitude, latitude), true);
+
+        assertNotNull(nativeOrder);
+        assertEquals(
+            northingFirst ? northing : easting,
+            nativeOrder.x,
+            PROJECTED_TOLERANCE);
+        assertEquals(
+            northingFirst ? easting : northing,
+            nativeOrder.y,
+            PROJECTED_TOLERANCE);
+    }
+
+    @ParameterizedTest(name = "EPSG:{0}")
+    @MethodSource("polarCrsCases")
+    void sourceReadsProjNativeAxisOrder(
+            int code,
+            String definition,
+            double longitude,
+            double latitude,
+            double easting,
+            double northing,
+            boolean northingFirst) {
+        Converter converter = new Converter(
+            new Proj(definition), new Proj("EPSG:4326"));
+        Point nativeOrder = northingFirst
+            ? new Point(northing, easting)
+            : new Point(easting, northing);
+
+        Point geographic = converter.forward(nativeOrder, true);
+
+        assertNotNull(geographic);
+        assertEquals(longitude, geographic.x, GEOGRAPHIC_TOLERANCE);
+        assertEquals(latitude, geographic.y, GEOGRAPHIC_TOLERANCE);
+    }
+
+    @ParameterizedTest(name = "EPSG:{0}")
+    @MethodSource("polarCrsCases")
+    void defaultTransformKeepsTraditionalEastingNorthingOrder(
+            int code,
+            String definition,
+            double longitude,
+            double latitude,
+            double easting,
+            double northing,
+            boolean northingFirst) {
+        Converter converter = new Converter(
+            new Proj("EPSG:4326"), new Proj(definition));
+
+        Point projected = converter.forward(new Point(longitude, latitude));
+
+        assertNotNull(projected);
+        assertEquals(easting, projected.x, PROJECTED_TOLERANCE);
+        assertEquals(northing, projected.y, PROJECTED_TOLERANCE);
+    }
+
+    @Test
+    void northingFirstRoundTripPreservesZAndMeasure() {
+        Converter converter = new Converter(
+            new Proj("EPSG:4326"), new Proj(upsNorth()));
+        Point geographic = new Point(30.0, 85.0, 123.5, 7.25);
+
+        Point nativeOrder = converter.forward(geographic, true);
+
+        assertNotNull(nativeOrder);
+        assertEquals(1518959.7883427655, nativeOrder.x, PROJECTED_TOLERANCE);
+        assertEquals(2277728.6956913387, nativeOrder.y, PROJECTED_TOLERANCE);
+        assertEquals(123.5, nativeOrder.z, PROJECTED_TOLERANCE);
+        assertEquals(7.25, nativeOrder.m, 0.0);
+
+        Point roundTrip = converter.inverse(nativeOrder, true);
+        assertNotNull(roundTrip);
+        assertEquals(30.0, roundTrip.x, GEOGRAPHIC_TOLERANCE);
+        assertEquals(85.0, roundTrip.y, GEOGRAPHIC_TOLERANCE);
+        assertEquals(123.5, roundTrip.z, PROJECTED_TOLERANCE);
+        assertEquals(7.25, roundTrip.m, 0.0);
+    }
+
+    @Test
+    void malformedOrMissingPolarMetadataFailsSafelyOnlyWhenEnforced() {
+        Proj missingMetadata = new Proj(upsNorth());
+        missingMetadata.getParams().coordinateAxes = Collections.emptyList();
+        Converter converter = new Converter(
+            new Proj("EPSG:4326"), missingMetadata);
+
+        assertNull(converter.forward(new Point(30.0, 85.0), true));
+        assertNull(new Converter(
+            missingMetadata, new Proj("EPSG:4326"))
+            .forward(
+                new Point(1518959.7883427655, 2277728.6956913387),
+                true));
+
+        Point traditionalOrder = converter.forward(new Point(30.0, 85.0));
+        assertNotNull(traditionalOrder);
+        assertEquals(2277728.6956913387, traditionalOrder.x, PROJECTED_TOLERANCE);
+        assertEquals(1518959.7883427655, traditionalOrder.y, PROJECTED_TOLERANCE);
+
+        Proj driftedAxis = new Proj(upsNorth());
+        driftedAxis.getParams().axis = "nnu";
+        assertNull(new Converter(
+            new Proj("EPSG:4326"), driftedAxis)
+            .forward(new Point(30.0, 85.0), true));
+
+        Proj duplicateRole = new Proj(upsNorth());
+        duplicateRole.getParams().coordinateAxes = Arrays.asList(
+            duplicateRole.getParams().coordinateAxes.get(0),
+            duplicateRole.getParams().coordinateAxes.get(0));
+        assertNull(new Converter(
+            new Proj("EPSG:4326"), duplicateRole)
+            .forward(new Point(30.0, 85.0), true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("ordinaryPolarCrs")
+    void ordinaryPolarAxesStayOnOrdinaryAxisPath(int code, double latitude) {
+        Converter converter = new Converter(
+            new Proj("EPSG:4326"), new Proj("EPSG:" + code));
+
+        Point traditional = converter.forward(new Point(30.0, latitude));
+        Point enforced = converter.forward(new Point(30.0, latitude), true);
+
+        assertNotNull(traditional);
+        assertNotNull(enforced);
+        assertEquals(traditional.x, enforced.x, 0.0);
+        assertEquals(traditional.y, enforced.y, 0.0);
+    }
+
+    @Test
+    void ordinaryProjAxisPermutationsRemainUnchanged() {
+        Point transformed = Transform.transform(
+            new Proj("+proj=longlat +datum=WGS84 +axis=neu"),
+            new Proj("+proj=longlat +datum=WGS84 +axis=uen"),
+            new Point(10.0, 20.0, 30.0, 40.0),
+            true);
+
+        assertNotNull(transformed);
+        assertEquals(30.0, transformed.x, 0.0);
+        assertEquals(20.0, transformed.y, 0.0);
+        assertEquals(10.0, transformed.z, PROJECTED_TOLERANCE);
+        assertEquals(40.0, transformed.m, 0.0);
+    }
+
+    /**
+     * Reference values generated by pyproj 3.7.1 / PROJ 9.5.1. The easting and
+     * northing columns use {@code always_xy=true}; the last column records native
+     * PROJ axis order with {@code always_xy=false}.
+     */
+    private static Stream<Arguments> polarCrsCases() {
+        return Stream.of(
+            Arguments.of(
+                3031, antarcticPolarStereographicWkt2(), 30.0, -80.0,
+                544589.7278130918, 943257.0778523809, false),
+            Arguments.of(
+                32661, upsNorth(), 30.0, 85.0,
+                2277728.6956913387, 1518959.7883427655, true),
+            Arguments.of(
+                32761, upsSouth(), 30.0, -85.0,
+                2277728.6956913387, 2481040.2116572345, true),
+            Arguments.of(
+                3413, nsidcSeaIceNorth(), -30.0, 80.0,
+                281056.85442872735, -1048918.4605435, false));
+    }
+
+    private static Stream<Arguments> ordinaryPolarCrs() {
+        return Stream.of(
+            Arguments.of(5041, 85.0),
+            Arguments.of(5042, -85.0));
+    }
+
+    private static String antarcticPolarStereographicWkt2() {
+        return "PROJCRS[\"WGS 84 / Antarctic Polar Stereographic\","
+            + "BASEGEOGCRS[\"WGS 84\","
+            + "DATUM[\"World Geodetic System 1984\","
+            + "ELLIPSOID[\"WGS 84\",6378137,298.257223563]],"
+            + "UNIT[\"degree\",0.0174532925199433]],"
+            + "CONVERSION[\"Antarctic Polar Stereographic\","
+            + "METHOD[\"Polar Stereographic (variant B)\"],"
+            + "PARAMETER[\"Latitude of standard parallel\",-71],"
+            + "PARAMETER[\"Longitude of origin\",0],"
+            + "PARAMETER[\"False easting\",0],"
+            + "PARAMETER[\"False northing\",0]],"
+            + "CS[Cartesian,2],"
+            + "AXIS[\"(E)\",north,MERIDIAN[90,"
+            + "UNIT[\"degree\",0.0174532925199433]]],"
+            + "AXIS[\"(N)\",north,MERIDIAN[0,"
+            + "UNIT[\"degree\",0.0174532925199433]]],"
+            + "UNIT[\"metre\",1],ID[\"EPSG\",3031]]";
+    }
+
+    private static String upsNorth() {
+        return polarCrs(
+            32661,
+            "Polar Stereographic (variant A)",
+            polarVariantAParameters(90.0, 0.0),
+            axis("Northing", "N", "south", 180.0),
+            axis("Easting", "E", "south", 90.0));
+    }
+
+    private static String upsSouth() {
+        return polarCrs(
+            32761,
+            "Polar Stereographic (variant A)",
+            polarVariantAParameters(-90.0, 0.0),
+            axis("Northing", "N", "north", 0.0),
+            axis("Easting", "E", "north", 90.0));
+    }
+
+    private static String nsidcSeaIceNorth() {
+        return polarCrs(
+            3413,
+            "Polar Stereographic (variant B)",
+            polarVariantBParameters(70.0, -45.0),
+            axis("Easting", "X", "south", 45.0),
+            axis("Northing", "Y", "south", 135.0));
+    }
+
+    private static String polarCrs(
+            int code,
+            String method,
+            String parameters,
+            String firstAxis,
+            String secondAxis) {
+        return "{"
+            + "\"type\":\"ProjectedCRS\","
+            + "\"name\":\"EPSG:" + code + "\","
+            + "\"base_crs\":{"
+            + "\"type\":\"GeographicCRS\","
+            + "\"name\":\"WGS 84\","
+            + "\"datum\":{"
+            + "\"type\":\"GeodeticReferenceFrame\","
+            + "\"name\":\"World Geodetic System 1984\","
+            + "\"ellipsoid\":{"
+            + "\"name\":\"WGS 84\","
+            + "\"semi_major_axis\":6378137,"
+            + "\"inverse_flattening\":298.257223563}}},"
+            + "\"conversion\":{"
+            + "\"name\":\"unnamed\","
+            + "\"method\":{\"name\":\"" + method + "\"},"
+            + "\"parameters\":[" + parameters + "]},"
+            + "\"coordinate_system\":{"
+            + "\"subtype\":\"Cartesian\","
+            + "\"axis\":[" + firstAxis + "," + secondAxis + "]},"
+            + "\"id\":{\"authority\":\"EPSG\",\"code\":" + code + "}}";
+    }
+
+    private static String polarVariantAParameters(
+            double latitude, double longitude) {
+        return naturalOriginAngles(latitude, longitude)
+            + ",{\"name\":\"Scale factor at natural origin\","
+            + "\"value\":0.994,\"unit\":\"unity\"}"
+            + ",{\"name\":\"False easting\",\"value\":2000000,"
+            + "\"unit\":\"metre\"}"
+            + ",{\"name\":\"False northing\",\"value\":2000000,"
+            + "\"unit\":\"metre\"}";
+    }
+
+    private static String polarVariantBParameters(
+            double latitudeOfStandardParallel, double longitude) {
+        return "{\"name\":\"Latitude of standard parallel\","
+            + "\"value\":" + latitudeOfStandardParallel
+            + ",\"unit\":\"degree\"},"
+            + angularParameter("Longitude of origin", longitude)
+            + ",{\"name\":\"False easting\",\"value\":0,\"unit\":\"metre\"}"
+            + ",{\"name\":\"False northing\",\"value\":0,\"unit\":\"metre\"}";
+    }
+
+    private static String naturalOriginAngles(
+            double latitude, double longitude) {
+        return angularParameter("Latitude of natural origin", latitude)
+            + "," + angularParameter("Longitude of natural origin", longitude);
+    }
+
+    private static String angularParameter(String name, double value) {
+        return "{\"name\":\"" + name + "\",\"value\":" + value
+            + ",\"unit\":\"degree\"}";
+    }
+
+    private static String axis(
+            String name,
+            String abbreviation,
+            String direction,
+            double meridian) {
+        return "{"
+            + "\"name\":\"" + name + "\","
+            + "\"abbreviation\":\"" + abbreviation + "\","
+            + "\"direction\":\"" + direction + "\","
+            + "\"meridian\":{\"longitude\":" + meridian + "},"
+            + "\"unit\":\"metre\"}";
+    }
+}


### PR DESCRIPTION
## Summary

- Resolve meridian-qualified polar axes to conventional positive easting and
  northing roles when `enforceAxis=true`.
- Share one validation and role resolver between CRS serialization and coordinate
  transformation instead of duplicating the meridian geometry.
- Preserve the default easting/northing behavior and all ordinary PROJ axis
  permutations.
- Document the supported enforcement behavior and add offline source/destination
  regressions.

## Why

#124 retained the axis metadata needed to represent polar coordinate systems whose
two horizontal axes both point north or both point south. The compact `nnu` and
`ssu` strings cannot distinguish easting from northing by themselves. Passing
those strings through the ordinary axis adjuster overwrites one coordinate and
produces invalid results when axis enforcement is enabled.

The qualifying meridians provide the missing roles. Relative to the projection's
central meridian, they identify the positive easting and northing axes without
introducing a sign inversion.

## Impact

- Correct native-axis transforms in both directions for easting-first and
  northing-first polar CRSs, including EPSG:3031, 32661, 32761, and 3413.
- Missing, malformed, or drifted duplicate-direction metadata fails safely only
  when enforcement is requested.
- `enforceAxis=false`, EPSG:5041/5042, and ordinary `enu`, `neu`, and `uen`
  behavior remain unchanged.

## Validation

- `mvn verify -Pbenchmarks`: 1,162 tests passed.
- Reference coordinates match pyproj 3.7.1 / PROJ 9.5.1 for all four representative
  CRSs in both directions.
- The meridian-axis parity gate remains green for 51 CRSs, 102 parser comparisons,
  and 306 export outcomes.
- The EPSG:3031 regression uses canonical simplified WKT2; the other representative
  cases use offline PROJJSON fixtures.
