### PR TITLE
Prepare 0.1.4 release

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,14 +12,14 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'org.datasyslab:proj4sedona:0.1.3'
+implementation 'org.datasyslab:proj4sedona:0.1.4'
 ```
 
 ### Building from Source

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <packaging>jar</packaging>
 
     <name>Proj4Sedona</name>


### PR DESCRIPTION
## Summary

- bump the Maven project version from 0.1.3 to 0.1.4
- update the Maven and Gradle dependency examples to use 0.1.4

## Why

Prepare the release artifact and published usage examples for proj4sedona 0.1.4.

## User impact

Consumers can reference the new release consistently from Maven or Gradle once it is published.

## Validation

- `mvn clean verify -Pbenchmarks`
- 1,165 tests passed with no failures or errors
- pyproj correctness comparisons and benchmark profile passed
- the exact parent revision was validated locally against Apache Sedona master across the common, Spark CRS transform, and GeoParquet test paths
