### PR TITLE
Export canonical grid-shift datums in standard CRS formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Full documentation is available in the [docs/](docs/) folder:
 `UnsupportedOperationException` instead of returning lossy output for definitions they
 cannot represent. WKT2 and PROJJSON preserve supported three- and seven-parameter
 `+towgs84` operations as a `BoundCRS` (geocentric sources are supported in PROJJSON
-only), while WKT1 uses `TOWGS84`. All standard exporters reject grid shifts, `+over`,
-`+R_A`, and two-point `omerc`. WKT2 and PROJJSON also reject `+approx`; WKT1 preserves
-approximate Transverse Mercator with the executable `Fast_Transverse_Mercator` method.
-Use `toProjString()` for remaining unsupported operation semantics. The complete list is
-in the [CRS export fidelity guide](docs/crs-formats.md#export-fidelity).
+only), while WKT1 uses `TOWGS84`. Canonical named grid-shift datums such as NAD27
+export through their standard datum identity; custom grid operations remain rejected.
+All standard exporters reject `+over`, `+R_A`, and two-point `omerc`. WKT2 and
+PROJJSON also reject `+approx`; WKT1 preserves approximate Transverse Mercator with
+the executable `Fast_Transverse_Mercator` method. Use `toProjString()` for remaining
+unsupported operation semantics. The complete list is in the
+[CRS export fidelity guide](docs/crs-formats.md#export-fidelity).
 
 ## Quick Start
 

--- a/docs/crs-formats.md
+++ b/docs/crs-formats.md
@@ -271,8 +271,8 @@ PROJ string.
 
 This applies to PROJ-only longitude handling (`+over`, `+lon_wrap`), authalic-radius
 mode (`+R_A`), `ob_tran`, Tilted Perspective, unsupported Oblique Mercator variants
-(`+no_rot` and the two-point form), and grid-shift operations. Approximate Transverse
-Mercator is format-dependent: WKT2 and PROJJSON reject it, while WKT1 emits
+(`+no_rot` and the two-point form), and custom grid-shift operations. Approximate
+Transverse Mercator is format-dependent: WKT2 and PROJJSON reject it, while WKT1 emits
 the executable `Fast_Transverse_Mercator` method. Other uses of `+approx` are rejected
 by all standard exporters. WKT2 and
 PROJJSON preserve coordinate-affecting three- and seven-parameter `+towgs84`
@@ -283,9 +283,16 @@ Geographic and projected sources target EPSG:4326 with EPSG methods 9603 and 960
 geocentric PROJJSON targets EPSG:4978 with methods 1031 and 1033. Helmert BoundCRS
 import is limited to those target/method combinations so an arbitrary target or
 coordinate-frame rotation cannot be silently rewritten as `+towgs84`. WKT1 preserves
-the same operation with `TOWGS84`. Grid-shift operations remain importable but are not
-yet exportable. Geocentric CRS export is supported as a PROJ string or PROJJSON, but
-not yet as WKT.
+the same operation with `TOWGS84`.
+
+Canonical named grid-shift datums such as NAD27 are exportable in WKT1, WKT2, and
+PROJJSON. As in PROJ's standard exports, the document describes the datum and
+ellipsoid without embedding grid filenames: the grid belongs to the coordinate
+operation selected for that datum. Re-import resolves the emitted datum name through
+the bundled registry and restores the identical grid list. A custom or overridden
+`+nadgrids` list, a conflicting ellipsoid, or a simultaneous `+towgs84` operation is
+still rejected because a plain standard CRS document cannot preserve that definition.
+Geocentric CRS export is supported as a PROJ string or PROJJSON, but not yet as WKT.
 
 For supported definitions, standard exports preserve projection parameters,
 linear-unit factors, horizontal axis order and direction, and non-Greenwich prime

--- a/scripts/pyproj-reference/generate_format_reference.py
+++ b/scripts/pyproj-reference/generate_format_reference.py
@@ -28,6 +28,11 @@ def get_test_crs_definitions() -> List[Dict[str, Any]]:
             "name": "nad83_geographic",
             "desc": "NAD83 Geographic"
         },
+        {
+            "input": "+proj=longlat +datum=NAD27 +no_defs",
+            "name": "nad27_geographic",
+            "desc": "NAD27 Geographic with canonical grid-shift datum"
+        },
         # Projected CRS - Mercator
         {
             "input": "EPSG:3857",
@@ -49,6 +54,11 @@ def get_test_crs_definitions() -> List[Dict[str, Any]]:
             "input": "EPSG:32733",
             "name": "utm_33s",
             "desc": "UTM Zone 33S"
+        },
+        {
+            "input": "+proj=utm +zone=11 +datum=NAD27 +units=m +no_defs",
+            "name": "nad27_utm_11n",
+            "desc": "NAD27 UTM Zone 11N with canonical grid-shift datum"
         },
         # Lambert Conformal Conic (from PROJ string)
         {

--- a/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
+++ b/src/main/java/org/datasyslab/proj4sedona/parser/CRSSerializer.java
@@ -2039,6 +2039,22 @@ public final class CRSSerializer {
         return value == null || value == 0.0;
     }
 
+    /**
+     * Whether a standard CRS document can omit the active grid operation and have
+     * this parser restore it from the emitted datum identity. A simultaneous
+     * {@code +towgs84} array is rejected even though the grid is operationally
+     * authoritative: WKT1 would expose the Helmert values and WKT2/PROJJSON could
+     * wrap them in a BoundCRS, changing the operation seen by outside consumers.
+     */
+    private static boolean gridShiftReconstructsFromDeclaredDatum(
+            ProjectionParams params) {
+        DatumParams actual = params.datum;
+        return actual != null
+            && actual.isGridShift()
+            && actual.getDatumParams() == null
+            && resolveProjDatumToken(params) != null;
+    }
+
     private static boolean declaredDatumOperationIsCanonical(ProjectionParams params) {
         DatumParams actual = params.datum;
         Datum declared = Datum.get(params.datumCode);
@@ -2050,6 +2066,7 @@ public final class CRSSerializer {
         String expectedGrid = declared.getNadgrids();
         if (expectedGrid != null) {
             return actual != null && actual.isGridShift()
+                && actual.getDatumParams() == null
                 && Objects.equals(expectedGrid, actual.getNadgrids());
         }
         if (actual != null && actual.isGridShift()) {
@@ -2547,6 +2564,7 @@ public final class CRSSerializer {
         DatumParams datum = params.datum;
         if (canon.nadgrids != null) {
             return datum != null && datum.isGridShift()
+                && datum.getDatumParams() == null
                 && canon.nadgrids.equals(datum.getNadgrids()) ? canon.token : null;
         }
         if (datum == null || datum.isGridShift() || datum.getDatumParams() == null) {
@@ -3052,7 +3070,19 @@ public final class CRSSerializer {
         }
 
         DatumParams datum = params.datum;
-        if (datum != null && datum.isGridShift()) {
+        // A canonical named grid shift belongs to the coordinate operation selected
+        // for that datum, not to the CRS document itself. Standard serializers such
+        // as PROJ therefore emit only the datum name and ellipsoid for NAD27. Our
+        // parsers resolve that name through the same datum registry and restore the
+        // identical grid list. An explicit/custom override has no such standard
+        // representation and must still fail instead of being silently replaced by
+        // the named datum's grids.
+        Datum declaredDatum = Datum.get(params.datumCode);
+        boolean declaresGridShift =
+            declaredDatum != null && declaredDatum.getNadgrids() != null;
+        boolean hasGridShift = datum != null && datum.isGridShift();
+        if ((declaresGridShift || hasGridShift)
+                && !gridShiftReconstructsFromDeclaredDatum(params)) {
             throw unsupportedStandardParameter(
                 "Grid-shift datum operations cannot be represented losslessly");
         }

--- a/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/parser/CRSSerializerRoundTripSafetyTest.java
@@ -150,7 +150,7 @@ class CRSSerializerRoundTripSafetyTest {
     }
 
     @Test
-    void datumOperationsAreNeverSilentlyDropped() {
+    void datumOperationsArePreservedOrRecoverableFromTheNamedDatum() {
         Proj helmert = new Proj("+proj=longlat +datum=ch1903 +no_defs");
         String wkt1 = CRSSerializer.toWkt1(helmert);
         assertTrue(wkt1.contains("TOWGS84[674.374,15.056,405.346]"), wkt1);
@@ -166,9 +166,56 @@ class CRSSerializerRoundTripSafetyTest {
                 bound);
         }
 
-        Proj grid = new Proj("+proj=longlat +datum=NAD27 +no_defs");
-        assertTrue(CRSSerializer.toProjString(grid).contains("+datum=NAD27"));
-        assertAllStandardsReject(grid);
+        for (Proj grid : new Proj[]{
+                new Proj("+proj=longlat +datum=NAD27 +no_defs"),
+                new Proj("+proj=utm +zone=11 +datum=NAD27 +units=m +no_defs"),
+                new Proj("+proj=lcc +lat_1=33 +lat_2=45 +lat_0=30 +lon_0=-96 "
+                    + "+datum=NAD27 +units=us-ft +no_defs"),
+                new Proj("+proj=longlat +datum=NAD27 "
+                    + "+nadgrids=@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat +no_defs")}) {
+            assertTrue(CRSSerializer.toProjString(grid).contains("+datum=NAD27"));
+            for (String serialized : new String[]{
+                    CRSSerializer.toWkt1(grid),
+                    CRSSerializer.toWkt2(grid),
+                    CRSSerializer.toProjJson(grid)}) {
+                assertFalse(serialized.contains("PROJ4_GRIDS"), serialized);
+                assertFalse(serialized.startsWith("BOUNDCRS["), serialized);
+                assertFalse(serialized.contains("\"transformation\""), serialized);
+                Proj reimported = new Proj(serialized);
+                assertTrue(reimported.getParams().datum.isGridShift(), serialized);
+                assertEquals(
+                    grid.getParams().datum.getNadgrids(),
+                    reimported.getParams().datum.getNadgrids(),
+                    serialized);
+            }
+        }
+
+        Proj mixedGridAndHelmert = new Proj(
+            "+proj=longlat +datum=NAD27 +towgs84=1,2,3 "
+                + "+nadgrids=@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat +no_defs");
+        for (Proj unrecoverable : new Proj[]{
+                new Proj("+proj=longlat +datum=NAD27 +nadgrids=@other.gsb +no_defs"),
+                new Proj("+proj=longlat +ellps=clrk66 "
+                    + "+nadgrids=@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat +no_defs"),
+                new Proj("+proj=longlat +datum=NAD83 +nadgrids=@other.gsb +no_defs"),
+                new Proj("+proj=longlat +datum=NAD27 "
+                    + "+nadgrids=@alaska,@conus,@ntv2_0.gsb,@ntv1_can.dat +no_defs"),
+                mixedGridAndHelmert,
+                new Proj("+proj=longlat +datum=NAD27 +a=6378206.4 +b=6300000 "
+                    + "+nadgrids=@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat +no_defs"),
+                new Proj("+proj=longlat +datum=NAD27 +nadgrids=null +no_defs"),
+                new Proj("+proj=longlat +datum=NAD27 +nadgrids= +no_defs")}) {
+            String projString = CRSSerializer.toProjString(unrecoverable);
+            assertDoesNotThrow(() -> new Proj(projString), projString);
+            assertAllStandardsReject(unrecoverable);
+        }
+        String mixedProjString = CRSSerializer.toProjString(mixedGridAndHelmert);
+        assertTrue(mixedProjString.contains("+towgs84=1,2,3"), mixedProjString);
+        assertTrue(
+            mixedProjString.contains(
+                "+nadgrids=@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat"),
+            mixedProjString);
+        assertNull(CRSSerializer.toAuthority(mixedGridAndHelmert.getParams()));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- export canonical named grid-shift datums such as NAD27 to WKT1, WKT2, and PROJJSON
- keep rejecting custom or conflicting grid operations that standard CRS formats cannot preserve
- preserve mixed grid/Helmert definitions in PROJ-string export and refuse a false EPSG identity
- extend pyproj serializer parity coverage and document the export contract

## Motivation

The strict serialization checks introduced in 0.1.4 reject every NAD27-family CRS in standard formats, even when its grid operation is exactly the canonical operation declared by the named datum. This breaks Apache Sedona's default `RS_CRS(raster)` PROJJSON path and causes GeoParquet CRS metadata to be omitted for NAD27 projected CRSs, blocking [apache/sedona#3191](https://github.com/apache/sedona/pull/3191).

PROJ represents NAD27 as a standard datum and ellipsoid without embedding grid filenames in the CRS document. The grid belongs to the coordinate operation selected for that datum. proj4sedona already reconstructs the canonical grid list when it imports that standard representation, so the named datum round trip is lossless within the library.

## Safety

Standard export is allowed only when all of these conditions hold:

- the active datum is a grid-shift datum
- its grid list exactly matches the canonical named datum, including order
- the ellipsoid matches the canonical datum
- no simultaneous `+towgs84` operation is present

Custom, reordered, unnamed, empty, or `null` grids; conflicting ellipsoids; and mixed grid/Helmert definitions continue to throw instead of being serialized lossily. Mixed grid/Helmert definitions also retain both operations in PROJ-string export and no longer recover an incorrect EPSG authority.

Tests cover geographic NAD27, NAD27 UTM, NAD27 Lambert Conformal Conic, an explicit canonical grid list, and the full set of rejection cases across WKT1, WKT2, and PROJJSON.

## Additional bug fixes

The same canonical-datum predicate exposed two pre-existing 0.1.4 bugs for a definition such as `+proj=longlat +datum=NAD27 +towgs84=1,2,3`:

| API | 0.1.4 | This PR |
|---|---|---|
| `toProjString()` | emitted only `+datum=NAD27`, silently dropping the Helmert parameters | emits both `+towgs84=1,2,3` and the canonical `+nadgrids` list |
| `toAuthority()` | returned `EPSG:4267` for the non-standard mixed definition | returns `null` |

The grid remains operationally authoritative, but a lossless PROJ-string export must retain both pieces of the supplied definition, and a mixed definition must not claim the standard NAD27 authority.

## Validation

- `mvn -q -Dtest=CRSSerializerTest,CRSSerializerRoundTripSafetyTest test`
- `mvn verify -Pbenchmarks`
  - 1,165/1,165 Java tests
  - serializer parity increased from 60 to 68 comparisons, all passing
  - 51 meridian-axis CRSs, 102 parser comparisons, and 306 export outcomes
- 36-code NAD27-family sweep: all definitions resolve and none throw for PROJJSON or WKT2
- PROJ accepts every generated EPSG:4267 and EPSG:26711 document and transforms identically to the canonical EPSG definition
- Apache Sedona direct application probe against the #3191 branch with this fix installed:
  - all 12 default-PROJJSON and explicit-format `RS_CRS` calls succeed for EPSG:4267 and EPSG:26711
  - `RS_SetCRS` re-import is byte-idempotent and preserves the SRID

The published #3191 head currently has 1,159 common tests, 81 `CrsRoundTripComplianceTest` cases, 37 `CRSTransformProj4Test` cases, and 52 `geoparquetIOTests` cases. Its CRS and GeoParquet suites are also green on 0.1.4 because they do not yet cover an NAD27 standard-export path.

A separate, currently unpushed Sedona follow-up adds four EPSG:4267/26711 PROJJSON/WKT2 round trips, checks the default `RS_CRS` path, and adds two GeoParquet metadata cases. Against a locally installed fixed snapshot it passes 1,163/1,163 common tests, 85/85 CRS round trips, 37/37 transform tests, and 54/54 GeoParquet tests. That patch will accompany #3191's retarget to the published 0.1.5 artifact.
