### PR TITLE
Prepare 0.1.5 release

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,14 +12,14 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'org.datasyslab:proj4sedona:0.1.4'
+implementation 'org.datasyslab:proj4sedona:0.1.5'
 ```
 
 ### Building from Source

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.4</version>
+    <version>0.1.5</version>
     <packaging>jar</packaging>
 
     <name>Proj4Sedona</name>


### PR DESCRIPTION
## Summary

- bump the Maven project version from 0.1.4 to 0.1.5
- update the Maven and Gradle dependency examples to use 0.1.5

## Why

Prepare the release artifact and published usage examples for proj4sedona 0.1.5. This release includes canonical grid-shift datum export support and the latest proj4js synchronization through upstream commit `955bfd6`.

## User impact

Consumers can reference the new release consistently from Maven or Gradle once it is published. NAD27-family CRSs can be exported through WKT1, WKT2, and PROJJSON again, while mixed grid-shift and Helmert definitions retain both operations in PROJ output and no longer claim an incorrect EPSG authority.

## Validation

- `mvn clean verify -Pbenchmarks`
- 1,165 tests passed with no failures, errors, or skips
- pyproj correctness comparisons passed: 135 transforms, 221 per-projection cases, 25 grid cases, 29 parser cases, 68 serializer cases, and the 51-CRS meridian-axis suite
- Apache Sedona master compatibility passed locally: common 1,165/1,165 and focused Spark CRS transform, GeoParquet, and geography suites 141/141
