### PR TITLE
Harden remote CRS resolution

### DIFF
--- a/docs/crs-registry.md
+++ b/docs/crs-registry.md
@@ -8,7 +8,7 @@ When you create a `Proj` from an authority code (e.g., `new Proj("EPSG:4326")`),
 
 ```
 EPSG:4326  -->  BuiltInCRSProvider (priority 100)
-           -->  UrlCRSProvider / pinned OSGeo snapshot (priority 101)
+           -->  UrlCRSProvider / OSGeo GitHub + CDN fallback (priority 101)
            -->  Custom providers (user-defined priority)
 ```
 
@@ -76,11 +76,11 @@ The `BuiltInCRSProvider` (priority 100) supplies PROJ strings for common EPSG co
 ## URL-Based Provider
 
 The `UrlCRSProvider` fetches CRS definitions from HTTP endpoints. The default
-remote provider reads a commit-addressed snapshot of the spatialreference.org
-data through jsDelivr's GitHub CDN. The snapshot was generated from PROJ 9.8.1
-and EPSG v12.029 at OSGeo commit
-`c43e4e72634af65fcf684def42ddc2dcfd834938`, so its contents do not move during
-a proj4sedona release.
+remote provider reads the rolling spatialreference.org `gh-pages` catalog from
+`raw.githubusercontent.com`. If GitHub has an endpoint failure, it tries a
+commit-addressed copy through jsDelivr. The backup was generated from PROJ
+9.8.1 and EPSG v12.029 at OSGeo commit
+`c43e4e72634af65fcf684def42ddc2dcfd834938`.
 
 The CRS catalog remains an external runtime dependency; it is not bundled in
 the proj4sedona JAR.
@@ -88,9 +88,9 @@ the proj4sedona JAR.
 ```java
 import org.datasyslab.proj4sedona.defs.UrlCRSProvider;
 
-// The default pinned OSGeo snapshot provider is registered automatically.
+// The default OSGeo GitHub provider and pinned CDN fallback are registered automatically.
 // It resolves codes like EPSG:2154, ESRI:102001, etc.
-Proj p = new Proj("EPSG:2154");  // fetched from the snapshot if not built-in
+Proj p = new Proj("EPSG:2154");  // fetched remotely if not built in
 ```
 
 ### Custom URL Provider
@@ -99,8 +99,20 @@ Build a provider for your own CRS service:
 
 ```java
 import org.datasyslab.proj4sedona.defs.UrlCRSProvider;
+import org.datasyslab.proj4sedona.defs.UrlCRSFetcher;
 import org.datasyslab.proj4sedona.defs.CRSResult;
 import java.time.Duration;
+
+UrlCRSFetcher mirror = UrlCRSFetcher.builder()
+    .baseUrl("https://mirror.example.com/api")
+    .pathTemplate("/{authority}/{code}.proj4")
+    .connectTimeout(3)
+    .readTimeout(5)
+    .totalTimeout(8)
+    .maxRetries(2)
+    .circuitBreakerFailureThreshold(3)
+    .circuitBreakerResetTimeout(Duration.ofSeconds(30))
+    .build();
 
 UrlCRSProvider myProvider = UrlCRSProvider.builder("my-crs-service")
     .baseUrl("https://crs.example.com/api")
@@ -109,20 +121,43 @@ UrlCRSProvider myProvider = UrlCRSProvider.builder("my-crs-service")
     .format(CRSResult.Format.PROJ4)
     .connectTimeout(3)             // per connection
     .readTimeout(5)                // per request
-    .totalTimeout(8)               // entire lookup, including retries
+    .totalTimeout(8)               // primary only, including retries
     .maxRetries(2)                 // two total attempts
     .circuitBreakerFailureThreshold(3)
     .circuitBreakerResetTimeout(Duration.ofSeconds(30))
+    .fallbackFetcher(mirror)       // independently configured endpoint
     .build();
 ```
 
-The built-in remote provider uses those same reliability settings. Concurrent
-lookups of the same authority and code share one in-flight HTTP request. After
-three consecutive endpoint failures—network failures, HTTP 401/403/408/429, or
-HTTP 5xx—its circuit breaker rejects requests locally for 30 seconds before
+Fallback fetchers are tried in insertion order after network failures, non-404
+HTTP errors, or an open circuit. A reachable primary that returns HTTP 404 is
+authoritative, so an older fallback cannot resurrect a CRS removed from the
+current catalog. If the primary fails and every fallback either fails or
+returns 404, the endpoint failure is propagated with diagnostics for each
+endpoint. An interrupted lookup stops immediately rather than starting another
+request.
+
+Configure each fallback explicitly. Its headers are not copied from the
+primary, so credentials are scoped to the fetcher on which they were
+configured. Redirects are followed only within the same origin. Every endpoint
+must serve the format configured on the provider.
+
+The built-in GitHub and jsDelivr fetchers each use the reliability settings in
+the example. Concurrent lookups of the same authority and code share one
+in-flight HTTP request per endpoint. After three consecutive endpoint
+failures—network failures, HTTP 401/403/408/429, or HTTP 5xx—an endpoint's
+independent circuit breaker rejects requests locally for 30 seconds before
 allowing one probe request.
 
-These stricter limits apply to the built-in remote fallback. Custom
+The eight-second overall deadline applies separately to each endpoint. A
+lookup can therefore take up to approximately 16 seconds when both default
+endpoints are unhealthy, with at most two attempts per endpoint. An already
+open GitHub circuit moves to jsDelivr immediately.
+
+Failover is based on transport and HTTP status. An HTTP 200 response is returned
+for parsing and does not trigger a fallback if its body is malformed.
+
+These stricter limits apply to both built-in remote endpoints. Custom
 `UrlCRSProvider` instances retain the earlier generic defaults (10-second
 connect timeout, 30-second request timeout, three total attempts, no overall
 deadline, and no circuit breaker) unless configured explicitly.
@@ -204,7 +239,7 @@ Providers are queried in ascending priority order. Lower numbers are checked fir
 |----------|----------|-------------|
 | 50 | (custom) | Your high-priority providers |
 | 100 | BuiltInCRSProvider | Built-in PROJ strings for common EPSG codes |
-| 101 | UrlCRSProvider | Immutable OSGeo spatialreference.org snapshot (network access) |
+| 101 | UrlCRSProvider | Rolling OSGeo GitHub catalog with pinned CDN fallback |
 
 Manual `Defs.set()` definitions always take precedence over providers.
 
@@ -212,8 +247,13 @@ Manual `Defs.set()` definitions always take precedence over providers.
 
 Successful provider results are parsed and cached in memory by normalized
 authority code. Repeated lookups such as `EPSG:2154` therefore do not repeat the
-HTTP request within the same JVM. HTTP 404 responses are negatively cached as
-well.
+HTTP request within the same JVM.
+
+The rolling GitHub primary does not cache HTTP 404 responses permanently,
+because a missing code can be added to the upstream catalog while a JVM is
+running. The immutable jsDelivr fallback does negatively cache 404 responses.
+Custom URL fetchers cache 404 responses by default; use
+`.cacheNotFound(false)` for another rolling catalog.
 
 The cache is process-local and is not persisted to disk. In a Spark deployment,
 each executor JVM may fetch a previously unseen CRS once; an executor restart

--- a/docs/crs-registry.md
+++ b/docs/crs-registry.md
@@ -8,7 +8,7 @@ When you create a `Proj` from an authority code (e.g., `new Proj("EPSG:4326")`),
 
 ```
 EPSG:4326  -->  BuiltInCRSProvider (priority 100)
-           -->  UrlCRSProvider / spatialreference.org (priority 101)
+           -->  UrlCRSProvider / pinned OSGeo snapshot (priority 101)
            -->  Custom providers (user-defined priority)
 ```
 
@@ -75,14 +75,22 @@ The `BuiltInCRSProvider` (priority 100) supplies PROJ strings for common EPSG co
 
 ## URL-Based Provider
 
-The `UrlCRSProvider` fetches CRS definitions from HTTP endpoints. A built-in factory creates a provider for spatialreference.org:
+The `UrlCRSProvider` fetches CRS definitions from HTTP endpoints. The default
+remote provider reads a commit-addressed snapshot of the spatialreference.org
+data through jsDelivr's GitHub CDN. The snapshot was generated from PROJ 9.8.1
+and EPSG v12.029 at OSGeo commit
+`c43e4e72634af65fcf684def42ddc2dcfd834938`, so its contents do not move during
+a proj4sedona release.
+
+The CRS catalog remains an external runtime dependency; it is not bundled in
+the proj4sedona JAR.
 
 ```java
 import org.datasyslab.proj4sedona.defs.UrlCRSProvider;
 
-// The default spatialreference.org provider is registered automatically.
+// The default pinned OSGeo snapshot provider is registered automatically.
 // It resolves codes like EPSG:2154, ESRI:102001, etc.
-Proj p = new Proj("EPSG:2154");  // fetched from spatialreference.org if not built-in
+Proj p = new Proj("EPSG:2154");  // fetched from the snapshot if not built-in
 ```
 
 ### Custom URL Provider
@@ -92,17 +100,32 @@ Build a provider for your own CRS service:
 ```java
 import org.datasyslab.proj4sedona.defs.UrlCRSProvider;
 import org.datasyslab.proj4sedona.defs.CRSResult;
+import java.time.Duration;
 
 UrlCRSProvider myProvider = UrlCRSProvider.builder("my-crs-service")
     .baseUrl("https://crs.example.com/api")
     .pathTemplate("/{authority}/{code}.proj4")
     .authorities("EPSG", "ESRI")
     .format(CRSResult.Format.PROJ4)
-    .connectTimeout(5)   // seconds
-    .readTimeout(5)      // seconds
-    .maxRetries(2)
+    .connectTimeout(3)             // per connection
+    .readTimeout(5)                // per request
+    .totalTimeout(8)               // entire lookup, including retries
+    .maxRetries(2)                 // two total attempts
+    .circuitBreakerFailureThreshold(3)
+    .circuitBreakerResetTimeout(Duration.ofSeconds(30))
     .build();
 ```
+
+The built-in remote provider uses those same reliability settings. Concurrent
+lookups of the same authority and code share one in-flight HTTP request. After
+three consecutive endpoint failures—network failures, HTTP 401/403/408/429, or
+HTTP 5xx—its circuit breaker rejects requests locally for 30 seconds before
+allowing one probe request.
+
+These stricter limits apply to the built-in remote fallback. Custom
+`UrlCRSProvider` instances retain the earlier generic defaults (10-second
+connect timeout, 30-second request timeout, three total attempts, no overall
+deadline, and no circuit breaker) unless configured explicitly.
 
 ### Registering and Managing Providers
 
@@ -181,9 +204,22 @@ Providers are queried in ascending priority order. Lower numbers are checked fir
 |----------|----------|-------------|
 | 50 | (custom) | Your high-priority providers |
 | 100 | BuiltInCRSProvider | Built-in PROJ strings for common EPSG codes |
-| 101 | UrlCRSProvider | spatialreference.org (network access) |
+| 101 | UrlCRSProvider | Immutable OSGeo spatialreference.org snapshot (network access) |
 
 Manual `Defs.set()` definitions always take precedence over providers.
+
+## Caching
+
+Successful provider results are parsed and cached in memory by normalized
+authority code. Repeated lookups such as `EPSG:2154` therefore do not repeat the
+HTTP request within the same JVM. HTTP 404 responses are negatively cached as
+well.
+
+The cache is process-local and is not persisted to disk. In a Spark deployment,
+each executor JVM may fetch a previously unseen CRS once; an executor restart
+starts with an empty cache. HTTP errors and network failures are deliberately
+not cached as missing definitions. The circuit breaker bounds repeated failures
+without confusing them with 404 responses.
 
 ## Error Handling
 
@@ -199,8 +235,14 @@ try {
         case NOT_FOUND:
             System.out.println("CRS not found");
             break;
+        case HTTP_ERROR:
+            System.out.println("CRS endpoint rejected the request: " + e.getMessage());
+            break;
         case NETWORK_ERROR:
             System.out.println("Network error: " + e.getMessage());
+            break;
+        case CIRCUIT_OPEN:
+            System.out.println("CRS endpoint temporarily unavailable: " + e.getMessage());
             break;
         case INVALID_RESPONSE:
             System.out.println("Invalid response from provider");

--- a/docs/crs-registry.md
+++ b/docs/crs-registry.md
@@ -8,9 +8,12 @@ When you create a `Proj` from an authority code (e.g., `new Proj("EPSG:4326")`),
 
 ```
 EPSG:4326  -->  BuiltInCRSProvider (priority 100)
-           -->  UrlCRSProvider / OSGeo GitHub + CDN fallback (priority 101)
+           -->  UrlCRSProvider / OSGeo jsDelivr + GitHub fallback (priority 101)
            -->  Custom providers (user-defined priority)
 ```
+
+A provider returning `null` allows resolution to continue. A provider exception
+stops the chain and is propagated.
 
 ## The Defs Registry
 
@@ -77,10 +80,22 @@ The `BuiltInCRSProvider` (priority 100) supplies PROJ strings for common EPSG co
 
 The `UrlCRSProvider` fetches CRS definitions from HTTP endpoints. The default
 remote provider reads the rolling spatialreference.org `gh-pages` catalog from
-`raw.githubusercontent.com`. If GitHub has an endpoint failure, it tries a
-commit-addressed copy through jsDelivr. The backup was generated from PROJ
-9.8.1 and EPSG v12.029 at OSGeo commit
-`c43e4e72634af65fcf684def42ddc2dcfd834938`.
+jsDelivr:
+
+```
+https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@gh-pages
+```
+
+If that endpoint fails, it uses the rolling raw GitHub branch:
+
+```
+https://raw.githubusercontent.com/OSGeo/spatialreference.org/gh-pages
+```
+
+jsDelivr is the normal traffic endpoint, while raw GitHub provides a separate
+delivery path and direct source check. jsDelivr can cache a branch revision for
+up to about 12 hours, so this arrangement favors availability and lower fan-out
+load over immediate visibility of every upstream commit.
 
 The CRS catalog remains an external runtime dependency; it is not bundled in
 the proj4sedona JAR.
@@ -88,7 +103,7 @@ the proj4sedona JAR.
 ```java
 import org.datasyslab.proj4sedona.defs.UrlCRSProvider;
 
-// The default OSGeo GitHub provider and pinned CDN fallback are registered automatically.
+// The default OSGeo jsDelivr provider and GitHub fallback are registered automatically.
 // It resolves codes like EPSG:2154, ESRI:102001, etc.
 Proj p = new Proj("EPSG:2154");  // fetched remotely if not built in
 ```
@@ -130,19 +145,41 @@ UrlCRSProvider myProvider = UrlCRSProvider.builder("my-crs-service")
 ```
 
 Fallback fetchers are tried in insertion order after network failures, non-404
-HTTP errors, or an open circuit. A reachable primary that returns HTTP 404 is
-authoritative, so an older fallback cannot resurrect a CRS removed from the
-current catalog. If the primary fails and every fallback either fails or
-returns 404, the endpoint failure is propagated with diagnostics for each
-endpoint. An interrupted lookup stops immediately rather than starting another
-request.
+HTTP errors, or an open circuit. By default, a reachable primary that returns
+HTTP 404 is authoritative, so an older fallback cannot resurrect a CRS removed
+from the current catalog. The not-found policy can instead advance to the next
+endpoint. If every endpoint is non-authoritative and returns 404, the result is
+not-found; if an earlier endpoint had a hard failure, that failure is propagated
+after the endpoint list is exhausted. An interrupted lookup stops immediately
+rather than starting another request.
+
+For mirrors that may lag their source, configure a non-authoritative primary
+miss explicitly:
+
+```java
+UrlCRSProvider provider = UrlCRSProvider.builder("cdn-first")
+    .baseUrl("https://cdn.example.com/crs")
+    .primaryNotFoundPolicy(UrlCRSProvider.NotFoundPolicy.TRY_NEXT_ENDPOINT)
+    .fallbackFetcher(
+        mirror,
+        UrlCRSProvider.NotFoundPolicy.AUTHORITATIVE)
+    .build();
+```
+
+The built-in provider uses this policy. A jsDelivr 404 advances to raw GitHub
+for confirmation. A GitHub 404 is authoritative, even if jsDelivr had a hard
+failure. If jsDelivr returns 404 but GitHub has a hard failure, the lookup
+propagates that failure instead of incorrectly reporting the code as missing.
 
 Configure each fallback explicitly. Its headers are not copied from the
 primary, so credentials are scoped to the fetcher on which they were
-configured. Redirects are followed only within the same origin. Every endpoint
-must serve the format configured on the provider.
+configured. Same-origin redirects are followed. Unsafe redirects, including
+cross-origin redirects, are refused and reported as an HTTP error with sanitized
+source and target origins; configured endpoint fallback still applies, and
+headers are never sent to the refused target. Every endpoint must serve the
+format configured on the provider.
 
-The built-in GitHub and jsDelivr fetchers each use the reliability settings in
+The built-in jsDelivr and GitHub fetchers each use the reliability settings in
 the example. Concurrent lookups of the same authority and code share one
 in-flight HTTP request per endpoint. After three consecutive endpoint
 failures—network failures, HTTP 401/403/408/429, or HTTP 5xx—an endpoint's
@@ -152,7 +189,7 @@ allowing one probe request.
 The eight-second overall deadline applies separately to each endpoint. A
 lookup can therefore take up to approximately 16 seconds when both default
 endpoints are unhealthy, with at most two attempts per endpoint. An already
-open GitHub circuit moves to jsDelivr immediately.
+open jsDelivr circuit moves to GitHub immediately.
 
 Failover is based on transport and HTTP status. An HTTP 200 response is returned
 for parsing and does not trigger a fallback if its body is malformed.
@@ -239,7 +276,7 @@ Providers are queried in ascending priority order. Lower numbers are checked fir
 |----------|----------|-------------|
 | 50 | (custom) | Your high-priority providers |
 | 100 | BuiltInCRSProvider | Built-in PROJ strings for common EPSG codes |
-| 101 | UrlCRSProvider | Rolling OSGeo GitHub catalog with pinned CDN fallback |
+| 101 | UrlCRSProvider | Rolling OSGeo catalog through jsDelivr, then raw GitHub |
 
 Manual `Defs.set()` definitions always take precedence over providers.
 
@@ -249,27 +286,37 @@ Successful provider results are parsed and cached in memory by normalized
 authority code. Repeated lookups such as `EPSG:2154` therefore do not repeat the
 HTTP request within the same JVM.
 
-The rolling GitHub primary does not cache HTTP 404 responses permanently,
-because a missing code can be added to the upstream catalog while a JVM is
-running. The immutable jsDelivr fallback does negatively cache 404 responses.
-Custom URL fetchers cache 404 responses by default; use
-`.cacheNotFound(false)` for another rolling catalog.
+Both built-in rolling endpoints cache HTTP 404 responses for five minutes. A
+repeated missing-code lookup therefore avoids repeated downloads during that
+window but can discover a newly added upstream code without restarting the JVM.
+Custom URL fetchers cache 404 responses for the fetcher's lifetime by default.
+Use `.notFoundCacheTtl(Duration.ofMinutes(5))` for an expiring negative cache or
+`.cacheNotFound(false)` to disable negative caching.
 
 The cache is process-local and is not persisted to disk. In a Spark deployment,
 each executor JVM may fetch a previously unseen CRS once; an executor restart
-starts with an empty cache. HTTP errors and network failures are deliberately
-not cached as missing definitions. The circuit breaker bounds repeated failures
-without confusing them with 404 responses.
+starts with an empty cache. Successful definitions remain cached in `Defs` for
+the JVM lifetime, so repeated transforms using the same CRS do not download the
+PROJJSON again. Concurrent first lookups share one in-flight request per
+endpoint. HTTP errors and network failures are deliberately not cached as
+missing definitions. The circuit breaker bounds repeated failures without
+confusing them with 404 responses.
 
 ## Error Handling
 
-When a CRS cannot be resolved, a `CRSFetchException` is thrown with a `Reason`:
+Only a provider's `null`/not-found result advances to the next registered
+provider. After a URL provider exhausts its configured endpoint fallbacks,
+non-404 HTTP responses and network failures abort the provider chain.
+
+Use `Defs.getOrThrow` when an unresolved code should produce a
+`CRSFetchException` with a `Reason`:
 
 ```java
 import org.datasyslab.proj4sedona.defs.CRSFetchException;
+import org.datasyslab.proj4sedona.defs.Defs;
 
 try {
-    Proj p = new Proj("EPSG:999999");
+    Defs.getOrThrow("EPSG:999999");
 } catch (CRSFetchException e) {
     switch (e.getReason()) {
         case NOT_FOUND:
@@ -290,6 +337,11 @@ try {
     }
 }
 ```
+
+`Defs.get` returns `null` for an unresolved code. Constructors such as
+`new Proj("EPSG:999999")` convert that missing definition to an
+`IllegalArgumentException`; endpoint failures still propagate as
+`CRSFetchException`.
 
 ## Registry Management
 

--- a/src/main/java/org/datasyslab/proj4sedona/defs/CRSFetchException.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/CRSFetchException.java
@@ -6,7 +6,9 @@ package org.datasyslab.proj4sedona.defs;
  * <p>This is an unchecked (runtime) exception that indicates one of the following:</p>
  * <ul>
  *   <li>{@link Reason#NOT_FOUND} - The CRS code does not exist on the remote server (HTTP 404)</li>
+ *   <li>{@link Reason#HTTP_ERROR} - The server rejected the request or returned an error response</li>
  *   <li>{@link Reason#NETWORK_ERROR} - A network error occurred (connection failed, timeout, etc.)</li>
+ *   <li>{@link Reason#CIRCUIT_OPEN} - Requests are temporarily suppressed after repeated failures</li>
  *   <li>{@link Reason#INVALID_RESPONSE} - The server returned an invalid or unparseable response</li>
  * </ul>
  * 
@@ -35,14 +37,24 @@ public class CRSFetchException extends RuntimeException {
         NOT_FOUND,
 
         /**
-         * A network error occurred while fetching (connection failed, timeout, server error, etc.).
+         * A network error occurred while fetching (connection failed, timeout, etc.).
          */
         NETWORK_ERROR,
 
         /**
          * The server returned an invalid or unparseable response.
          */
-        INVALID_RESPONSE
+        INVALID_RESPONSE,
+
+        /**
+         * The remote server returned an HTTP error other than 404.
+         */
+        HTTP_ERROR,
+
+        /**
+         * The remote provider's circuit breaker is open after repeated failures.
+         */
+        CIRCUIT_OPEN
     }
 
     private final String crsCode;

--- a/src/main/java/org/datasyslab/proj4sedona/defs/CRSProvider.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/CRSProvider.java
@@ -13,8 +13,8 @@ package org.datasyslab.proj4sedona.defs;
  *   <li>Return a {@link CRSResult} when the provider can resolve the code.</li>
  *   <li>Return {@code null} when the provider does not know the code, so the next
  *       provider in the chain can try.</li>
- *   <li>Throw {@link CRSFetchException} only on hard errors (network failure,
- *       invalid response) that should abort the chain.</li>
+ *   <li>Throw {@link CRSFetchException} only on hard errors (HTTP or network
+ *       failure, open circuit, invalid response) that should abort the chain.</li>
  * </ul>
  *
  * <h3>Example — custom URL provider</h3>

--- a/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
@@ -22,17 +22,19 @@ import org.datasyslab.proj4sedona.util.CRSUtils;
  * <p>This class maintains a cache of parsed {@link ProjectionDef} objects and a
  * priority-ordered chain of {@link CRSProvider} instances that are consulted on cache
  * miss. Providers are tried in ascending priority order (lower value = tried first);
- * the first non-null {@link CRSResult} is parsed and cached.</p>
+ * the first non-null {@link CRSResult} is parsed and cached. A provider exception
+ * stops resolution and is propagated rather than being treated as not-found.</p>
  *
  * <p>By default, {@link #globals()} registers two providers:</p>
  * <ul>
  *   <li>{@link BuiltInCRSProvider} at priority <b>100</b> — instant map lookup, no network</li>
  *   <li>{@link UrlCRSProvider#spatialReference()} at priority <b>101</b> — fetches
- *       from the OSGeo spatialreference.org GitHub catalog with a pinned CDN fallback</li>
+ *       the OSGeo spatialreference.org catalog through jsDelivr with a raw GitHub fallback</li>
  * </ul>
  *
  * <p>Users can register custom providers at a lower priority to override defaults,
- * or at a higher priority to act as fallback:</p>
+ * or at a higher priority to act as fallback when earlier providers return
+ * {@code null}:</p>
  * <pre>
  * Defs.registerProvider(new MyCRSProvider(), 50);  // tried before built-in
  * </pre>
@@ -419,7 +421,7 @@ public final class Defs {
      * <ul>
      *   <li>{@link BuiltInCRSProvider} at priority 100</li>
      *   <li>{@link UrlCRSProvider#spatialReference()} at priority 101, backed by
-     *       the OSGeo GitHub catalog and a pinned CDN fallback</li>
+     *       the OSGeo catalog through jsDelivr and raw GitHub</li>
      * </ul>
      *
      * <p>It also pre-populates the cache with common aliases that are not in

--- a/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
@@ -27,7 +27,8 @@ import org.datasyslab.proj4sedona.util.CRSUtils;
  * <p>By default, {@link #globals()} registers two providers:</p>
  * <ul>
  *   <li>{@link BuiltInCRSProvider} at priority <b>100</b> — instant map lookup, no network</li>
- *   <li>{@link UrlCRSProvider#spatialReference()} at priority <b>101</b> — fetches from spatialreference.org</li>
+ *   <li>{@link UrlCRSProvider#spatialReference()} at priority <b>101</b> — fetches
+ *       from an immutable OSGeo spatialreference.org snapshot</li>
  * </ul>
  *
  * <p>Users can register custom providers at a lower priority to override defaults,
@@ -256,7 +257,8 @@ public final class Defs {
      *
      * @param name The name/code to look up (e.g., "EPSG:4326", "WGS84", "ESRI:102001")
      * @return The ProjectionDef, or null if no provider can resolve the code
-     * @throws CRSFetchException if a provider encounters a hard error (network failure, etc.)
+     * @throws CRSFetchException if a provider encounters an HTTP or network failure,
+     *         open circuit, or invalid response
      */
     public static ProjectionDef get(String name) {
         // Auto-initialize globals if not yet done
@@ -299,7 +301,8 @@ public final class Defs {
      * @return The ProjectionDef (never null)
      * @throws CRSFetchException with {@link CRSFetchException.Reason#NOT_FOUND} if no
      *         provider can resolve the code
-     * @throws CRSFetchException if a provider encounters a hard error (network failure, etc.)
+     * @throws CRSFetchException if a provider encounters an HTTP or network failure,
+     *         open circuit, or invalid response
      */
     public static ProjectionDef getOrThrow(String name) {
         ProjectionDef def = get(name);
@@ -415,7 +418,8 @@ public final class Defs {
      * after the first call. It registers:</p>
      * <ul>
      *   <li>{@link BuiltInCRSProvider} at priority 100</li>
-     *   <li>{@link UrlCRSProvider#spatialReference()} at priority 101</li>
+     *   <li>{@link UrlCRSProvider#spatialReference()} at priority 101, backed by
+     *       an immutable OSGeo snapshot</li>
      * </ul>
      *
      * <p>It also pre-populates the cache with common aliases that are not in

--- a/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/Defs.java
@@ -28,7 +28,7 @@ import org.datasyslab.proj4sedona.util.CRSUtils;
  * <ul>
  *   <li>{@link BuiltInCRSProvider} at priority <b>100</b> — instant map lookup, no network</li>
  *   <li>{@link UrlCRSProvider#spatialReference()} at priority <b>101</b> — fetches
- *       from an immutable OSGeo spatialreference.org snapshot</li>
+ *       from the OSGeo spatialreference.org GitHub catalog with a pinned CDN fallback</li>
  * </ul>
  *
  * <p>Users can register custom providers at a lower priority to override defaults,
@@ -419,7 +419,7 @@ public final class Defs {
      * <ul>
      *   <li>{@link BuiltInCRSProvider} at priority 100</li>
      *   <li>{@link UrlCRSProvider#spatialReference()} at priority 101, backed by
-     *       an immutable OSGeo snapshot</li>
+     *       the OSGeo GitHub catalog and a pinned CDN fallback</li>
      * </ul>
      *
      * <p>It also pre-populates the cache with common aliases that are not in

--- a/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSFetcher.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSFetcher.java
@@ -288,6 +288,9 @@ public final class UrlCRSFetcher {
     /** Default circuit-breaker threshold; zero leaves the breaker disabled. */
     public static final int DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD = 0;
 
+    /** Default behavior for caching HTTP 404 responses. */
+    public static final boolean DEFAULT_CACHE_NOT_FOUND = true;
+
     /** Default delay before allowing a probe request through an open circuit. */
     public static final Duration DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT = Duration.ofSeconds(30);
 
@@ -306,6 +309,7 @@ public final class UrlCRSFetcher {
     private final int totalTimeoutSeconds;
     private final int circuitBreakerFailureThreshold;
     private final long circuitBreakerResetTimeoutNanos;
+    private final boolean cacheNotFound;
     private final Map<String, String> headers;
     private final HttpClient httpClient;
 
@@ -343,6 +347,7 @@ public final class UrlCRSFetcher {
         this.circuitBreakerFailureThreshold = builder.circuitBreakerFailureThreshold;
         this.circuitBreakerResetTimeoutNanos =
                 builder.circuitBreakerResetTimeout.toNanos();
+        this.cacheNotFound = builder.cacheNotFound;
         this.headers = Collections.unmodifiableMap(new LinkedHashMap<>(builder.headers));
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(connectTimeoutSeconds))
@@ -371,7 +376,7 @@ public final class UrlCRSFetcher {
     public FetchResult fetch(String authority, String code) {
         String cacheKey = authority.toLowerCase(Locale.ROOT) + ":" + code;
 
-        if (notFoundCache.contains(cacheKey)) {
+        if (cacheNotFound && notFoundCache.contains(cacheKey)) {
             return FetchResult.notFound(0);
         }
 
@@ -450,7 +455,9 @@ public final class UrlCRSFetcher {
                 if (statusCode == 200) {
                     return FetchResult.success(response.body(), attemptCount);
                 } else if (statusCode == 404) {
-                    notFoundCache.add(cacheKey);
+                    if (cacheNotFound) {
+                        notFoundCache.add(cacheKey);
+                    }
                     return FetchResult.notFound(attemptCount);
                 } else if (isRetryableStatusCode(statusCode)) {
                     lastHttpStatusCode = statusCode;
@@ -488,7 +495,15 @@ public final class UrlCRSFetcher {
 
     private FetchResult awaitInFlight(CompletableFuture<FetchResult> request) {
         try {
-            return request.get();
+            FetchResult sharedResult = request.get();
+            if (isInterruptedNetworkError(sharedResult)) {
+                return FetchResult.networkError(
+                        new IOException(
+                                "The owner of the shared CRS fetch was interrupted",
+                                sharedResult.getLastException()),
+                        sharedResult.getAttemptCount());
+            }
+            return sharedResult;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return FetchResult.networkError(e, 0);
@@ -613,6 +628,10 @@ public final class UrlCRSFetcher {
     }
 
     private static boolean isNeutralEndpointResult(FetchResult result) {
+        return isInterruptedNetworkError(result);
+    }
+
+    private static boolean isInterruptedNetworkError(FetchResult result) {
         return result.isNetworkError()
                 && result.getLastException() instanceof InterruptedException;
     }
@@ -742,8 +761,21 @@ public final class UrlCRSFetcher {
                 && !"https".equalsIgnoreCase(targetScheme)) {
             return false;
         }
-        return !"https".equalsIgnoreCase(source.getScheme())
-                || "https".equalsIgnoreCase(targetScheme);
+        if (target.getUserInfo() != null
+                || !source.getScheme().equalsIgnoreCase(targetScheme)
+                || source.getHost() == null
+                || target.getHost() == null
+                || !source.getHost().equalsIgnoreCase(target.getHost())) {
+            return false;
+        }
+        return effectivePort(source) == effectivePort(target);
+    }
+
+    private static int effectivePort(URI uri) {
+        if (uri.getPort() >= 0) {
+            return uri.getPort();
+        }
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
     }
 
     // ==================== Retry Helpers ====================
@@ -810,6 +842,9 @@ public final class UrlCRSFetcher {
         return Duration.ofNanos(circuitBreakerResetTimeoutNanos);
     }
 
+    /** Check whether HTTP 404 responses are cached. */
+    public boolean isNotFoundCacheEnabled() { return cacheNotFound; }
+
     /** Get the number of consecutive endpoint failures. */
     public int getConsecutiveFailureCount() {
         synchronized (circuitLock) {
@@ -868,6 +903,7 @@ public final class UrlCRSFetcher {
                 DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD;
         private Duration circuitBreakerResetTimeout =
                 DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT;
+        private boolean cacheNotFound = DEFAULT_CACHE_NOT_FOUND;
         private final Map<String, String> headers = new LinkedHashMap<>();
 
         private Builder() {}
@@ -1017,6 +1053,21 @@ public final class UrlCRSFetcher {
                         "circuit breaker reset timeout must be positive");
             }
             this.circuitBreakerResetTimeout = timeout;
+            return this;
+        }
+
+        /**
+         * Set whether HTTP 404 responses are cached for the lifetime of this fetcher.
+         * Default: {@code true}.
+         *
+         * <p>Disable this for a rolling catalog where a previously missing code may
+         * be added while the JVM is still running.</p>
+         *
+         * @param enabled whether to cache HTTP 404 responses
+         * @return this builder
+         */
+        public Builder cacheNotFound(boolean enabled) {
+            this.cacheNotFound = enabled;
             return this;
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSFetcher.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSFetcher.java
@@ -2,18 +2,29 @@ package org.datasyslab.proj4sedona.defs;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * HTTP fetch engine for retrieving CRS definition files (PROJJSON, WKT, PROJ.4)
@@ -22,8 +33,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>This class is used by {@link UrlCRSProvider} and handles:</p>
  * <ul>
  *   <li>URL construction from a configurable base URL and path template</li>
- *   <li>Retry with exponential backoff for transient failures</li>
+ *   <li>Bounded retry with exponential backoff for transient failures</li>
  *   <li>Negative cache to skip known 404s</li>
+ *   <li>Single-flight request coalescing for concurrent lookups of the same CRS</li>
+ *   <li>A host-level circuit breaker to avoid repeatedly calling an unhealthy endpoint</li>
  *   <li>Custom HTTP headers (e.g., for private GitHub repos or pre-signed S3)</li>
  * </ul>
  *
@@ -54,6 +67,104 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public final class UrlCRSFetcher {
 
+    private enum CircuitState {
+        CLOSED,
+        OPEN,
+        HALF_OPEN
+    }
+
+    private static final class CircuitPermit {
+        private final long generation;
+        private final boolean halfOpenProbe;
+
+        private CircuitPermit(long generation, boolean halfOpenProbe) {
+            this.generation = generation;
+            this.halfOpenProbe = halfOpenProbe;
+        }
+    }
+
+    private static final class CancellableBodyHandler<T>
+            implements HttpResponse.BodyHandler<T> {
+        private final HttpResponse.BodyHandler<T> delegate;
+        private volatile CancellableBodySubscriber<T> subscriber;
+        private volatile boolean cancelled;
+
+        private CancellableBodyHandler(HttpResponse.BodyHandler<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public HttpResponse.BodySubscriber<T> apply(
+                HttpResponse.ResponseInfo responseInfo) {
+            CancellableBodySubscriber<T> wrapped =
+                    new CancellableBodySubscriber<>(delegate.apply(responseInfo));
+            subscriber = wrapped;
+            if (cancelled) {
+                wrapped.cancel();
+            }
+            return wrapped;
+        }
+
+        private void cancel() {
+            cancelled = true;
+            CancellableBodySubscriber<T> current = subscriber;
+            if (current != null) {
+                current.cancel();
+            }
+        }
+    }
+
+    private static final class CancellableBodySubscriber<T>
+            implements HttpResponse.BodySubscriber<T> {
+        private final HttpResponse.BodySubscriber<T> delegate;
+        private volatile Flow.Subscription subscription;
+        private volatile boolean cancelled;
+
+        private CancellableBodySubscriber(HttpResponse.BodySubscriber<T> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public CompletionStage<T> getBody() {
+            return delegate.getBody();
+        }
+
+        @Override
+        public void onSubscribe(Flow.Subscription newSubscription) {
+            subscription = newSubscription;
+            if (cancelled) {
+                newSubscription.cancel();
+            }
+            delegate.onSubscribe(newSubscription);
+            if (cancelled) {
+                newSubscription.cancel();
+            }
+        }
+
+        @Override
+        public void onNext(List<ByteBuffer> item) {
+            delegate.onNext(item);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            delegate.onError(throwable);
+        }
+
+        @Override
+        public void onComplete() {
+            delegate.onComplete();
+        }
+
+        private void cancel() {
+            cancelled = true;
+            Flow.Subscription current = subscription;
+            if (current != null) {
+                current.cancel();
+            }
+        }
+    }
+
     // ==================== FetchResult ====================
 
     /**
@@ -69,34 +180,58 @@ public final class UrlCRSFetcher {
             /** The CRS code was not found (HTTP 404) */
             NOT_FOUND,
             /** A network error occurred after exhausting retries */
-            NETWORK_ERROR
+            NETWORK_ERROR,
+            /** The server returned an HTTP error other than 404 */
+            HTTP_ERROR,
+            /** The request was skipped because the endpoint circuit breaker is open */
+            CIRCUIT_OPEN
         }
 
         private final Status status;
         private final String body;
         private final Exception lastException;
         private final int attemptCount;
+        private final int httpStatusCode;
 
-        private FetchResult(Status status, String body, Exception lastException, int attemptCount) {
+        private FetchResult(
+                Status status,
+                String body,
+                Exception lastException,
+                int attemptCount,
+                int httpStatusCode) {
             this.status = status;
             this.body = body;
             this.lastException = lastException;
             this.attemptCount = attemptCount;
+            this.httpStatusCode = httpStatusCode;
         }
 
         /** Create a successful result. */
         public static FetchResult success(String body, int attemptCount) {
-            return new FetchResult(Status.SUCCESS, body, null, attemptCount);
+            return new FetchResult(Status.SUCCESS, body, null, attemptCount, 200);
         }
 
         /** Create a not-found result. */
         public static FetchResult notFound(int attemptCount) {
-            return new FetchResult(Status.NOT_FOUND, null, null, attemptCount);
+            return new FetchResult(Status.NOT_FOUND, null, null, attemptCount, 404);
+        }
+
+        /** Create an HTTP error result. */
+        public static FetchResult httpError(
+                int statusCode, Exception lastException, int attemptCount) {
+            return new FetchResult(
+                    Status.HTTP_ERROR, null, lastException, attemptCount, statusCode);
         }
 
         /** Create a network error result. */
         public static FetchResult networkError(Exception lastException, int attemptCount) {
-            return new FetchResult(Status.NETWORK_ERROR, null, lastException, attemptCount);
+            return new FetchResult(
+                    Status.NETWORK_ERROR, null, lastException, attemptCount, -1);
+        }
+
+        /** Create a circuit-open result. */
+        public static FetchResult circuitOpen(Exception lastException) {
+            return new FetchResult(Status.CIRCUIT_OPEN, null, lastException, 0, -1);
         }
 
         /** Get the status of this result. */
@@ -111,14 +246,23 @@ public final class UrlCRSFetcher {
         /** Check if a network error occurred. */
         public boolean isNetworkError() { return status == Status.NETWORK_ERROR; }
 
+        /** Check if the server returned a non-404 HTTP error. */
+        public boolean isHttpError() { return status == Status.HTTP_ERROR; }
+
+        /** Check if the request was rejected by the circuit breaker. */
+        public boolean isCircuitOpen() { return status == Status.CIRCUIT_OPEN; }
+
         /** Get the response body (only valid if status is SUCCESS). */
         public String getBody() { return body; }
 
-        /** Get the last exception (only valid if status is NETWORK_ERROR). */
+        /** Get the underlying exception for HTTP, network, or circuit-open failures. */
         public Exception getLastException() { return lastException; }
 
         /** Get the number of attempts made. */
         public int getAttemptCount() { return attemptCount; }
+
+        /** Get the HTTP status code, or -1 when no response was received. */
+        public int getHttpStatusCode() { return httpStatusCode; }
     }
 
     // ==================== Defaults ====================
@@ -132,14 +276,24 @@ public final class UrlCRSFetcher {
     /** Default read timeout in seconds. */
     public static final int DEFAULT_READ_TIMEOUT_SECONDS = 30;
 
-    /** Default maximum number of retry attempts. */
+    /** Default maximum number of total attempts, including the initial request. */
     public static final int DEFAULT_MAX_RETRIES = 3;
 
     /** Default initial backoff delay in milliseconds. */
     public static final long DEFAULT_INITIAL_BACKOFF_MS = 500;
 
+    /** Default overall deadline; zero preserves the per-attempt timeouts without a total limit. */
+    public static final int DEFAULT_TOTAL_TIMEOUT_SECONDS = 0;
+
+    /** Default circuit-breaker threshold; zero leaves the breaker disabled. */
+    public static final int DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD = 0;
+
+    /** Default delay before allowing a probe request through an open circuit. */
+    public static final Duration DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT = Duration.ofSeconds(30);
+
     private static final double BACKOFF_MULTIPLIER = 2.0;
     private static final long MAX_BACKOFF_MS = 5000;
+    private static final int MAX_REDIRECTS = 5;
 
     // ==================== Instance Fields ====================
 
@@ -149,11 +303,32 @@ public final class UrlCRSFetcher {
     private final int readTimeoutSeconds;
     private final int maxRetries;
     private final long initialBackoffMs;
+    private final int totalTimeoutSeconds;
+    private final int circuitBreakerFailureThreshold;
+    private final long circuitBreakerResetTimeoutNanos;
     private final Map<String, String> headers;
     private final HttpClient httpClient;
 
     /** Negative cache: track codes that are known 404s. */
     private final Set<String> notFoundCache = ConcurrentHashMap.newKeySet();
+
+    /** Concurrent requests for the same authority/code share one HTTP operation. */
+    private final Map<String, CompletableFuture<FetchResult>> inFlight = new ConcurrentHashMap<>();
+
+    /** Guards all circuit-breaker state and generation transitions. */
+    private final Object circuitLock = new Object();
+
+    /** Circuit state for the configured endpoint. Guarded by {@link #circuitLock}. */
+    private CircuitState circuitState = CircuitState.CLOSED;
+
+    /** Consecutive logical lookup failures. Guarded by {@link #circuitLock}. */
+    private int consecutiveFailures;
+
+    /** Monotonic timestamp when the circuit opened. Guarded by {@link #circuitLock}. */
+    private long circuitOpenedAtNanos;
+
+    /** Invalidates results from requests admitted under an older circuit state. */
+    private long circuitGeneration;
 
     // ==================== Constructor (via Builder) ====================
 
@@ -164,10 +339,14 @@ public final class UrlCRSFetcher {
         this.readTimeoutSeconds = builder.readTimeoutSeconds;
         this.maxRetries = builder.maxRetries;
         this.initialBackoffMs = builder.initialBackoffMs;
+        this.totalTimeoutSeconds = builder.totalTimeoutSeconds;
+        this.circuitBreakerFailureThreshold = builder.circuitBreakerFailureThreshold;
+        this.circuitBreakerResetTimeoutNanos =
+                builder.circuitBreakerResetTimeout.toNanos();
         this.headers = Collections.unmodifiableMap(new LinkedHashMap<>(builder.headers));
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(connectTimeoutSeconds))
-                .followRedirects(HttpClient.Redirect.NORMAL)
+                .followRedirects(HttpClient.Redirect.NEVER)
                 .build();
     }
 
@@ -196,25 +375,76 @@ public final class UrlCRSFetcher {
             return FetchResult.notFound(0);
         }
 
+        CompletableFuture<FetchResult> request = new CompletableFuture<>();
+        CompletableFuture<FetchResult> existing = inFlight.putIfAbsent(cacheKey, request);
+        if (existing != null) {
+            return awaitInFlight(existing);
+        }
+
+        CircuitPermit circuitPermit = null;
+        try {
+            circuitPermit = acquireCircuitPermit();
+            if (circuitPermit == null) {
+                FetchResult circuitRejection = circuitOpenResult();
+                request.complete(circuitRejection);
+                return circuitRejection;
+            }
+
+            FetchResult result = fetchWithRetries(authority, code, cacheKey);
+            if (isNeutralEndpointResult(result)) {
+                releaseCircuitPermit(circuitPermit);
+            } else {
+                recordEndpointResult(circuitPermit, isEndpointFailure(result));
+            }
+            request.complete(result);
+            return result;
+        } catch (RuntimeException | Error e) {
+            releaseCircuitPermit(circuitPermit);
+            request.completeExceptionally(e);
+            throw e;
+        } finally {
+            inFlight.remove(cacheKey, request);
+        }
+    }
+
+    private FetchResult fetchWithRetries(String authority, String code, String cacheKey) {
         String url = buildUrl(authority, code);
         Exception lastException = null;
+        int lastHttpStatusCode = -1;
         int attemptCount = 0;
+        long deadlineNanos = totalTimeoutSeconds == 0
+                ? 0
+                : System.nanoTime() + Duration.ofSeconds(totalTimeoutSeconds).toNanos();
 
         for (int attempt = 0; attempt < maxRetries; attempt++) {
-            attemptCount = attempt + 1;
-
             if (attempt > 0) {
                 long backoffMs = calculateBackoff(attempt);
+                long remainingNanos = remainingNanos(deadlineNanos);
+                if (remainingNanos <= 0) {
+                    lastException = overallTimeout(url);
+                    lastHttpStatusCode = -1;
+                    break;
+                }
+                long remainingMs = Math.max(1, Duration.ofNanos(remainingNanos).toMillis());
+                long boundedBackoffMs = Math.min(backoffMs, remainingMs);
                 try {
-                    Thread.sleep(backoffMs);
+                    Thread.sleep(boundedBackoffMs);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     return FetchResult.networkError(e, attemptCount);
                 }
             }
 
+            long remainingNanos = remainingNanos(deadlineNanos);
+            if (remainingNanos <= 0) {
+                lastException = overallTimeout(url);
+                lastHttpStatusCode = -1;
+                break;
+            }
+
+            attemptCount = attempt + 1;
             try {
-                HttpResponse<String> response = executeRequest(url);
+                HttpResponse<String> response = executeRequest(url, remainingNanos);
                 int statusCode = response.statusCode();
 
                 if (statusCode == 200) {
@@ -223,17 +453,20 @@ public final class UrlCRSFetcher {
                     notFoundCache.add(cacheKey);
                     return FetchResult.notFound(attemptCount);
                 } else if (isRetryableStatusCode(statusCode)) {
+                    lastHttpStatusCode = statusCode;
                     lastException = new IOException("HTTP " + statusCode + " from " + url);
                     continue;
                 } else {
-                    // Other 4xx — treat as not found
-                    return FetchResult.notFound(attemptCount);
+                    IOException error = new IOException("HTTP " + statusCode + " from " + url);
+                    return FetchResult.httpError(statusCode, error, attemptCount);
                 }
             } catch (ConnectException | SocketTimeoutException e) {
                 lastException = e;
+                lastHttpStatusCode = -1;
             } catch (IOException e) {
                 if (isRetryableException(e)) {
                     lastException = e;
+                    lastHttpStatusCode = -1;
                 } else {
                     return FetchResult.networkError(e, attemptCount);
                 }
@@ -243,7 +476,145 @@ public final class UrlCRSFetcher {
             }
         }
 
+        if (lastHttpStatusCode >= 0) {
+            return FetchResult.httpError(
+                    lastHttpStatusCode, lastException, attemptCount);
+        }
+        if (lastException == null) {
+            lastException = overallTimeout(url);
+        }
         return FetchResult.networkError(lastException, attemptCount);
+    }
+
+    private FetchResult awaitInFlight(CompletableFuture<FetchResult> request) {
+        try {
+            return request.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return FetchResult.networkError(e, 0);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            Exception wrapped = cause instanceof Exception
+                    ? (Exception) cause
+                    : new IOException("Concurrent CRS fetch failed", cause);
+            return FetchResult.networkError(wrapped, 0);
+        }
+    }
+
+    private FetchResult circuitOpenResult() {
+        IOException error = new IOException(
+                "Circuit breaker is open for CRS endpoint " + baseUrl);
+        return FetchResult.circuitOpen(error);
+    }
+
+    private CircuitPermit acquireCircuitPermit() {
+        synchronized (circuitLock) {
+            if (circuitState == CircuitState.CLOSED) {
+                return new CircuitPermit(circuitGeneration, false);
+            }
+            if (circuitState == CircuitState.OPEN
+                    && System.nanoTime() - circuitOpenedAtNanos
+                            >= circuitBreakerResetTimeoutNanos) {
+                circuitState = CircuitState.HALF_OPEN;
+                return new CircuitPermit(circuitGeneration, true);
+            }
+            return null;
+        }
+    }
+
+    private void recordEndpointResult(CircuitPermit permit, boolean failed) {
+        if (circuitBreakerFailureThreshold == 0) {
+            return;
+        }
+        synchronized (circuitLock) {
+            if (permit.generation != circuitGeneration) {
+                return;
+            }
+
+            if (permit.halfOpenProbe) {
+                if (circuitState != CircuitState.HALF_OPEN) {
+                    return;
+                }
+                circuitGeneration++;
+                if (failed) {
+                    circuitState = CircuitState.OPEN;
+                    circuitOpenedAtNanos = System.nanoTime();
+                    consecutiveFailures = circuitBreakerFailureThreshold;
+                } else {
+                    closeCircuit();
+                }
+                return;
+            }
+
+            if (circuitState != CircuitState.CLOSED) {
+                return;
+            }
+            if (!failed) {
+                consecutiveFailures = 0;
+                return;
+            }
+
+            consecutiveFailures++;
+            if (consecutiveFailures >= circuitBreakerFailureThreshold) {
+                circuitGeneration++;
+                circuitState = CircuitState.OPEN;
+                circuitOpenedAtNanos = System.nanoTime();
+            }
+        }
+    }
+
+    private void releaseCircuitPermit(CircuitPermit permit) {
+        if (permit == null || !permit.halfOpenProbe) {
+            return;
+        }
+        synchronized (circuitLock) {
+            if (permit.generation == circuitGeneration
+                    && circuitState == CircuitState.HALF_OPEN) {
+                circuitGeneration++;
+                circuitState = CircuitState.OPEN;
+            }
+        }
+    }
+
+    private void closeCircuit() {
+        circuitState = CircuitState.CLOSED;
+        consecutiveFailures = 0;
+        circuitOpenedAtNanos = 0;
+    }
+
+    private static SocketTimeoutException overallTimeout(String url) {
+        return new SocketTimeoutException(
+                "Overall timeout while fetching CRS definition from " + url);
+    }
+
+    private static long remainingNanos(long deadlineNanos) {
+        return deadlineNanos == 0 ? Long.MAX_VALUE : deadlineNanos - System.nanoTime();
+    }
+
+    private static boolean isEndpointFailure(FetchResult result) {
+        if (result.isNetworkError()) {
+            return true;
+        }
+        if (!result.isHttpError()) {
+            return false;
+        }
+        int statusCode = result.getHttpStatusCode();
+        return statusCode >= 500
+                || statusCode == 401
+                || statusCode == 403
+                || statusCode == 408
+                || statusCode == 429;
+    }
+
+    private static boolean isNeutralEndpointResult(FetchResult result) {
+        return result.isNetworkError()
+                && result.getLastException() instanceof InterruptedException;
     }
 
     // ==================== URL Building ====================
@@ -269,10 +640,55 @@ public final class UrlCRSFetcher {
 
     // ==================== HTTP Execution ====================
 
-    private HttpResponse<String> executeRequest(String url) throws IOException, InterruptedException {
+    private HttpResponse<String> executeRequest(String url, long remainingNanos)
+            throws IOException, InterruptedException {
+        long readTimeoutNanos = Duration.ofSeconds(readTimeoutSeconds).toNanos();
+        long requestTimeoutNanos =
+                Math.max(1, Math.min(readTimeoutNanos, remainingNanos));
+        long requestDeadlineNanos = System.nanoTime() + requestTimeoutNanos;
+        URI currentUri = URI.create(url);
+
+        for (int redirects = 0; ; redirects++) {
+            long currentRequestTimeoutNanos =
+                    requestDeadlineNanos - System.nanoTime();
+            if (currentRequestTimeoutNanos <= 0) {
+                throw overallTimeout(url);
+            }
+
+            HttpResponse<String> response =
+                    executeSingleRequest(currentUri, currentRequestTimeoutNanos);
+            if (!isRedirectStatusCode(response.statusCode())) {
+                return response;
+            }
+
+            String location = response.headers().firstValue("location").orElse(null);
+            if (location == null) {
+                return response;
+            }
+            if (redirects >= MAX_REDIRECTS) {
+                throw new IOException("Too many redirects while fetching " + url);
+            }
+
+            URI redirectUri;
+            try {
+                redirectUri = currentUri.resolve(location);
+            } catch (IllegalArgumentException e) {
+                throw new IOException("Invalid redirect from " + currentUri, e);
+            }
+            if (!isAllowedRedirect(currentUri, redirectUri)) {
+                return response;
+            }
+            currentUri = redirectUri;
+        }
+    }
+
+    private HttpResponse<String> executeSingleRequest(
+            URI uri, long requestTimeoutNanos)
+            throws IOException, InterruptedException {
+        Duration requestTimeout = Duration.ofNanos(requestTimeoutNanos);
         HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
-                .uri(URI.create(url))
-                .timeout(Duration.ofSeconds(readTimeoutSeconds))
+                .uri(uri)
+                .timeout(requestTimeout)
                 .GET();
 
         // Apply custom headers
@@ -280,7 +696,54 @@ public final class UrlCRSFetcher {
             reqBuilder.header(h.getKey(), h.getValue());
         }
 
-        return httpClient.send(reqBuilder.build(), HttpResponse.BodyHandlers.ofString());
+        CancellableBodyHandler<String> bodyHandler =
+                new CancellableBodyHandler<>(HttpResponse.BodyHandlers.ofString());
+        CompletableFuture<HttpResponse<String>> responseFuture =
+                httpClient.sendAsync(reqBuilder.build(), bodyHandler);
+        try {
+            return responseFuture.get(requestTimeoutNanos, TimeUnit.NANOSECONDS);
+        } catch (TimeoutException e) {
+            bodyHandler.cancel();
+            responseFuture.cancel(true);
+            SocketTimeoutException timeout = new SocketTimeoutException(
+                    "Timed out while fetching CRS response body from " + uri);
+            timeout.initCause(e);
+            throw timeout;
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw (IOException) cause;
+            }
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new IOException("Failed to fetch CRS definition from " + uri, cause);
+        } catch (InterruptedException e) {
+            bodyHandler.cancel();
+            responseFuture.cancel(true);
+            throw e;
+        }
+    }
+
+    private static boolean isRedirectStatusCode(int statusCode) {
+        return statusCode == 301
+                || statusCode == 302
+                || statusCode == 303
+                || statusCode == 307
+                || statusCode == 308;
+    }
+
+    private static boolean isAllowedRedirect(URI source, URI target) {
+        String targetScheme = target.getScheme();
+        if (!"http".equalsIgnoreCase(targetScheme)
+                && !"https".equalsIgnoreCase(targetScheme)) {
+            return false;
+        }
+        return !"https".equalsIgnoreCase(source.getScheme())
+                || "https".equalsIgnoreCase(targetScheme);
     }
 
     // ==================== Retry Helpers ====================
@@ -297,7 +760,11 @@ public final class UrlCRSFetcher {
     }
 
     private static boolean isRetryableException(Exception e) {
-        if (e instanceof ConnectException || e instanceof SocketTimeoutException) {
+        if (e instanceof ConnectException
+                || e instanceof NoRouteToHostException
+                || e instanceof SocketTimeoutException
+                || e instanceof UnknownHostException
+                || e instanceof HttpTimeoutException) {
             return true;
         }
         String message = e.getMessage();
@@ -318,7 +785,7 @@ public final class UrlCRSFetcher {
     /** Get the configured path template. */
     public String getPathTemplate() { return pathTemplate; }
 
-    /** Get the max retries. */
+    /** Get the maximum number of total attempts. */
     public int getMaxRetries() { return maxRetries; }
 
     /** Get the connect timeout in seconds. */
@@ -329,6 +796,44 @@ public final class UrlCRSFetcher {
 
     /** Get the initial backoff in milliseconds. */
     public long getInitialBackoffMs() { return initialBackoffMs; }
+
+    /** Get the overall lookup timeout in seconds. */
+    public int getTotalTimeoutSeconds() { return totalTimeoutSeconds; }
+
+    /** Get the number of failed lookups that opens the circuit. */
+    public int getCircuitBreakerFailureThreshold() {
+        return circuitBreakerFailureThreshold;
+    }
+
+    /** Get the circuit breaker reset timeout. */
+    public Duration getCircuitBreakerResetTimeout() {
+        return Duration.ofNanos(circuitBreakerResetTimeoutNanos);
+    }
+
+    /** Get the number of consecutive endpoint failures. */
+    public int getConsecutiveFailureCount() {
+        synchronized (circuitLock) {
+            return consecutiveFailures;
+        }
+    }
+
+    /** Check whether the endpoint circuit has been opened. */
+    public boolean isCircuitOpen() {
+        synchronized (circuitLock) {
+            return circuitState != CircuitState.CLOSED;
+        }
+    }
+
+    /** Close the circuit and clear its failure count. */
+    public void resetCircuitBreaker() {
+        synchronized (circuitLock) {
+            circuitGeneration++;
+            closeCircuit();
+        }
+    }
+
+    /** Get the number of currently active logical fetches. */
+    int getInFlightCount() { return inFlight.size(); }
 
     /** Get the unmodifiable map of custom headers. */
     public Map<String, String> getHeaders() { return headers; }
@@ -358,6 +863,11 @@ public final class UrlCRSFetcher {
         private int readTimeoutSeconds = DEFAULT_READ_TIMEOUT_SECONDS;
         private int maxRetries = DEFAULT_MAX_RETRIES;
         private long initialBackoffMs = DEFAULT_INITIAL_BACKOFF_MS;
+        private int totalTimeoutSeconds = DEFAULT_TOTAL_TIMEOUT_SECONDS;
+        private int circuitBreakerFailureThreshold =
+                DEFAULT_CIRCUIT_BREAKER_FAILURE_THRESHOLD;
+        private Duration circuitBreakerResetTimeout =
+                DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT;
         private final Map<String, String> headers = new LinkedHashMap<>();
 
         private Builder() {}
@@ -448,9 +958,10 @@ public final class UrlCRSFetcher {
         }
 
         /**
-         * Set the maximum number of retry attempts. Default: 3.
+         * Set the maximum number of total attempts, including the initial request.
+         * Default: 3.
          *
-         * @param maxRetries maximum retries (minimum 1)
+         * @param maxRetries maximum total attempts (minimum 1)
          * @return this builder
          */
         public Builder maxRetries(int maxRetries) {
@@ -466,6 +977,46 @@ public final class UrlCRSFetcher {
          */
         public Builder initialBackoffMs(long ms) {
             this.initialBackoffMs = Math.max(0, ms);
+            return this;
+        }
+
+        /**
+         * Set the overall deadline for a logical lookup, including retries and backoff.
+         * Set to zero to rely only on the per-attempt timeouts. Default: 0.
+         *
+         * @param seconds overall timeout in seconds, or zero to disable it
+         * @return this builder
+         */
+        public Builder totalTimeout(int seconds) {
+            this.totalTimeoutSeconds = Math.max(0, seconds);
+            return this;
+        }
+
+        /**
+         * Set the number of consecutive failed lookups that opens the endpoint circuit.
+         * Set to zero to disable circuit breaking. Default: 0.
+         *
+         * @param failures failure threshold, or zero to disable circuit breaking
+         * @return this builder
+         */
+        public Builder circuitBreakerFailureThreshold(int failures) {
+            this.circuitBreakerFailureThreshold = Math.max(0, failures);
+            return this;
+        }
+
+        /**
+         * Set how long an open circuit waits before permitting one probe request.
+         * Default: 30 seconds.
+         *
+         * @param timeout positive reset timeout
+         * @return this builder
+         */
+        public Builder circuitBreakerResetTimeout(Duration timeout) {
+            if (timeout == null || timeout.isZero() || timeout.isNegative()) {
+                throw new IllegalArgumentException(
+                        "circuit breaker reset timeout must be positive");
+            }
+            this.circuitBreakerResetTimeout = timeout;
             return this;
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSFetcher.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSFetcher.java
@@ -17,7 +17,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CompletionStage;
@@ -25,6 +24,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Flow;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.LongSupplier;
 
 /**
  * HTTP fetch engine for retrieving CRS definition files (PROJJSON, WKT, PROJ.4)
@@ -36,7 +37,7 @@ import java.util.concurrent.TimeoutException;
  *   <li>Bounded retry with exponential backoff for transient failures</li>
  *   <li>Negative cache to skip known 404s</li>
  *   <li>Single-flight request coalescing for concurrent lookups of the same CRS</li>
- *   <li>A host-level circuit breaker to avoid repeatedly calling an unhealthy endpoint</li>
+ *   <li>A fetcher-local circuit breaker to avoid repeatedly calling an unhealthy endpoint</li>
  *   <li>Custom HTTP headers (e.g., for private GitHub repos or pre-signed S3)</li>
  * </ul>
  *
@@ -83,6 +84,11 @@ public final class UrlCRSFetcher {
         }
     }
 
+    /**
+     * Java 11 does not reliably stop an active response-body subscription when
+     * the sendAsync future is cancelled. These wrappers retain the subscription
+     * so a lookup timeout can cancel body delivery explicitly.
+     */
     private static final class CancellableBodyHandler<T>
             implements HttpResponse.BodyHandler<T> {
         private final HttpResponse.BodyHandler<T> delegate;
@@ -136,6 +142,8 @@ public final class UrlCRSFetcher {
                 newSubscription.cancel();
             }
             delegate.onSubscribe(newSubscription);
+            // Close the race where cancel() runs while the delegate handles
+            // onSubscribe, after the first check but before it returns.
             if (cancelled) {
                 newSubscription.cancel();
             }
@@ -162,6 +170,18 @@ public final class UrlCRSFetcher {
             if (current != null) {
                 current.cancel();
             }
+        }
+    }
+
+    private static final class RefusedRedirectException extends IOException {
+        private final int statusCode;
+
+        private RefusedRedirectException(int statusCode, URI source, URI target) {
+            super("refused unsafe redirect from " + origin(source) + " to "
+                    + origin(target)
+                    + "; redirects must use HTTP(S), omit user info, "
+                    + "and remain within one origin");
+            this.statusCode = statusCode;
         }
     }
 
@@ -291,6 +311,12 @@ public final class UrlCRSFetcher {
     /** Default behavior for caching HTTP 404 responses. */
     public static final boolean DEFAULT_CACHE_NOT_FOUND = true;
 
+    /**
+     * Default negative-cache TTL. Zero means cached 404s do not expire during
+     * the fetcher's lifetime.
+     */
+    public static final Duration DEFAULT_NOT_FOUND_CACHE_TTL = Duration.ZERO;
+
     /** Default delay before allowing a probe request through an open circuit. */
     public static final Duration DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT = Duration.ofSeconds(30);
 
@@ -310,11 +336,16 @@ public final class UrlCRSFetcher {
     private final int circuitBreakerFailureThreshold;
     private final long circuitBreakerResetTimeoutNanos;
     private final boolean cacheNotFound;
+    private final long notFoundCacheTtlNanos;
+    private final LongSupplier notFoundCacheTicker;
     private final Map<String, String> headers;
     private final HttpClient httpClient;
 
-    /** Negative cache: track codes that are known 404s. */
-    private final Set<String> notFoundCache = ConcurrentHashMap.newKeySet();
+    /** Negative cache: code to monotonic timestamp when its latest 404 arrived. */
+    private final Map<String, Long> notFoundCache = new ConcurrentHashMap<>();
+
+    /** Triggers occasional lazy cleanup for expired entries with distinct keys. */
+    private final AtomicInteger notFoundCacheWrites = new AtomicInteger();
 
     /** Concurrent requests for the same authority/code share one HTTP operation. */
     private final Map<String, CompletableFuture<FetchResult>> inFlight = new ConcurrentHashMap<>();
@@ -348,6 +379,8 @@ public final class UrlCRSFetcher {
         this.circuitBreakerResetTimeoutNanos =
                 builder.circuitBreakerResetTimeout.toNanos();
         this.cacheNotFound = builder.cacheNotFound;
+        this.notFoundCacheTtlNanos = builder.notFoundCacheTtl.toNanos();
+        this.notFoundCacheTicker = builder.notFoundCacheTicker;
         this.headers = Collections.unmodifiableMap(new LinkedHashMap<>(builder.headers));
         this.httpClient = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(connectTimeoutSeconds))
@@ -376,7 +409,7 @@ public final class UrlCRSFetcher {
     public FetchResult fetch(String authority, String code) {
         String cacheKey = authority.toLowerCase(Locale.ROOT) + ":" + code;
 
-        if (cacheNotFound && notFoundCache.contains(cacheKey)) {
+        if (isNotFoundCached(cacheKey)) {
             return FetchResult.notFound(0);
         }
 
@@ -388,6 +421,14 @@ public final class UrlCRSFetcher {
 
         CircuitPermit circuitPermit = null;
         try {
+            // A different owner may have cached a 404 after our fast-path check
+            // but before this request won single-flight ownership.
+            if (isNotFoundCached(cacheKey)) {
+                FetchResult cachedResult = FetchResult.notFound(0);
+                request.complete(cachedResult);
+                return cachedResult;
+            }
+
             circuitPermit = acquireCircuitPermit();
             if (circuitPermit == null) {
                 FetchResult circuitRejection = circuitOpenResult();
@@ -456,7 +497,7 @@ public final class UrlCRSFetcher {
                     return FetchResult.success(response.body(), attemptCount);
                 } else if (statusCode == 404) {
                     if (cacheNotFound) {
-                        notFoundCache.add(cacheKey);
+                        recordNotFound(cacheKey);
                     }
                     return FetchResult.notFound(attemptCount);
                 } else if (isRetryableStatusCode(statusCode)) {
@@ -467,6 +508,9 @@ public final class UrlCRSFetcher {
                     IOException error = new IOException("HTTP " + statusCode + " from " + url);
                     return FetchResult.httpError(statusCode, error, attemptCount);
                 }
+            } catch (RefusedRedirectException e) {
+                return FetchResult.httpError(
+                        e.statusCode, e, attemptCount);
             } catch (ConnectException | SocketTimeoutException e) {
                 lastException = e;
                 lastHttpStatusCode = -1;
@@ -593,6 +637,9 @@ public final class UrlCRSFetcher {
                     && circuitState == CircuitState.HALF_OPEN) {
                 circuitGeneration++;
                 circuitState = CircuitState.OPEN;
+                // The probe ended for a caller-local reason (for example,
+                // interruption), not endpoint evidence. The reset interval has
+                // already elapsed, so allow another caller to probe immediately.
             }
         }
     }
@@ -634,6 +681,50 @@ public final class UrlCRSFetcher {
     private static boolean isInterruptedNetworkError(FetchResult result) {
         return result.isNetworkError()
                 && result.getLastException() instanceof InterruptedException;
+    }
+
+    // ==================== Negative Cache ====================
+
+    private boolean isNotFoundCached(String cacheKey) {
+        if (!cacheNotFound) {
+            return false;
+        }
+        Long cachedAtNanos = notFoundCache.get(cacheKey);
+        if (cachedAtNanos == null) {
+            return false;
+        }
+        if (notFoundCacheTtlNanos == 0
+                || isNotFoundEntryFresh(
+                        cachedAtNanos, notFoundCacheTicker.getAsLong())) {
+            return true;
+        }
+        notFoundCache.remove(cacheKey, cachedAtNanos);
+        return false;
+    }
+
+    private boolean isNotFoundEntryFresh(long cachedAtNanos, long nowNanos) {
+        long elapsedNanos = nowNanos - cachedAtNanos;
+        return elapsedNanos < 0 || elapsedNanos < notFoundCacheTtlNanos;
+    }
+
+    private void recordNotFound(String cacheKey) {
+        notFoundCache.put(cacheKey, notFoundCacheTicker.getAsLong());
+        if (notFoundCacheTtlNanos > 0
+                && (notFoundCacheWrites.incrementAndGet() & 0xff) == 0) {
+            removeExpiredNotFoundEntries();
+        }
+    }
+
+    private void removeExpiredNotFoundEntries() {
+        if (notFoundCacheTtlNanos == 0) {
+            return;
+        }
+        long nowNanos = notFoundCacheTicker.getAsLong();
+        for (Map.Entry<String, Long> entry : notFoundCache.entrySet()) {
+            if (!isNotFoundEntryFresh(entry.getValue(), nowNanos)) {
+                notFoundCache.remove(entry.getKey(), entry.getValue());
+            }
+        }
     }
 
     // ==================== URL Building ====================
@@ -695,7 +786,8 @@ public final class UrlCRSFetcher {
                 throw new IOException("Invalid redirect from " + currentUri, e);
             }
             if (!isAllowedRedirect(currentUri, redirectUri)) {
-                return response;
+                throw new RefusedRedirectException(
+                        response.statusCode(), currentUri, redirectUri);
             }
             currentUri = redirectUri;
         }
@@ -778,6 +870,27 @@ public final class UrlCRSFetcher {
         return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
     }
 
+    private static String origin(URI uri) {
+        String scheme = uri.getScheme() == null
+                ? "<missing-scheme>"
+                : uri.getScheme().toLowerCase(Locale.ROOT);
+        String host = uri.getHost() == null
+                ? "<invalid-host>"
+                : uri.getHost().toLowerCase(Locale.ROOT);
+        StringBuilder result = new StringBuilder()
+                .append(scheme)
+                .append("://");
+        if (host.indexOf(':') >= 0) {
+            result.append('[').append(host).append(']');
+        } else {
+            result.append(host);
+        }
+        if (uri.getPort() >= 0) {
+            result.append(':').append(uri.getPort());
+        }
+        return result.toString();
+    }
+
     // ==================== Retry Helpers ====================
 
     private long calculateBackoff(int attempt) {
@@ -845,6 +958,14 @@ public final class UrlCRSFetcher {
     /** Check whether HTTP 404 responses are cached. */
     public boolean isNotFoundCacheEnabled() { return cacheNotFound; }
 
+    /**
+     * Get the negative-cache TTL. Zero means cached 404s remain for the
+     * fetcher's lifetime.
+     */
+    public Duration getNotFoundCacheTtl() {
+        return Duration.ofNanos(notFoundCacheTtlNanos);
+    }
+
     /** Get the number of consecutive endpoint failures. */
     public int getConsecutiveFailureCount() {
         synchronized (circuitLock) {
@@ -867,22 +988,36 @@ public final class UrlCRSFetcher {
         }
     }
 
-    /** Get the number of currently active logical fetches. */
+    /** Get the number of currently active logical fetches. Visible for testing. */
     int getInFlightCount() { return inFlight.size(); }
 
     /** Get the unmodifiable map of custom headers. */
     public Map<String, String> getHeaders() { return headers; }
 
+    static String refusedRedirectDescription(FetchResult result) {
+        Exception exception = result.getLastException();
+        return exception instanceof RefusedRedirectException
+                ? exception.getMessage()
+                : null;
+    }
+
     /** Check if a code is in the negative cache. */
     public boolean isInNotFoundCache(String authority, String code) {
-        return notFoundCache.contains(authority.toLowerCase(Locale.ROOT) + ":" + code);
+        return isNotFoundCached(
+                authority.toLowerCase(Locale.ROOT) + ":" + code);
     }
 
     /** Get the size of the negative cache. */
-    public int getNotFoundCacheSize() { return notFoundCache.size(); }
+    public int getNotFoundCacheSize() {
+        removeExpiredNotFoundEntries();
+        return notFoundCache.size();
+    }
 
     /** Clear the negative cache. */
-    public void clearNotFoundCache() { notFoundCache.clear(); }
+    public void clearNotFoundCache() {
+        notFoundCache.clear();
+        notFoundCacheWrites.set(0);
+    }
 
     // ==================== Builder ====================
 
@@ -904,6 +1039,8 @@ public final class UrlCRSFetcher {
         private Duration circuitBreakerResetTimeout =
                 DEFAULT_CIRCUIT_BREAKER_RESET_TIMEOUT;
         private boolean cacheNotFound = DEFAULT_CACHE_NOT_FOUND;
+        private Duration notFoundCacheTtl = DEFAULT_NOT_FOUND_CACHE_TTL;
+        private LongSupplier notFoundCacheTicker = System::nanoTime;
         private final Map<String, String> headers = new LinkedHashMap<>();
 
         private Builder() {}
@@ -1057,17 +1194,51 @@ public final class UrlCRSFetcher {
         }
 
         /**
-         * Set whether HTTP 404 responses are cached for the lifetime of this fetcher.
-         * Default: {@code true}.
-         *
-         * <p>Disable this for a rolling catalog where a previously missing code may
-         * be added while the JVM is still running.</p>
+         * Set whether HTTP 404 responses are cached. Default: {@code true}.
+         * Use {@link #notFoundCacheTtl(Duration)} to expire cached misses for a
+         * rolling catalog.
          *
          * @param enabled whether to cache HTTP 404 responses
          * @return this builder
          */
         public Builder cacheNotFound(boolean enabled) {
             this.cacheNotFound = enabled;
+            return this;
+        }
+
+        /**
+         * Set how long HTTP 404 responses remain cached. A zero duration keeps
+         * them for the fetcher's lifetime. Default: zero.
+         *
+         * @param ttl zero for no expiration, or a positive cache duration
+         * @return this builder
+         * @throws IllegalArgumentException if {@code ttl} is null, negative,
+         *         or too large to represent in nanoseconds
+         */
+        public Builder notFoundCacheTtl(Duration ttl) {
+            if (ttl == null || ttl.isNegative()) {
+                throw new IllegalArgumentException(
+                        "not-found cache TTL must not be null or negative");
+            }
+            try {
+                ttl.toNanos();
+            } catch (ArithmeticException e) {
+                throw new IllegalArgumentException(
+                        "not-found cache TTL is too large", e);
+            }
+            this.notFoundCacheTtl = ttl;
+            return this;
+        }
+
+        /**
+         * Override the monotonic clock used by the negative cache. Visible for testing.
+         */
+        Builder notFoundCacheTicker(LongSupplier ticker) {
+            if (ticker == null) {
+                throw new IllegalArgumentException(
+                        "not-found cache ticker must not be null");
+            }
+            this.notFoundCacheTicker = ticker;
             return this;
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSProvider.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSProvider.java
@@ -1,8 +1,11 @@
 package org.datasyslab.proj4sedona.defs;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
@@ -28,6 +31,15 @@ import java.util.Set;
  * UrlCRSProvider privateRepo = UrlCRSProvider.builder("private-crs")
  *     .baseUrl("https://raw.githubusercontent.com/myorg/private-defs/main")
  *     .header("Authorization", "token YOUR_TOKEN_HERE")
+ *     .build();
+ *
+ * // Optional fallback, configured separately so credentials are never copied
+ * UrlCRSFetcher mirror = UrlCRSFetcher.builder()
+ *     .baseUrl("https://mirror.example.com/crs")
+ *     .build();
+ * UrlCRSProvider resilient = UrlCRSProvider.builder("resilient-crs")
+ *     .baseUrl("https://primary.example.com/crs")
+ *     .fallbackFetcher(mirror)
  *     .build();
  *
  * // Register before the defaults (priority &lt; 100)
@@ -64,16 +76,21 @@ public final class UrlCRSProvider implements CRSProvider {
     /**
      * Legacy spatialreference.org origin URL.
      *
-     * @deprecated the default provider uses {@link #SPATIAL_REFERENCE_CDN_BASE_URL}
+     * @deprecated the default provider uses {@link #SPATIAL_REFERENCE_GITHUB_BASE_URL}
+     *             with {@link #SPATIAL_REFERENCE_CDN_BASE_URL} as a fallback
      */
     @Deprecated
     public static final String SPATIAL_REFERENCE_BASE_URL = "https://spatialreference.org";
+
+    /** Primary raw GitHub URL for the rolling OSGeo spatialreference.org catalog. */
+    public static final String SPATIAL_REFERENCE_GITHUB_BASE_URL =
+            "https://raw.githubusercontent.com/OSGeo/spatialreference.org/gh-pages";
 
     /** Generated spatialreference.org data commit based on PROJ 9.8.1. */
     public static final String SPATIAL_REFERENCE_SNAPSHOT_COMMIT =
             "c43e4e72634af65fcf684def42ddc2dcfd834938";
 
-    /** Default CDN URL for the immutable OSGeo spatialreference.org data snapshot. */
+    /** Backup CDN URL for the immutable OSGeo spatialreference.org data snapshot. */
     public static final String SPATIAL_REFERENCE_CDN_BASE_URL =
             "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@"
                     + SPATIAL_REFERENCE_SNAPSHOT_COMMIT;
@@ -103,16 +120,17 @@ public final class UrlCRSProvider implements CRSProvider {
     public static final Duration SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT =
             Duration.ofSeconds(30);
 
-    /** Path template within the spatialreference.org snapshot. */
+    /** Path template within the spatialreference.org catalog. */
     static final String SPATIAL_REFERENCE_PATH = "/ref/{authority}/{code}/projjson.json";
 
     // ==================== spatialreference.org factories ====================
 
     /**
      * Create a {@link UrlCRSProvider} pre-configured for
-     * the immutable OSGeo
+     * the OSGeo
      * <a href="https://github.com/OSGeo/spatialreference.org">spatialreference.org</a>
-     * data snapshot.
+     * catalog. Raw GitHub content is the primary endpoint; a commit-addressed
+     * jsDelivr snapshot is used after endpoint failures.
      *
      * <p>This is the default remote CRS provider registered by
      * {@link Defs#globals()} at priority 101. For a custom mirror or different
@@ -120,13 +138,25 @@ public final class UrlCRSProvider implements CRSProvider {
      * {@link #SPATIAL_REFERENCE_NAME} as the name and
      * {@code /ref/{authority}/{code}/projjson.json} as the path template.</p>
      *
-     * @return a provider that fetches PROJJSON from a pinned OSGeo snapshot
+     * @return a provider that fetches PROJJSON from GitHub with a pinned CDN fallback
      */
     public static UrlCRSProvider spatialReference() {
-        return builder(SPATIAL_REFERENCE_NAME)
-                .baseUrl(SPATIAL_REFERENCE_CDN_BASE_URL)
+        UrlCRSFetcher github = spatialReferenceFetcher(
+                SPATIAL_REFERENCE_GITHUB_BASE_URL, false);
+        UrlCRSFetcher jsDelivr = spatialReferenceFetcher(
+                SPATIAL_REFERENCE_CDN_BASE_URL, true);
+        return new UrlCRSProvider(
+                SPATIAL_REFERENCE_NAME,
+                CRSResult.Format.PROJJSON,
+                null,
+                Arrays.asList(github, jsDelivr));
+    }
+
+    private static UrlCRSFetcher spatialReferenceFetcher(
+            String baseUrl, boolean cacheNotFound) {
+        return UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
                 .pathTemplate(SPATIAL_REFERENCE_PATH)
-                .format(CRSResult.Format.PROJJSON)
                 .connectTimeout(SPATIAL_REFERENCE_CONNECT_TIMEOUT_SECONDS)
                 .readTimeout(SPATIAL_REFERENCE_READ_TIMEOUT_SECONDS)
                 .maxRetries(SPATIAL_REFERENCE_MAX_ATTEMPTS)
@@ -136,6 +166,7 @@ public final class UrlCRSProvider implements CRSProvider {
                         SPATIAL_REFERENCE_CIRCUIT_BREAKER_FAILURE_THRESHOLD)
                 .circuitBreakerResetTimeout(
                         SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT)
+                .cacheNotFound(cacheNotFound)
                 .header("Accept", "application/json")
                 .build();
     }
@@ -144,15 +175,36 @@ public final class UrlCRSProvider implements CRSProvider {
 
     private final String name;
     private final UrlCRSFetcher fetcher;
+    private final List<UrlCRSFetcher> fetchers;
     private final CRSResult.Format format;
     private final Set<String> authorities; // null = accept all
 
     private UrlCRSProvider(Builder builder) {
-        this.name = builder.name;
-        this.format = builder.format;
-        this.authorities = builder.authorities == null ? null
-                : Collections.unmodifiableSet(new LinkedHashSet<>(builder.authorities));
-        this.fetcher = builder.fetcherBuilder.build();
+        this(
+                builder.name,
+                builder.format,
+                builder.authorities,
+                buildFetchers(builder));
+    }
+
+    private UrlCRSProvider(
+            String name,
+            CRSResult.Format format,
+            Set<String> authorities,
+            List<UrlCRSFetcher> fetchers) {
+        this.name = name;
+        this.format = format;
+        this.authorities = authorities == null ? null
+                : Collections.unmodifiableSet(new LinkedHashSet<>(authorities));
+        this.fetchers = Collections.unmodifiableList(new ArrayList<>(fetchers));
+        this.fetcher = this.fetchers.get(0);
+    }
+
+    private static List<UrlCRSFetcher> buildFetchers(Builder builder) {
+        List<UrlCRSFetcher> fetchers = new ArrayList<>();
+        fetchers.add(builder.fetcherBuilder.build());
+        fetchers.addAll(builder.fallbackFetchers);
+        return fetchers;
     }
 
     @Override
@@ -165,8 +217,9 @@ public final class UrlCRSProvider implements CRSProvider {
      *
      * <p>If {@link Builder#authorities(String...) authorities} were configured, this
      * method returns {@code null} immediately for any authority not in that set.
-     * Otherwise, a URL is constructed from the base URL and path template, and an
-     * HTTP GET is issued.</p>
+     * Otherwise, the configured fetchers are queried in order. Endpoint failures
+     * advance to the next fetcher, while a primary HTTP 404 returns {@code null}
+     * without consulting older fallbacks.</p>
      *
      * @param authority the authority name, lower-cased (e.g., {@code "epsg"})
      * @param code      the CRS code (e.g., {@code "4326"})
@@ -183,41 +236,129 @@ public final class UrlCRSProvider implements CRSProvider {
 
         String fullCode = authority.toUpperCase(Locale.ROOT) + ":" + code;
 
-        UrlCRSFetcher.FetchResult result = fetcher.fetch(authority, code);
+        List<CRSFetchException> endpointFailures = new ArrayList<>();
+        List<String> outcomes = new ArrayList<>();
 
+        for (UrlCRSFetcher currentFetcher : fetchers) {
+            UrlCRSFetcher.FetchResult result = currentFetcher.fetch(authority, code);
+
+            switch (result.getStatus()) {
+                case SUCCESS:
+                    return wrapResult(result.getBody());
+
+                case NOT_FOUND:
+                    if (endpointFailures.isEmpty()) {
+                        return null;
+                    }
+                    outcomes.add(currentFetcher.getBaseUrl() + ": HTTP 404");
+                    break;
+
+                case HTTP_ERROR:
+                case NETWORK_ERROR:
+                case CIRCUIT_OPEN:
+                    CRSFetchException failure =
+                            endpointFailure(fullCode, currentFetcher, result);
+                    if (isInterrupted(result)) {
+                        throw failure;
+                    }
+                    endpointFailures.add(failure);
+                    outcomes.add(currentFetcher.getBaseUrl() + ": "
+                            + outcomeDescription(result));
+                    break;
+
+                default:
+                    throw new IllegalStateException(
+                            "Unknown fetch status " + result.getStatus()
+                                    + " for " + fullCode);
+            }
+        }
+
+        throw combinedFailure(fullCode, endpointFailures, outcomes);
+    }
+
+    private CRSFetchException endpointFailure(
+            String fullCode,
+            UrlCRSFetcher currentFetcher,
+            UrlCRSFetcher.FetchResult result) {
         switch (result.getStatus()) {
-            case SUCCESS:
-                return wrapResult(result.getBody());
-
-            case NOT_FOUND:
-                return null;
-
             case HTTP_ERROR:
-                throw new CRSFetchException(fullCode, CRSFetchException.Reason.HTTP_ERROR,
-                        "CRS endpoint " + name + " (" + fetcher.getBaseUrl()
-                                + ") returned HTTP "
-                                + result.getHttpStatusCode() + " for " + fullCode
-                                + " after " + result.getAttemptCount() + " attempts",
+                return new CRSFetchException(
+                        fullCode,
+                        CRSFetchException.Reason.HTTP_ERROR,
+                        "CRS endpoint " + name + " (" + currentFetcher.getBaseUrl()
+                                + ") returned HTTP " + result.getHttpStatusCode()
+                                + " for " + fullCode + " after "
+                                + result.getAttemptCount() + " attempts",
                         result.getLastException());
 
             case NETWORK_ERROR:
-                throw new CRSFetchException(fullCode, CRSFetchException.Reason.NETWORK_ERROR,
-                        "Failed to fetch CRS definition for " + fullCode +
-                                " from " + name + " (" + fetcher.getBaseUrl() + ") after "
+                return new CRSFetchException(
+                        fullCode,
+                        CRSFetchException.Reason.NETWORK_ERROR,
+                        "Failed to fetch CRS definition for " + fullCode
+                                + " from " + name + " ("
+                                + currentFetcher.getBaseUrl() + ") after "
                                 + result.getAttemptCount() + " attempts",
                         result.getLastException());
 
             case CIRCUIT_OPEN:
-                throw new CRSFetchException(fullCode, CRSFetchException.Reason.CIRCUIT_OPEN,
-                        "CRS endpoint " + name + " (" + fetcher.getBaseUrl()
+                return new CRSFetchException(
+                        fullCode,
+                        CRSFetchException.Reason.CIRCUIT_OPEN,
+                        "CRS endpoint " + name + " (" + currentFetcher.getBaseUrl()
                                 + ") is temporarily unavailable; "
                                 + "circuit breaker is open for " + fullCode,
                         result.getLastException());
 
             default:
-                throw new IllegalStateException(
-                        "Unknown fetch status " + result.getStatus() + " for " + fullCode);
+                throw new IllegalArgumentException(
+                        "Fetch result is not an endpoint failure: " + result.getStatus());
         }
+    }
+
+    private static boolean isInterrupted(UrlCRSFetcher.FetchResult result) {
+        return Thread.currentThread().isInterrupted()
+                && result.isNetworkError()
+                && result.getLastException() instanceof InterruptedException;
+    }
+
+    private static String outcomeDescription(UrlCRSFetcher.FetchResult result) {
+        switch (result.getStatus()) {
+            case HTTP_ERROR:
+                return "HTTP " + result.getHttpStatusCode();
+            case NETWORK_ERROR:
+                return "network error";
+            case CIRCUIT_OPEN:
+                return "circuit open";
+            default:
+                return result.getStatus().name();
+        }
+    }
+
+    private static CRSFetchException combinedFailure(
+            String fullCode,
+            List<CRSFetchException> failures,
+            List<String> outcomes) {
+        if (failures.size() == 1 && outcomes.size() == 1) {
+            return failures.get(0);
+        }
+        if (failures.isEmpty()) {
+            throw new IllegalStateException(
+                    "No endpoint failure recorded for " + fullCode);
+        }
+
+        CRSFetchException primaryFailure = failures.get(0);
+        CRSFetchException combined = new CRSFetchException(
+                fullCode,
+                primaryFailure.getReason(),
+                "Failed to resolve " + fullCode
+                        + " from all configured CRS endpoints: "
+                        + String.join("; ", outcomes),
+                primaryFailure);
+        for (int i = 1; i < failures.size(); i++) {
+            combined.addSuppressed(failures.get(i));
+        }
+        return combined;
     }
 
     /**
@@ -235,8 +376,16 @@ public final class UrlCRSProvider implements CRSProvider {
 
     // ==================== Accessors ====================
 
-    /** Get the underlying fetcher (useful for clearing the negative cache, etc.). */
+    /** Get the primary fetcher. */
     public UrlCRSFetcher getFetcher() { return fetcher; }
+
+    /**
+     * Get all fetchers in resolution order. The first entry is the primary and
+     * subsequent entries are fallbacks.
+     *
+     * @return an unmodifiable list containing the primary and all fallbacks
+     */
+    public List<UrlCRSFetcher> getFetchers() { return fetchers; }
 
     /** Get the expected response format. */
     public CRSResult.Format getFormat() { return format; }
@@ -261,10 +410,15 @@ public final class UrlCRSProvider implements CRSProvider {
      * Fluent builder for {@link UrlCRSProvider}.
      *
      * <p>Required: {@link #baseUrl(String)}. Everything else has sensible defaults.</p>
+     *
+     * <p>Except for {@link #fallbackFetcher(UrlCRSFetcher)}, these methods configure
+     * the primary fetcher only. Each fallback carries its own URL, headers,
+     * reliability settings, cache, and circuit breaker.</p>
      */
     public static final class Builder {
         private final String name;
         private final UrlCRSFetcher.Builder fetcherBuilder = UrlCRSFetcher.builder();
+        private final List<UrlCRSFetcher> fallbackFetchers = new ArrayList<>();
         private CRSResult.Format format = CRSResult.Format.PROJJSON;
         private Set<String> authorities; // null = all
 
@@ -394,8 +548,9 @@ public final class UrlCRSProvider implements CRSProvider {
         }
 
         /**
-         * Set the overall deadline for a logical lookup, including retries and backoff.
-         * Set to zero to rely only on per-attempt timeouts. Default: 0.
+         * Set the primary fetcher's overall deadline, including retries and backoff.
+         * Each fallback has its own deadline. Set to zero to rely only on
+         * per-attempt timeouts. Default: 0.
          *
          * @param seconds overall timeout in seconds, or zero to disable it
          * @return this builder
@@ -425,6 +580,39 @@ public final class UrlCRSProvider implements CRSProvider {
          */
         public Builder circuitBreakerResetTimeout(Duration timeout) {
             fetcherBuilder.circuitBreakerResetTimeout(timeout);
+            return this;
+        }
+
+        /**
+         * Set whether the primary fetcher caches HTTP 404 responses. Default:
+         * {@code true}.
+         *
+         * @param enabled whether to cache HTTP 404 responses
+         * @return this builder
+         */
+        public Builder cacheNotFound(boolean enabled) {
+            fetcherBuilder.cacheNotFound(enabled);
+            return this;
+        }
+
+        /**
+         * Add an independently configured fallback fetcher. Fallbacks are tried
+         * in insertion order after HTTP errors, network errors, or an open primary
+         * circuit. A primary HTTP 404 remains definitive.
+         *
+         * <p>Configure each fallback separately so endpoint-specific headers,
+         * timeouts, caches, and circuit breakers remain isolated. Every fallback
+         * must serve the response format configured on this provider.</p>
+         *
+         * @param fallbackFetcher independently configured fallback fetcher
+         * @return this builder
+         */
+        public Builder fallbackFetcher(UrlCRSFetcher fallbackFetcher) {
+            if (fallbackFetcher == null) {
+                throw new IllegalArgumentException(
+                        "fallbackFetcher must not be null");
+            }
+            fallbackFetchers.add(fallbackFetcher);
             return this;
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSProvider.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSProvider.java
@@ -1,6 +1,6 @@
 package org.datasyslab.proj4sedona.defs;
 
-import java.util.Arrays;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -61,34 +61,81 @@ public final class UrlCRSProvider implements CRSProvider {
 
     // ==================== spatialreference.org constants ====================
 
-    /** Default spatialreference.org base URL. */
+    /**
+     * Legacy spatialreference.org origin URL.
+     *
+     * @deprecated the default provider uses {@link #SPATIAL_REFERENCE_CDN_BASE_URL}
+     */
+    @Deprecated
     public static final String SPATIAL_REFERENCE_BASE_URL = "https://spatialreference.org";
+
+    /** Generated spatialreference.org data commit based on PROJ 9.8.1. */
+    public static final String SPATIAL_REFERENCE_SNAPSHOT_COMMIT =
+            "c43e4e72634af65fcf684def42ddc2dcfd834938";
+
+    /** Default CDN URL for the immutable OSGeo spatialreference.org data snapshot. */
+    public static final String SPATIAL_REFERENCE_CDN_BASE_URL =
+            "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@"
+                    + SPATIAL_REFERENCE_SNAPSHOT_COMMIT;
 
     /** Provider name used for the spatialreference.org instance. */
     public static final String SPATIAL_REFERENCE_NAME = "spatialreference.org";
 
-    /** Path template for spatialreference.org. */
+    /** Connection timeout used by the default remote provider. */
+    public static final int SPATIAL_REFERENCE_CONNECT_TIMEOUT_SECONDS = 3;
+
+    /** Per-request timeout used by the default remote provider. */
+    public static final int SPATIAL_REFERENCE_READ_TIMEOUT_SECONDS = 5;
+
+    /** Total attempts used by the default remote provider. */
+    public static final int SPATIAL_REFERENCE_MAX_ATTEMPTS = 2;
+
+    /** Initial retry backoff used by the default remote provider. */
+    public static final long SPATIAL_REFERENCE_INITIAL_BACKOFF_MS = 250;
+
+    /** Overall deadline used by the default remote provider. */
+    public static final int SPATIAL_REFERENCE_TOTAL_TIMEOUT_SECONDS = 8;
+
+    /** Endpoint failures that open the default provider's circuit. */
+    public static final int SPATIAL_REFERENCE_CIRCUIT_BREAKER_FAILURE_THRESHOLD = 3;
+
+    /** Delay before the default provider permits a probe through an open circuit. */
+    public static final Duration SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT =
+            Duration.ofSeconds(30);
+
+    /** Path template within the spatialreference.org snapshot. */
     static final String SPATIAL_REFERENCE_PATH = "/ref/{authority}/{code}/projjson.json";
 
     // ==================== spatialreference.org factories ====================
 
     /**
      * Create a {@link UrlCRSProvider} pre-configured for
-     * <a href="https://spatialreference.org">spatialreference.org</a>.
+     * the immutable OSGeo
+     * <a href="https://github.com/OSGeo/spatialreference.org">spatialreference.org</a>
+     * data snapshot.
      *
      * <p>This is the default remote CRS provider registered by
-     * {@link Defs#globals()} at priority 101. For a custom spatialreference.org
-     * mirror or different timeouts, use {@link #builder(String)} with
+     * {@link Defs#globals()} at priority 101. For a custom mirror or different
+     * reliability settings, use {@link #builder(String)} with
      * {@link #SPATIAL_REFERENCE_NAME} as the name and
      * {@code /ref/{authority}/{code}/projjson.json} as the path template.</p>
      *
-     * @return a provider that fetches PROJJSON from spatialreference.org
+     * @return a provider that fetches PROJJSON from a pinned OSGeo snapshot
      */
     public static UrlCRSProvider spatialReference() {
         return builder(SPATIAL_REFERENCE_NAME)
-                .baseUrl(SPATIAL_REFERENCE_BASE_URL)
+                .baseUrl(SPATIAL_REFERENCE_CDN_BASE_URL)
                 .pathTemplate(SPATIAL_REFERENCE_PATH)
                 .format(CRSResult.Format.PROJJSON)
+                .connectTimeout(SPATIAL_REFERENCE_CONNECT_TIMEOUT_SECONDS)
+                .readTimeout(SPATIAL_REFERENCE_READ_TIMEOUT_SECONDS)
+                .maxRetries(SPATIAL_REFERENCE_MAX_ATTEMPTS)
+                .initialBackoffMs(SPATIAL_REFERENCE_INITIAL_BACKOFF_MS)
+                .totalTimeout(SPATIAL_REFERENCE_TOTAL_TIMEOUT_SECONDS)
+                .circuitBreakerFailureThreshold(
+                        SPATIAL_REFERENCE_CIRCUIT_BREAKER_FAILURE_THRESHOLD)
+                .circuitBreakerResetTimeout(
+                        SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT)
                 .header("Accept", "application/json")
                 .build();
     }
@@ -125,7 +172,7 @@ public final class UrlCRSProvider implements CRSProvider {
      * @param code      the CRS code (e.g., {@code "4326"})
      * @return a {@link CRSResult} on success, {@code null} if the code is not found
      *         or the authority is not handled by this provider
-     * @throws CRSFetchException on network errors after exhausting retries
+     * @throws CRSFetchException on HTTP errors, network errors, or an open circuit breaker
      */
     @Override
     public CRSResult resolve(String authority, String code) {
@@ -145,10 +192,26 @@ public final class UrlCRSProvider implements CRSProvider {
             case NOT_FOUND:
                 return null;
 
+            case HTTP_ERROR:
+                throw new CRSFetchException(fullCode, CRSFetchException.Reason.HTTP_ERROR,
+                        "CRS endpoint " + name + " (" + fetcher.getBaseUrl()
+                                + ") returned HTTP "
+                                + result.getHttpStatusCode() + " for " + fullCode
+                                + " after " + result.getAttemptCount() + " attempts",
+                        result.getLastException());
+
             case NETWORK_ERROR:
                 throw new CRSFetchException(fullCode, CRSFetchException.Reason.NETWORK_ERROR,
                         "Failed to fetch CRS definition for " + fullCode +
-                                " from " + name + " after " + result.getAttemptCount() + " attempts",
+                                " from " + name + " (" + fetcher.getBaseUrl() + ") after "
+                                + result.getAttemptCount() + " attempts",
+                        result.getLastException());
+
+            case CIRCUIT_OPEN:
+                throw new CRSFetchException(fullCode, CRSFetchException.Reason.CIRCUIT_OPEN,
+                        "CRS endpoint " + name + " (" + fetcher.getBaseUrl()
+                                + ") is temporarily unavailable; "
+                                + "circuit breaker is open for " + fullCode,
                         result.getLastException());
 
             default:
@@ -308,9 +371,10 @@ public final class UrlCRSProvider implements CRSProvider {
         }
 
         /**
-         * Set the maximum number of retry attempts. Default: 3.
+         * Set the maximum number of total attempts, including the initial request.
+         * Default: 3.
          *
-         * @param maxRetries maximum retries
+         * @param maxRetries maximum total attempts
          * @return this builder
          */
         public Builder maxRetries(int maxRetries) {
@@ -326,6 +390,41 @@ public final class UrlCRSProvider implements CRSProvider {
          */
         public Builder initialBackoffMs(long ms) {
             fetcherBuilder.initialBackoffMs(ms);
+            return this;
+        }
+
+        /**
+         * Set the overall deadline for a logical lookup, including retries and backoff.
+         * Set to zero to rely only on per-attempt timeouts. Default: 0.
+         *
+         * @param seconds overall timeout in seconds, or zero to disable it
+         * @return this builder
+         */
+        public Builder totalTimeout(int seconds) {
+            fetcherBuilder.totalTimeout(seconds);
+            return this;
+        }
+
+        /**
+         * Set the number of consecutive failed lookups that opens the endpoint circuit.
+         * Set to zero to disable circuit breaking. Default: 0.
+         *
+         * @param failures failure threshold, or zero to disable circuit breaking
+         * @return this builder
+         */
+        public Builder circuitBreakerFailureThreshold(int failures) {
+            fetcherBuilder.circuitBreakerFailureThreshold(failures);
+            return this;
+        }
+
+        /**
+         * Set how long an open circuit waits before permitting one probe request.
+         *
+         * @param timeout positive reset timeout
+         * @return this builder
+         */
+        public Builder circuitBreakerResetTimeout(Duration timeout) {
+            fetcherBuilder.circuitBreakerResetTimeout(timeout);
             return this;
         }
 

--- a/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSProvider.java
+++ b/src/main/java/org/datasyslab/proj4sedona/defs/UrlCRSProvider.java
@@ -71,29 +71,50 @@ import java.util.Set;
  */
 public final class UrlCRSProvider implements CRSProvider {
 
+    /**
+     * Controls whether an endpoint's HTTP 404 response is definitive.
+     */
+    public enum NotFoundPolicy {
+        /** Return not-found immediately without consulting later endpoints. */
+        AUTHORITATIVE,
+        /**
+         * Consult the next endpoint, if any, to confirm the missing code. If
+         * the endpoint list is exhausted, return not-found unless a hard
+         * endpoint failure was recorded, in which case propagate that failure.
+         */
+        TRY_NEXT_ENDPOINT
+    }
+
+    private static final class Endpoint {
+        private final UrlCRSFetcher fetcher;
+        private final NotFoundPolicy notFoundPolicy;
+
+        private Endpoint(
+                UrlCRSFetcher fetcher,
+                NotFoundPolicy notFoundPolicy) {
+            this.fetcher = fetcher;
+            this.notFoundPolicy = notFoundPolicy;
+        }
+    }
+
     // ==================== spatialreference.org constants ====================
 
     /**
      * Legacy spatialreference.org origin URL.
      *
-     * @deprecated the default provider uses {@link #SPATIAL_REFERENCE_GITHUB_BASE_URL}
-     *             with {@link #SPATIAL_REFERENCE_CDN_BASE_URL} as a fallback
+     * @deprecated the default provider uses {@link #SPATIAL_REFERENCE_CDN_BASE_URL}
+     *             with {@link #SPATIAL_REFERENCE_GITHUB_BASE_URL} as a fallback
      */
     @Deprecated
     public static final String SPATIAL_REFERENCE_BASE_URL = "https://spatialreference.org";
 
-    /** Primary raw GitHub URL for the rolling OSGeo spatialreference.org catalog. */
+    /** Raw GitHub fallback for the rolling OSGeo spatialreference.org catalog. */
     public static final String SPATIAL_REFERENCE_GITHUB_BASE_URL =
             "https://raw.githubusercontent.com/OSGeo/spatialreference.org/gh-pages";
 
-    /** Generated spatialreference.org data commit based on PROJ 9.8.1. */
-    public static final String SPATIAL_REFERENCE_SNAPSHOT_COMMIT =
-            "c43e4e72634af65fcf684def42ddc2dcfd834938";
-
-    /** Backup CDN URL for the immutable OSGeo spatialreference.org data snapshot. */
+    /** Primary jsDelivr URL for the rolling OSGeo spatialreference.org catalog. */
     public static final String SPATIAL_REFERENCE_CDN_BASE_URL =
-            "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@"
-                    + SPATIAL_REFERENCE_SNAPSHOT_COMMIT;
+            "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@gh-pages";
 
     /** Provider name used for the spatialreference.org instance. */
     public static final String SPATIAL_REFERENCE_NAME = "spatialreference.org";
@@ -120,6 +141,10 @@ public final class UrlCRSProvider implements CRSProvider {
     public static final Duration SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT =
             Duration.ofSeconds(30);
 
+    /** How long the default rolling endpoints cache an HTTP 404 locally. */
+    public static final Duration SPATIAL_REFERENCE_NOT_FOUND_CACHE_TTL =
+            Duration.ofMinutes(5);
+
     /** Path template within the spatialreference.org catalog. */
     static final String SPATIAL_REFERENCE_PATH = "/ref/{authority}/{code}/projjson.json";
 
@@ -129,8 +154,10 @@ public final class UrlCRSProvider implements CRSProvider {
      * Create a {@link UrlCRSProvider} pre-configured for
      * the OSGeo
      * <a href="https://github.com/OSGeo/spatialreference.org">spatialreference.org</a>
-     * catalog. Raw GitHub content is the primary endpoint; a commit-addressed
-     * jsDelivr snapshot is used after endpoint failures.
+     * catalog. The rolling jsDelivr mirror carries normal traffic, with raw
+     * GitHub as an independent fallback. Because branch-backed CDN content can
+     * lag the source, a jsDelivr 404 is confirmed against GitHub; a GitHub 404
+     * is authoritative.
      *
      * <p>This is the default remote CRS provider registered by
      * {@link Defs#globals()} at priority 101. For a custom mirror or different
@@ -138,22 +165,23 @@ public final class UrlCRSProvider implements CRSProvider {
      * {@link #SPATIAL_REFERENCE_NAME} as the name and
      * {@code /ref/{authority}/{code}/projjson.json} as the path template.</p>
      *
-     * @return a provider that fetches PROJJSON from GitHub with a pinned CDN fallback
+     * @return a provider that fetches PROJJSON from jsDelivr with a GitHub fallback
      */
     public static UrlCRSProvider spatialReference() {
-        UrlCRSFetcher github = spatialReferenceFetcher(
-                SPATIAL_REFERENCE_GITHUB_BASE_URL, false);
         UrlCRSFetcher jsDelivr = spatialReferenceFetcher(
-                SPATIAL_REFERENCE_CDN_BASE_URL, true);
+                SPATIAL_REFERENCE_CDN_BASE_URL);
+        UrlCRSFetcher github = spatialReferenceFetcher(
+                SPATIAL_REFERENCE_GITHUB_BASE_URL);
         return new UrlCRSProvider(
                 SPATIAL_REFERENCE_NAME,
                 CRSResult.Format.PROJJSON,
                 null,
-                Arrays.asList(github, jsDelivr));
+                Arrays.asList(
+                        new Endpoint(jsDelivr, NotFoundPolicy.TRY_NEXT_ENDPOINT),
+                        new Endpoint(github, NotFoundPolicy.AUTHORITATIVE)));
     }
 
-    private static UrlCRSFetcher spatialReferenceFetcher(
-            String baseUrl, boolean cacheNotFound) {
+    private static UrlCRSFetcher spatialReferenceFetcher(String baseUrl) {
         return UrlCRSFetcher.builder()
                 .baseUrl(baseUrl)
                 .pathTemplate(SPATIAL_REFERENCE_PATH)
@@ -166,7 +194,8 @@ public final class UrlCRSProvider implements CRSProvider {
                         SPATIAL_REFERENCE_CIRCUIT_BREAKER_FAILURE_THRESHOLD)
                 .circuitBreakerResetTimeout(
                         SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT)
-                .cacheNotFound(cacheNotFound)
+                .cacheNotFound(true)
+                .notFoundCacheTtl(SPATIAL_REFERENCE_NOT_FOUND_CACHE_TTL)
                 .header("Accept", "application/json")
                 .build();
     }
@@ -176,6 +205,8 @@ public final class UrlCRSProvider implements CRSProvider {
     private final String name;
     private final UrlCRSFetcher fetcher;
     private final List<UrlCRSFetcher> fetchers;
+    private final List<Endpoint> endpoints;
+    private final List<NotFoundPolicy> notFoundPolicies;
     private final CRSResult.Format format;
     private final Set<String> authorities; // null = accept all
 
@@ -184,27 +215,38 @@ public final class UrlCRSProvider implements CRSProvider {
                 builder.name,
                 builder.format,
                 builder.authorities,
-                buildFetchers(builder));
+                buildEndpoints(builder));
     }
 
     private UrlCRSProvider(
             String name,
             CRSResult.Format format,
             Set<String> authorities,
-            List<UrlCRSFetcher> fetchers) {
+            List<Endpoint> endpoints) {
         this.name = name;
         this.format = format;
         this.authorities = authorities == null ? null
                 : Collections.unmodifiableSet(new LinkedHashSet<>(authorities));
-        this.fetchers = Collections.unmodifiableList(new ArrayList<>(fetchers));
+        this.endpoints = Collections.unmodifiableList(new ArrayList<>(endpoints));
+        List<UrlCRSFetcher> configuredFetchers = new ArrayList<>();
+        List<NotFoundPolicy> configuredNotFoundPolicies = new ArrayList<>();
+        for (Endpoint endpoint : endpoints) {
+            configuredFetchers.add(endpoint.fetcher);
+            configuredNotFoundPolicies.add(endpoint.notFoundPolicy);
+        }
+        this.fetchers = Collections.unmodifiableList(configuredFetchers);
+        this.notFoundPolicies =
+                Collections.unmodifiableList(configuredNotFoundPolicies);
         this.fetcher = this.fetchers.get(0);
     }
 
-    private static List<UrlCRSFetcher> buildFetchers(Builder builder) {
-        List<UrlCRSFetcher> fetchers = new ArrayList<>();
-        fetchers.add(builder.fetcherBuilder.build());
-        fetchers.addAll(builder.fallbackFetchers);
-        return fetchers;
+    private static List<Endpoint> buildEndpoints(Builder builder) {
+        List<Endpoint> endpoints = new ArrayList<>();
+        endpoints.add(new Endpoint(
+                builder.fetcherBuilder.build(),
+                builder.primaryNotFoundPolicy));
+        endpoints.addAll(builder.fallbackEndpoints);
+        return endpoints;
     }
 
     @Override
@@ -218,8 +260,10 @@ public final class UrlCRSProvider implements CRSProvider {
      * <p>If {@link Builder#authorities(String...) authorities} were configured, this
      * method returns {@code null} immediately for any authority not in that set.
      * Otherwise, the configured fetchers are queried in order. Endpoint failures
-     * advance to the next fetcher, while a primary HTTP 404 returns {@code null}
-     * without consulting older fallbacks.</p>
+     * advance to the next fetcher. A 404 from an endpoint configured with
+     * {@link NotFoundPolicy#AUTHORITATIVE} returns {@code null}; a 404 from an
+     * endpoint configured with {@link NotFoundPolicy#TRY_NEXT_ENDPOINT} advances
+     * to the next endpoint.</p>
      *
      * @param authority the authority name, lower-cased (e.g., {@code "epsg"})
      * @param code      the CRS code (e.g., {@code "4326"})
@@ -239,7 +283,8 @@ public final class UrlCRSProvider implements CRSProvider {
         List<CRSFetchException> endpointFailures = new ArrayList<>();
         List<String> outcomes = new ArrayList<>();
 
-        for (UrlCRSFetcher currentFetcher : fetchers) {
+        for (Endpoint endpoint : endpoints) {
+            UrlCRSFetcher currentFetcher = endpoint.fetcher;
             UrlCRSFetcher.FetchResult result = currentFetcher.fetch(authority, code);
 
             switch (result.getStatus()) {
@@ -247,10 +292,10 @@ public final class UrlCRSProvider implements CRSProvider {
                     return wrapResult(result.getBody());
 
                 case NOT_FOUND:
-                    if (endpointFailures.isEmpty()) {
+                    outcomes.add(currentFetcher.getBaseUrl() + ": HTTP 404");
+                    if (endpoint.notFoundPolicy == NotFoundPolicy.AUTHORITATIVE) {
                         return null;
                     }
-                    outcomes.add(currentFetcher.getBaseUrl() + ": HTTP 404");
                     break;
 
                 case HTTP_ERROR:
@@ -273,6 +318,9 @@ public final class UrlCRSProvider implements CRSProvider {
             }
         }
 
+        if (endpointFailures.isEmpty()) {
+            return null;
+        }
         throw combinedFailure(fullCode, endpointFailures, outcomes);
     }
 
@@ -286,7 +334,7 @@ public final class UrlCRSProvider implements CRSProvider {
                         fullCode,
                         CRSFetchException.Reason.HTTP_ERROR,
                         "CRS endpoint " + name + " (" + currentFetcher.getBaseUrl()
-                                + ") returned HTTP " + result.getHttpStatusCode()
+                                + ") returned " + outcomeDescription(result)
                                 + " for " + fullCode + " after "
                                 + result.getAttemptCount() + " attempts",
                         result.getLastException());
@@ -325,7 +373,12 @@ public final class UrlCRSProvider implements CRSProvider {
     private static String outcomeDescription(UrlCRSFetcher.FetchResult result) {
         switch (result.getStatus()) {
             case HTTP_ERROR:
-                return "HTTP " + result.getHttpStatusCode();
+                String description = "HTTP " + result.getHttpStatusCode();
+                String redirectDetail =
+                        UrlCRSFetcher.refusedRedirectDescription(result);
+                return redirectDetail == null
+                        ? description
+                        : description + " (" + redirectDetail + ")";
             case NETWORK_ERROR:
                 return "network error";
             case CIRCUIT_OPEN:
@@ -387,6 +440,15 @@ public final class UrlCRSProvider implements CRSProvider {
      */
     public List<UrlCRSFetcher> getFetchers() { return fetchers; }
 
+    /**
+     * Get each endpoint's not-found policy in resolution order.
+     *
+     * @return an unmodifiable list aligned with {@link #getFetchers()}
+     */
+    public List<NotFoundPolicy> getNotFoundPolicies() {
+        return notFoundPolicies;
+    }
+
     /** Get the expected response format. */
     public CRSResult.Format getFormat() { return format; }
 
@@ -411,14 +473,16 @@ public final class UrlCRSProvider implements CRSProvider {
      *
      * <p>Required: {@link #baseUrl(String)}. Everything else has sensible defaults.</p>
      *
-     * <p>Except for {@link #fallbackFetcher(UrlCRSFetcher)}, these methods configure
-     * the primary fetcher only. Each fallback carries its own URL, headers,
-     * reliability settings, cache, and circuit breaker.</p>
+     * <p>Except for the fallback methods, these methods configure the primary
+     * fetcher only. Each fallback carries its own URL, headers, reliability
+     * settings, cache, and circuit breaker.</p>
      */
     public static final class Builder {
         private final String name;
         private final UrlCRSFetcher.Builder fetcherBuilder = UrlCRSFetcher.builder();
-        private final List<UrlCRSFetcher> fallbackFetchers = new ArrayList<>();
+        private final List<Endpoint> fallbackEndpoints = new ArrayList<>();
+        private NotFoundPolicy primaryNotFoundPolicy =
+                NotFoundPolicy.AUTHORITATIVE;
         private CRSResult.Format format = CRSResult.Format.PROJJSON;
         private Set<String> authorities; // null = all
 
@@ -596,9 +660,43 @@ public final class UrlCRSProvider implements CRSProvider {
         }
 
         /**
+         * Set how long the primary fetcher caches HTTP 404 responses. A zero
+         * duration keeps them for the fetcher's lifetime. Default: zero.
+         *
+         * @param ttl zero for no expiration, or a positive cache duration
+         * @return this builder
+         * @throws IllegalArgumentException if {@code ttl} is null, negative,
+         *         or too large to represent in nanoseconds
+         */
+        public Builder notFoundCacheTtl(Duration ttl) {
+            fetcherBuilder.notFoundCacheTtl(ttl);
+            return this;
+        }
+
+        /**
+         * Set whether a primary HTTP 404 is definitive. Default:
+         * {@link NotFoundPolicy#AUTHORITATIVE}.
+         *
+         * @param policy primary not-found policy
+         * @return this builder
+         * @throws IllegalArgumentException if {@code policy} is null
+         */
+        public Builder primaryNotFoundPolicy(NotFoundPolicy policy) {
+            if (policy == null) {
+                throw new IllegalArgumentException(
+                        "primary not-found policy must not be null");
+            }
+            this.primaryNotFoundPolicy = policy;
+            return this;
+        }
+
+        /**
          * Add an independently configured fallback fetcher. Fallbacks are tried
-         * in insertion order after HTTP errors, network errors, or an open primary
-         * circuit. A primary HTTP 404 remains definitive.
+         * in insertion order after HTTP errors, network errors, or an open
+         * primary circuit. By default, fallback 404s advance to the next
+         * endpoint, if present. A terminal fallback 404 returns not-found when
+         * no earlier endpoint failed; otherwise the earlier failure is
+         * propagated.
          *
          * <p>Configure each fallback separately so endpoint-specific headers,
          * timeouts, caches, and circuit breakers remain isolated. Every fallback
@@ -606,13 +704,35 @@ public final class UrlCRSProvider implements CRSProvider {
          *
          * @param fallbackFetcher independently configured fallback fetcher
          * @return this builder
+         * @throws IllegalArgumentException if {@code fallbackFetcher} is null
          */
         public Builder fallbackFetcher(UrlCRSFetcher fallbackFetcher) {
+            return fallbackFetcher(
+                    fallbackFetcher, NotFoundPolicy.TRY_NEXT_ENDPOINT);
+        }
+
+        /**
+         * Add an independently configured fallback fetcher with an explicit
+         * not-found policy.
+         *
+         * @param fallbackFetcher independently configured fallback fetcher
+         * @param notFoundPolicy whether this endpoint's HTTP 404 is definitive
+         * @return this builder
+         * @throws IllegalArgumentException if either argument is null
+         */
+        public Builder fallbackFetcher(
+                UrlCRSFetcher fallbackFetcher,
+                NotFoundPolicy notFoundPolicy) {
             if (fallbackFetcher == null) {
                 throw new IllegalArgumentException(
                         "fallbackFetcher must not be null");
             }
-            fallbackFetchers.add(fallbackFetcher);
+            if (notFoundPolicy == null) {
+                throw new IllegalArgumentException(
+                        "fallback not-found policy must not be null");
+            }
+            fallbackEndpoints.add(new Endpoint(
+                    fallbackFetcher, notFoundPolicy));
             return this;
         }
 

--- a/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
@@ -365,7 +365,7 @@ class DefsTest {
     }
 
     // ==================== Remote Fetch Tests (Non-EPSG Authorities) ====================
-    // These tests require network access to spatialreference.org
+    // These tests require network access to the pinned OSGeo snapshot
 
     @Test
     void testRemoteFetch_ESRI_102001_CanadaAlbers() {
@@ -375,7 +375,7 @@ class DefsTest {
         
         ProjectionDef def = Defs.get("ESRI:102001");
         
-        assertNotNull(def, "ESRI:102001 should be fetched from spatialreference.org");
+        assertNotNull(def, "ESRI:102001 should be fetched from the pinned OSGeo snapshot");
         // PROJJSON returns full name "Albers Equal Area", check it contains expected keywords
         String projName = def.getProjName().toLowerCase();
         assertTrue(projName.contains("aea") || projName.contains("albers"), 
@@ -412,7 +412,7 @@ class DefsTest {
         
         ProjectionDef def = Defs.get("ESRI:102008");
         
-        assertNotNull(def, "ESRI:102008 should be fetched from spatialreference.org");
+        assertNotNull(def, "ESRI:102008 should be fetched from the pinned OSGeo snapshot");
         // PROJJSON returns full name "Albers Equal Area", check it contains expected keywords
         String projName = def.getProjName().toLowerCase();
         assertTrue(projName.contains("aea") || projName.contains("albers"), 
@@ -426,7 +426,7 @@ class DefsTest {
         
         ProjectionDef def = Defs.get("IAU_2015:49900");
         
-        assertNotNull(def, "IAU_2015:49900 should be fetched from spatialreference.org");
+        assertNotNull(def, "IAU_2015:49900 should be fetched from the pinned OSGeo snapshot");
         assertEquals("longlat", def.getProjName(), "Mars geographic CRS should be longlat");
     }
 

--- a/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
@@ -365,7 +365,7 @@ class DefsTest {
     }
 
     // ==================== Remote Fetch Tests (Non-EPSG Authorities) ====================
-    // These tests require network access to the OSGeo GitHub catalog or CDN fallback
+    // These tests require network access to jsDelivr or the raw OSGeo GitHub fallback
 
     @Test
     void testRemoteFetch_ESRI_102001_CanadaAlbers() {

--- a/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/DefsTest.java
@@ -365,7 +365,7 @@ class DefsTest {
     }
 
     // ==================== Remote Fetch Tests (Non-EPSG Authorities) ====================
-    // These tests require network access to the pinned OSGeo snapshot
+    // These tests require network access to the OSGeo GitHub catalog or CDN fallback
 
     @Test
     void testRemoteFetch_ESRI_102001_CanadaAlbers() {
@@ -375,7 +375,7 @@ class DefsTest {
         
         ProjectionDef def = Defs.get("ESRI:102001");
         
-        assertNotNull(def, "ESRI:102001 should be fetched from the pinned OSGeo snapshot");
+        assertNotNull(def, "ESRI:102001 should be fetched from the OSGeo remote catalog");
         // PROJJSON returns full name "Albers Equal Area", check it contains expected keywords
         String projName = def.getProjName().toLowerCase();
         assertTrue(projName.contains("aea") || projName.contains("albers"), 
@@ -412,7 +412,7 @@ class DefsTest {
         
         ProjectionDef def = Defs.get("ESRI:102008");
         
-        assertNotNull(def, "ESRI:102008 should be fetched from the pinned OSGeo snapshot");
+        assertNotNull(def, "ESRI:102008 should be fetched from the OSGeo remote catalog");
         // PROJJSON returns full name "Albers Equal Area", check it contains expected keywords
         String projName = def.getProjName().toLowerCase();
         assertTrue(projName.contains("aea") || projName.contains("albers"), 
@@ -426,7 +426,7 @@ class DefsTest {
         
         ProjectionDef def = Defs.get("IAU_2015:49900");
         
-        assertNotNull(def, "IAU_2015:49900 should be fetched from the pinned OSGeo snapshot");
+        assertNotNull(def, "IAU_2015:49900 should be fetched from the OSGeo remote catalog");
         assertEquals("longlat", def.getProjName(), "Mars geographic CRS should be longlat");
     }
 

--- a/src/test/java/org/datasyslab/proj4sedona/defs/SpatialReferenceFetcherTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/SpatialReferenceFetcherTest.java
@@ -14,25 +14,28 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for the pinned spatialreference.org snapshot provider stack and Defs remote lookup.
+ * Tests for the spatialreference.org provider stack and Defs remote lookup.
  *
  * <p>The spatialreference.org provider is now a pre-configured
  * {@link UrlCRSProvider} (created via {@link UrlCRSProvider#spatialReference()}),
  * so these tests exercise both the provider and the underlying
  * {@link UrlCRSFetcher} directly for retry / negative-cache behaviour.</p>
  *
- * <p>Some tests require network access to the commit-addressed OSGeo CDN
- * snapshot and may be slow due to network latency.</p>
+ * <p>Some tests require network access to the rolling OSGeo GitHub catalog or
+ * its commit-addressed CDN fallback and may be slow due to network latency.</p>
  */
 class SpatialReferenceFetcherTest {
 
     /** A UrlCRSFetcher configured exactly like the default spatialReference() provider. */
     private UrlCRSFetcher defaultFetcher;
+    private UrlCRSFetcher fallbackFetcher;
 
     @BeforeEach
     void setUp() {
         Defs.reset();
-        defaultFetcher = UrlCRSProvider.spatialReference().getFetcher();
+        UrlCRSProvider provider = UrlCRSProvider.spatialReference();
+        defaultFetcher = provider.getFetcher();
+        fallbackFetcher = provider.getFetchers().get(1);
     }
 
     @AfterEach
@@ -40,7 +43,7 @@ class SpatialReferenceFetcherTest {
         Defs.reset();
     }
 
-    // ==================== Direct UrlCRSFetcher Tests (pinned OSGeo snapshot) ====================
+    // ==================== Direct UrlCRSFetcher Tests (OSGeo remote catalog) ====================
 
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
@@ -64,20 +67,22 @@ class SpatialReferenceFetcherTest {
 
         assertTrue(result.isNotFound(), "Should return NOT_FOUND for non-existent EPSG code");
         assertNull(result.getBody());
+        assertFalse(defaultFetcher.isInNotFoundCache("epsg", "999999"),
+                "Rolling GitHub catalog must not cache 404s permanently");
     }
 
     @Test
     void testNegativeCache() {
         // First call should add to negative cache
-        UrlCRSFetcher.FetchResult result1 = defaultFetcher.fetch("epsg", "999999");
+        UrlCRSFetcher.FetchResult result1 = fallbackFetcher.fetch("epsg", "999999");
         assertTrue(result1.isNotFound());
 
         // Verify it's in the negative cache
-        assertTrue(defaultFetcher.isInNotFoundCache("epsg", "999999"),
-                "Non-existent code should be in negative cache");
+        assertTrue(fallbackFetcher.isInNotFoundCache("epsg", "999999"),
+                "Pinned fallback should cache a non-existent code");
 
         // Second call should return from cache immediately (0 attempts)
-        UrlCRSFetcher.FetchResult result2 = defaultFetcher.fetch("epsg", "999999");
+        UrlCRSFetcher.FetchResult result2 = fallbackFetcher.fetch("epsg", "999999");
         assertTrue(result2.isNotFound());
         assertEquals(0, result2.getAttemptCount(), "Should return from cache with 0 attempts");
     }
@@ -85,20 +90,23 @@ class SpatialReferenceFetcherTest {
     @Test
     void testClearNotFoundCache() {
         // Add to negative cache
-        defaultFetcher.fetch("epsg", "999999");
-        assertTrue(defaultFetcher.isInNotFoundCache("epsg", "999999"));
+        fallbackFetcher.fetch("epsg", "999999");
+        assertTrue(fallbackFetcher.isInNotFoundCache("epsg", "999999"));
 
         // Clear cache
-        defaultFetcher.clearNotFoundCache();
+        fallbackFetcher.clearNotFoundCache();
 
         // Should no longer be in cache
-        assertFalse(defaultFetcher.isInNotFoundCache("epsg", "999999"));
-        assertEquals(0, defaultFetcher.getNotFoundCacheSize());
+        assertFalse(fallbackFetcher.isInNotFoundCache("epsg", "999999"));
+        assertEquals(0, fallbackFetcher.getNotFoundCacheSize());
     }
 
     @Test
     void testFetcherDefaults() {
-        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL, defaultFetcher.getBaseUrl());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_GITHUB_BASE_URL,
+                defaultFetcher.getBaseUrl());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL,
+                fallbackFetcher.getBaseUrl());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_PATH, defaultFetcher.getPathTemplate());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CONNECT_TIMEOUT_SECONDS,
                 defaultFetcher.getConnectTimeoutSeconds());
@@ -114,6 +122,8 @@ class SpatialReferenceFetcherTest {
                 defaultFetcher.getCircuitBreakerFailureThreshold());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT,
                 defaultFetcher.getCircuitBreakerResetTimeout());
+        assertFalse(defaultFetcher.isNotFoundCacheEnabled());
+        assertTrue(fallbackFetcher.isNotFoundCacheEnabled());
     }
 
     // ==================== Network Failure Tests ====================
@@ -187,7 +197,7 @@ class SpatialReferenceFetcherTest {
         // EPSG:2154 is not in the default globals, should be fetched remotely
         ProjectionDef def = Defs.get("EPSG:2154");
 
-        assertNotNull(def, "Should fetch EPSG:2154 from the pinned OSGeo snapshot");
+        assertNotNull(def, "Should fetch EPSG:2154 from the OSGeo remote catalog");
         assertEquals("EPSG:2154", def.getSrsCode());
     }
 

--- a/src/test/java/org/datasyslab/proj4sedona/defs/SpatialReferenceFetcherTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/SpatialReferenceFetcherTest.java
@@ -21,21 +21,21 @@ import static org.junit.jupiter.api.Assertions.*;
  * so these tests exercise both the provider and the underlying
  * {@link UrlCRSFetcher} directly for retry / negative-cache behaviour.</p>
  *
- * <p>Some tests require network access to the rolling OSGeo GitHub catalog or
- * its commit-addressed CDN fallback and may be slow due to network latency.</p>
+ * <p>Some tests require network access to the rolling OSGeo catalog through
+ * jsDelivr or raw GitHub and may be slow due to network latency.</p>
  */
 class SpatialReferenceFetcherTest {
 
     /** A UrlCRSFetcher configured exactly like the default spatialReference() provider. */
-    private UrlCRSFetcher defaultFetcher;
-    private UrlCRSFetcher fallbackFetcher;
+    private UrlCRSFetcher cdnFetcher;
+    private UrlCRSFetcher githubFetcher;
 
     @BeforeEach
     void setUp() {
         Defs.reset();
         UrlCRSProvider provider = UrlCRSProvider.spatialReference();
-        defaultFetcher = provider.getFetcher();
-        fallbackFetcher = provider.getFetchers().get(1);
+        cdnFetcher = provider.getFetcher();
+        githubFetcher = provider.getFetchers().get(1);
     }
 
     @AfterEach
@@ -49,7 +49,7 @@ class SpatialReferenceFetcherTest {
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     void testFetchProjJson_EPSG2154() {
         // EPSG:2154 - RGF93 / Lambert-93 (French national projection)
-        UrlCRSFetcher.FetchResult result = defaultFetcher.fetch("epsg", "2154");
+        UrlCRSFetcher.FetchResult result = cdnFetcher.fetch("epsg", "2154");
 
         assertTrue(result.isSuccess(), "Should fetch PROJJSON for EPSG:2154");
         assertNotNull(result.getBody());
@@ -63,26 +63,26 @@ class SpatialReferenceFetcherTest {
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     void testFetchProjJson_NonExistent() {
         // EPSG:999999 should not exist
-        UrlCRSFetcher.FetchResult result = defaultFetcher.fetch("epsg", "999999");
+        UrlCRSFetcher.FetchResult result = cdnFetcher.fetch("epsg", "999999");
 
         assertTrue(result.isNotFound(), "Should return NOT_FOUND for non-existent EPSG code");
         assertNull(result.getBody());
-        assertFalse(defaultFetcher.isInNotFoundCache("epsg", "999999"),
-                "Rolling GitHub catalog must not cache 404s permanently");
+        assertTrue(cdnFetcher.isInNotFoundCache("epsg", "999999"),
+                "Rolling CDN misses should be cached for the configured TTL");
     }
 
     @Test
     void testNegativeCache() {
         // First call should add to negative cache
-        UrlCRSFetcher.FetchResult result1 = fallbackFetcher.fetch("epsg", "999999");
+        UrlCRSFetcher.FetchResult result1 = githubFetcher.fetch("epsg", "999999");
         assertTrue(result1.isNotFound());
 
         // Verify it's in the negative cache
-        assertTrue(fallbackFetcher.isInNotFoundCache("epsg", "999999"),
-                "Pinned fallback should cache a non-existent code");
+        assertTrue(githubFetcher.isInNotFoundCache("epsg", "999999"),
+                "GitHub fallback should cache a non-existent code");
 
         // Second call should return from cache immediately (0 attempts)
-        UrlCRSFetcher.FetchResult result2 = fallbackFetcher.fetch("epsg", "999999");
+        UrlCRSFetcher.FetchResult result2 = githubFetcher.fetch("epsg", "999999");
         assertTrue(result2.isNotFound());
         assertEquals(0, result2.getAttemptCount(), "Should return from cache with 0 attempts");
     }
@@ -90,40 +90,44 @@ class SpatialReferenceFetcherTest {
     @Test
     void testClearNotFoundCache() {
         // Add to negative cache
-        fallbackFetcher.fetch("epsg", "999999");
-        assertTrue(fallbackFetcher.isInNotFoundCache("epsg", "999999"));
+        githubFetcher.fetch("epsg", "999999");
+        assertTrue(githubFetcher.isInNotFoundCache("epsg", "999999"));
 
         // Clear cache
-        fallbackFetcher.clearNotFoundCache();
+        githubFetcher.clearNotFoundCache();
 
         // Should no longer be in cache
-        assertFalse(fallbackFetcher.isInNotFoundCache("epsg", "999999"));
-        assertEquals(0, fallbackFetcher.getNotFoundCacheSize());
+        assertFalse(githubFetcher.isInNotFoundCache("epsg", "999999"));
+        assertEquals(0, githubFetcher.getNotFoundCacheSize());
     }
 
     @Test
     void testFetcherDefaults() {
-        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_GITHUB_BASE_URL,
-                defaultFetcher.getBaseUrl());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL,
-                fallbackFetcher.getBaseUrl());
-        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_PATH, defaultFetcher.getPathTemplate());
+                cdnFetcher.getBaseUrl());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_GITHUB_BASE_URL,
+                githubFetcher.getBaseUrl());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_PATH, cdnFetcher.getPathTemplate());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CONNECT_TIMEOUT_SECONDS,
-                defaultFetcher.getConnectTimeoutSeconds());
+                cdnFetcher.getConnectTimeoutSeconds());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_READ_TIMEOUT_SECONDS,
-                defaultFetcher.getReadTimeoutSeconds());
+                cdnFetcher.getReadTimeoutSeconds());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_MAX_ATTEMPTS,
-                defaultFetcher.getMaxRetries());
+                cdnFetcher.getMaxRetries());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_INITIAL_BACKOFF_MS,
-                defaultFetcher.getInitialBackoffMs());
+                cdnFetcher.getInitialBackoffMs());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_TOTAL_TIMEOUT_SECONDS,
-                defaultFetcher.getTotalTimeoutSeconds());
+                cdnFetcher.getTotalTimeoutSeconds());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
-                defaultFetcher.getCircuitBreakerFailureThreshold());
+                cdnFetcher.getCircuitBreakerFailureThreshold());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT,
-                defaultFetcher.getCircuitBreakerResetTimeout());
-        assertFalse(defaultFetcher.isNotFoundCacheEnabled());
-        assertTrue(fallbackFetcher.isNotFoundCacheEnabled());
+                cdnFetcher.getCircuitBreakerResetTimeout());
+        assertTrue(cdnFetcher.isNotFoundCacheEnabled());
+        assertTrue(githubFetcher.isNotFoundCacheEnabled());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_NOT_FOUND_CACHE_TTL,
+                cdnFetcher.getNotFoundCacheTtl());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_NOT_FOUND_CACHE_TTL,
+                githubFetcher.getNotFoundCacheTtl());
     }
 
     // ==================== Network Failure Tests ====================

--- a/src/test/java/org/datasyslab/proj4sedona/defs/SpatialReferenceFetcherTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/SpatialReferenceFetcherTest.java
@@ -14,15 +14,15 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Tests for the spatialreference.org provider stack and Defs remote lookup.
+ * Tests for the pinned spatialreference.org snapshot provider stack and Defs remote lookup.
  *
  * <p>The spatialreference.org provider is now a pre-configured
  * {@link UrlCRSProvider} (created via {@link UrlCRSProvider#spatialReference()}),
  * so these tests exercise both the provider and the underlying
  * {@link UrlCRSFetcher} directly for retry / negative-cache behaviour.</p>
  *
- * <p>Some tests require network access to spatialreference.org and may be
- * slow due to network latency.</p>
+ * <p>Some tests require network access to the commit-addressed OSGeo CDN
+ * snapshot and may be slow due to network latency.</p>
  */
 class SpatialReferenceFetcherTest {
 
@@ -32,11 +32,7 @@ class SpatialReferenceFetcherTest {
     @BeforeEach
     void setUp() {
         Defs.reset();
-        defaultFetcher = UrlCRSFetcher.builder()
-                .baseUrl(UrlCRSProvider.SPATIAL_REFERENCE_BASE_URL)
-                .pathTemplate(UrlCRSProvider.SPATIAL_REFERENCE_PATH)
-                .header("Accept", "application/json")
-                .build();
+        defaultFetcher = UrlCRSProvider.spatialReference().getFetcher();
     }
 
     @AfterEach
@@ -44,7 +40,7 @@ class SpatialReferenceFetcherTest {
         Defs.reset();
     }
 
-    // ==================== Direct UrlCRSFetcher Tests (spatialreference.org) ====================
+    // ==================== Direct UrlCRSFetcher Tests (pinned OSGeo snapshot) ====================
 
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
@@ -102,12 +98,22 @@ class SpatialReferenceFetcherTest {
 
     @Test
     void testFetcherDefaults() {
-        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_BASE_URL, defaultFetcher.getBaseUrl());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL, defaultFetcher.getBaseUrl());
         assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_PATH, defaultFetcher.getPathTemplate());
-        assertEquals(UrlCRSFetcher.DEFAULT_CONNECT_TIMEOUT_SECONDS, defaultFetcher.getConnectTimeoutSeconds());
-        assertEquals(UrlCRSFetcher.DEFAULT_READ_TIMEOUT_SECONDS, defaultFetcher.getReadTimeoutSeconds());
-        assertEquals(UrlCRSFetcher.DEFAULT_MAX_RETRIES, defaultFetcher.getMaxRetries());
-        assertEquals(UrlCRSFetcher.DEFAULT_INITIAL_BACKOFF_MS, defaultFetcher.getInitialBackoffMs());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CONNECT_TIMEOUT_SECONDS,
+                defaultFetcher.getConnectTimeoutSeconds());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_READ_TIMEOUT_SECONDS,
+                defaultFetcher.getReadTimeoutSeconds());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_MAX_ATTEMPTS,
+                defaultFetcher.getMaxRetries());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_INITIAL_BACKOFF_MS,
+                defaultFetcher.getInitialBackoffMs());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_TOTAL_TIMEOUT_SECONDS,
+                defaultFetcher.getTotalTimeoutSeconds());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CIRCUIT_BREAKER_FAILURE_THRESHOLD,
+                defaultFetcher.getCircuitBreakerFailureThreshold());
+        assertEquals(UrlCRSProvider.SPATIAL_REFERENCE_CIRCUIT_BREAKER_RESET_TIMEOUT,
+                defaultFetcher.getCircuitBreakerResetTimeout());
     }
 
     // ==================== Network Failure Tests ====================
@@ -181,7 +187,7 @@ class SpatialReferenceFetcherTest {
         // EPSG:2154 is not in the default globals, should be fetched remotely
         ProjectionDef def = Defs.get("EPSG:2154");
 
-        assertNotNull(def, "Should fetch EPSG:2154 from spatialreference.org");
+        assertNotNull(def, "Should fetch EPSG:2154 from the pinned OSGeo snapshot");
         assertEquals("EPSG:2154", def.getSrsCode());
     }
 

--- a/src/test/java/org/datasyslab/proj4sedona/defs/UrlCRSProviderTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/UrlCRSProviderTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,17 +40,22 @@ class UrlCRSProviderTest {
 
     /** Embedded HTTP server serving fake CRS files. */
     private static HttpServer server;
+    private static HttpServer redirectTargetServer;
     private static ExecutorService serverExecutor;
     private static int port;
     private static String baseUrl;
+    private static String redirectTargetBaseUrl;
     private static final ConcurrentMap<String, AtomicInteger> requestCounts =
             new ConcurrentHashMap<>();
+    private static final AtomicReference<String> redirectedAuthorization =
+            new AtomicReference<>();
     private static volatile CountDownLatch oldRequestStarted;
     private static volatile CountDownLatch releaseOldRequest;
     private static volatile CountDownLatch probeRequestStarted;
     private static volatile CountDownLatch releaseProbeRequest;
     private static volatile CountDownLatch slowBodyStopped;
     private static volatile CountDownLatch slowRedirectStopped;
+    private static volatile CountDownLatch interruptRequestStarted;
 
     /** A valid PROJJSON for WGS 84 (EPSG:4326). */
     private static final String WGS84_PROJJSON = "{\n" +
@@ -85,6 +91,15 @@ class UrlCRSProviderTest {
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         port = server.getAddress().getPort();
         baseUrl = "http://127.0.0.1:" + port;
+        redirectTargetServer =
+                HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        redirectTargetBaseUrl = "http://127.0.0.1:"
+                + redirectTargetServer.getAddress().getPort();
+        redirectTargetServer.createContext("/", exchange -> {
+            redirectedAuthorization.set(
+                    exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 200, WGS84_PROJJSON);
+        });
 
         // Serve PROJJSON files at /{authority}/{code}.json
         server.createContext("/", exchange -> {
@@ -126,6 +141,11 @@ class UrlCRSProviderTest {
             } else if ("/redirect/slow.json".equals(path)) {
                 exchange.getResponseHeaders().set("Location", "/epsg/4326.json");
                 streamResponse(exchange, 302, 5000, slowRedirectStopped);
+            } else if ("/redirect/cross-origin.json".equals(path)) {
+                exchange.getResponseHeaders().set(
+                        "Location", redirectTargetBaseUrl + "/target.json");
+                exchange.sendResponseHeaders(302, -1);
+                exchange.close();
             } else if ("/mixed/failure.json".equals(path)) {
                 if (currentRequestCount == 1) {
                     respond(exchange, 503, "Service Unavailable");
@@ -152,6 +172,36 @@ class UrlCRSProviderTest {
                 String body = "{\"auth\":\"" + (auth != null ? auth : "") +
                         "\",\"custom\":\"" + (custom != null ? custom : "") + "\"}";
                 respond(exchange, 200, body);
+            } else if ("/rolling/epsg/3000.json".equals(path)) {
+                if (currentRequestCount == 1) {
+                    respond(exchange, 404, "Not Found");
+                } else {
+                    respond(exchange, 200, WGS84_PROJJSON);
+                }
+            } else if ("/primary/epsg/4326.json".equals(path)
+                    || "/primary/epsg/2154.json".equals(path)
+                    || "/primary/esri/102001.json".equals(path)) {
+                respond(exchange, 503, "Service Unavailable");
+            } else if ("/fallback/epsg/4326.json".equals(path)
+                    || "/fallback/esri/102001.json".equals(path)) {
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/primary/epsg/9999.json".equals(path)
+                    || "/fallback/epsg/2154.json".equals(path)) {
+                respond(exchange, 404, "Not Found");
+            } else if ("/fallback/epsg/9999.json".equals(path)) {
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/second-fallback/epsg/2154.json".equals(path)) {
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/primary/epsg/500.json".equals(path)) {
+                respond(exchange, 500, "Internal Server Error");
+            } else if ("/fallback/epsg/500.json".equals(path)) {
+                respond(exchange, 429, "Too Many Requests");
+            } else if ("/interrupt-primary/epsg/4326.json".equals(path)) {
+                interruptRequestStarted.countDown();
+                try { Thread.sleep(5000); } catch (InterruptedException ignored) {}
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/interrupt-fallback/epsg/4326.json".equals(path)) {
+                respond(exchange, 200, WGS84_PROJJSON);
             } else {
                 respond(exchange, 404, "Not Found");
             }
@@ -159,13 +209,18 @@ class UrlCRSProviderTest {
 
         serverExecutor = Executors.newCachedThreadPool();
         server.setExecutor(serverExecutor);
+        redirectTargetServer.setExecutor(serverExecutor);
         server.start();
+        redirectTargetServer.start();
     }
 
     @AfterAll
     static void stopServer() {
         if (server != null) {
             server.stop(0);
+        }
+        if (redirectTargetServer != null) {
+            redirectTargetServer.stop(0);
         }
         if (serverExecutor != null) {
             serverExecutor.shutdownNow();
@@ -176,12 +231,14 @@ class UrlCRSProviderTest {
     void setUp() {
         Defs.reset();
         requestCounts.clear();
+        redirectedAuthorization.set(null);
         oldRequestStarted = new CountDownLatch(1);
         releaseOldRequest = new CountDownLatch(1);
         probeRequestStarted = new CountDownLatch(1);
         releaseProbeRequest = new CountDownLatch(1);
         slowBodyStopped = new CountDownLatch(1);
         slowRedirectStopped = new CountDownLatch(1);
+        interruptRequestStarted = new CountDownLatch(1);
     }
 
     @AfterEach
@@ -292,6 +349,14 @@ class UrlCRSProviderTest {
     }
 
     @Test
+    void testBuilder_NullFallbackFetcherThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                UrlCRSProvider.builder("test")
+                        .baseUrl(baseUrl)
+                        .fallbackFetcher(null));
+    }
+
+    @Test
     void testExistingFailureEnumOrdinalsRemainStable() {
         assertEquals(2, UrlCRSFetcher.FetchResult.Status.NETWORK_ERROR.ordinal());
         assertEquals(1, CRSFetchException.Reason.NETWORK_ERROR.ordinal());
@@ -341,6 +406,24 @@ class UrlCRSProviderTest {
         UrlCRSFetcher.FetchResult r2 = fetcher.fetch("epsg", "9999");
         assertTrue(r2.isNotFound());
         assertEquals(0, r2.getAttemptCount());
+    }
+
+    @Test
+    void testFetcher_NegativeCacheCanBeDisabledForRollingCatalog() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/rolling/{authority}/{code}.json")
+                .cacheNotFound(false)
+                .build();
+
+        UrlCRSFetcher.FetchResult first = fetcher.fetch("epsg", "3000");
+        UrlCRSFetcher.FetchResult second = fetcher.fetch("epsg", "3000");
+
+        assertTrue(first.isNotFound());
+        assertTrue(second.isSuccess());
+        assertFalse(fetcher.isNotFoundCacheEnabled());
+        assertFalse(fetcher.isInNotFoundCache("epsg", "3000"));
+        assertEquals(2, requestCount("/rolling/epsg/3000.json"));
     }
 
     @Test
@@ -567,6 +650,23 @@ class UrlCRSProviderTest {
     }
 
     @Test
+    void testFetcher_DoesNotForwardHeadersAcrossOrigins() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/redirect/{code}.json")
+                .maxRetries(1)
+                .header("Authorization", "Bearer top-secret")
+                .build();
+
+        UrlCRSFetcher.FetchResult result =
+                fetcher.fetch("epsg", "cross-origin");
+
+        assertTrue(result.isHttpError());
+        assertEquals(302, result.getHttpStatusCode());
+        assertNull(redirectedAuthorization.get());
+    }
+
+    @Test
     void testFetcher_OverallTimeoutCancelsRedirectBody() throws Exception {
         UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
                 .baseUrl(baseUrl)
@@ -711,6 +811,7 @@ class UrlCRSProviderTest {
                 .totalTimeout(20)
                 .circuitBreakerFailureThreshold(4)
                 .circuitBreakerResetTimeout(Duration.ofSeconds(45))
+                .cacheNotFound(false)
                 .header("X-Key", "abc")
                 .build();
 
@@ -723,6 +824,7 @@ class UrlCRSProviderTest {
         assertEquals(20, fetcher.getTotalTimeoutSeconds());
         assertEquals(4, fetcher.getCircuitBreakerFailureThreshold());
         assertEquals(Duration.ofSeconds(45), fetcher.getCircuitBreakerResetTimeout());
+        assertFalse(fetcher.isNotFoundCacheEnabled());
         assertEquals("abc", fetcher.getHeaders().get("X-Key"));
     }
 
@@ -738,6 +840,7 @@ class UrlCRSProviderTest {
         assertEquals(500, fetcher.getInitialBackoffMs());
         assertEquals(0, fetcher.getTotalTimeoutSeconds());
         assertEquals(0, fetcher.getCircuitBreakerFailureThreshold());
+        assertTrue(fetcher.isNotFoundCacheEnabled());
     }
 
     // ==================== UrlCRSProvider ====================
@@ -849,20 +952,245 @@ class UrlCRSProviderTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void testSpatialReferenceProviderUsesPinnedOsGeoSnapshot() {
+    void testSpatialReferenceProviderUsesGitHubWithPinnedCdnFallback() {
         UrlCRSProvider provider = UrlCRSProvider.spatialReference();
         String commit = "c43e4e72634af65fcf684def42ddc2dcfd834938";
-        String base =
+        String github =
+                "https://raw.githubusercontent.com/OSGeo/spatialreference.org/gh-pages";
+        String jsDelivr =
                 "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@" + commit;
 
         assertEquals(commit, UrlCRSProvider.SPATIAL_REFERENCE_SNAPSHOT_COMMIT);
-        assertEquals(base, UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL);
-        assertEquals(base, provider.getFetcher().getBaseUrl());
+        assertEquals(github, UrlCRSProvider.SPATIAL_REFERENCE_GITHUB_BASE_URL);
+        assertEquals(jsDelivr, UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL);
+        assertEquals(2, provider.getFetchers().size());
+        assertEquals(github, provider.getFetcher().getBaseUrl());
+        assertEquals(github, provider.getFetchers().get(0).getBaseUrl());
+        assertEquals(jsDelivr, provider.getFetchers().get(1).getBaseUrl());
         assertEquals(
-                base + "/ref/epsg/2154/projjson.json",
+                github + "/ref/epsg/2154/projjson.json",
                 provider.getFetcher().buildUrl("epsg", "2154"));
+        assertEquals(
+                jsDelivr + "/ref/epsg/2154/projjson.json",
+                provider.getFetchers().get(1).buildUrl("epsg", "2154"));
+        assertFalse(provider.getFetcher().isNotFoundCacheEnabled());
+        assertTrue(provider.getFetchers().get(1).isNotFoundCacheEnabled());
         assertEquals("https://spatialreference.org",
                 UrlCRSProvider.SPATIAL_REFERENCE_BASE_URL);
+    }
+
+    @Test
+    void testProvider_FallsBackAfterPrimaryHttpError() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("with-fallback")
+                .baseUrl(baseUrl + "/primary")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+
+        CRSResult result = provider.resolve("epsg", "4326");
+
+        assertNotNull(result);
+        assertEquals(1, requestCount("/primary/epsg/4326.json"));
+        assertEquals(1, requestCount("/fallback/epsg/4326.json"));
+        assertEquals(2, provider.getFetchers().size());
+    }
+
+    @Test
+    void testProvider_PrimaryNotFoundDoesNotUseOlderFallback() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("with-fallback")
+                .baseUrl(baseUrl + "/primary")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+
+        assertNull(provider.resolve("epsg", "9999"));
+        assertEquals(1, requestCount("/primary/epsg/9999.json"));
+        assertEquals(0, requestCount("/fallback/epsg/9999.json"));
+    }
+
+    @Test
+    void testProvider_FallbackNotFoundDoesNotMaskPrimaryFailure() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("with-fallback")
+                .baseUrl(baseUrl + "/primary")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+
+        CRSFetchException ex = assertThrows(CRSFetchException.class, () ->
+                provider.resolve("epsg", "2154"));
+
+        assertEquals(CRSFetchException.Reason.HTTP_ERROR, ex.getReason());
+        assertTrue(ex.getMessage().contains(baseUrl + "/primary"));
+        assertTrue(ex.getMessage().contains("HTTP 503"));
+        assertTrue(ex.getMessage().contains(baseUrl + "/fallback"));
+        assertTrue(ex.getMessage().contains("HTTP 404"));
+    }
+
+    @Test
+    void testProvider_TriesFallbacksInOrderUntilOneSucceeds() {
+        UrlCRSFetcher missingFallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSFetcher successfulFallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/second-fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("multiple-fallbacks")
+                .baseUrl(baseUrl + "/primary")
+                .maxRetries(1)
+                .fallbackFetcher(missingFallback)
+                .fallbackFetcher(successfulFallback)
+                .build();
+
+        assertNotNull(provider.resolve("epsg", "2154"));
+        assertEquals(1, requestCount("/primary/epsg/2154.json"));
+        assertEquals(1, requestCount("/fallback/epsg/2154.json"));
+        assertEquals(1, requestCount("/second-fallback/epsg/2154.json"));
+        assertEquals(3, provider.getFetchers().size());
+    }
+
+    @Test
+    void testProvider_AllEndpointFailuresKeepDiagnostics() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("with-fallback")
+                .baseUrl(baseUrl + "/primary")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+
+        CRSFetchException ex = assertThrows(CRSFetchException.class, () ->
+                provider.resolve("epsg", "500"));
+
+        assertEquals(CRSFetchException.Reason.HTTP_ERROR, ex.getReason());
+        assertTrue(ex.getMessage().contains(baseUrl + "/primary"));
+        assertTrue(ex.getMessage().contains("HTTP 500"));
+        assertTrue(ex.getMessage().contains(baseUrl + "/fallback"));
+        assertTrue(ex.getMessage().contains("HTTP 429"));
+        assertEquals(1, ex.getSuppressed().length);
+    }
+
+    @Test
+    void testProvider_PrimaryAndFallbackCircuitsAreIndependent() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/fallback")
+                .maxRetries(1)
+                .circuitBreakerFailureThreshold(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("with-fallback")
+                .baseUrl(baseUrl + "/primary")
+                .maxRetries(1)
+                .circuitBreakerFailureThreshold(1)
+                .fallbackFetcher(fallback)
+                .build();
+
+        assertNotNull(provider.resolve("epsg", "4326"));
+        assertTrue(provider.getFetcher().isCircuitOpen());
+        assertFalse(fallback.isCircuitOpen());
+
+        assertNotNull(provider.resolve("esri", "102001"));
+        assertEquals(0, requestCount("/primary/esri/102001.json"));
+        assertEquals(1, requestCount("/fallback/esri/102001.json"));
+    }
+
+    @Test
+    void testProvider_InterruptedPrimaryDoesNotCallFallback() throws Exception {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/interrupt-fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("interruptible")
+                .baseUrl(baseUrl + "/interrupt-primary")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread resolver = new Thread(() -> {
+            try {
+                provider.resolve("epsg", "4326");
+            } catch (Throwable t) {
+                thrown.set(t);
+            }
+        });
+
+        resolver.start();
+        assertTrue(interruptRequestStarted.await(5, TimeUnit.SECONDS));
+        resolver.interrupt();
+        resolver.join(5000);
+
+        assertFalse(resolver.isAlive());
+        assertTrue(thrown.get() instanceof CRSFetchException);
+        CRSFetchException failure = (CRSFetchException) thrown.get();
+        assertEquals(CRSFetchException.Reason.NETWORK_ERROR, failure.getReason());
+        assertEquals(0, requestCount("/interrupt-fallback/epsg/4326.json"));
+    }
+
+    @Test
+    void testProvider_InterruptedSingleFlightOwnerDoesNotPoisonWaiter()
+            throws Exception {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/interrupt-fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("interruptible-shared")
+                .baseUrl(baseUrl + "/interrupt-primary")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+        AtomicReference<Throwable> ownerFailure = new AtomicReference<>();
+        AtomicReference<Throwable> waiterFailure = new AtomicReference<>();
+        AtomicReference<CRSResult> waiterResult = new AtomicReference<>();
+        Thread owner = new Thread(() -> {
+            try {
+                provider.resolve("epsg", "4326");
+            } catch (Throwable t) {
+                ownerFailure.set(t);
+            }
+        });
+        Thread waiter = new Thread(() -> {
+            try {
+                waiterResult.set(provider.resolve("epsg", "4326"));
+            } catch (Throwable t) {
+                waiterFailure.set(t);
+            }
+        });
+
+        owner.start();
+        assertTrue(interruptRequestStarted.await(5, TimeUnit.SECONDS));
+        waiter.start();
+        long waitingDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (waiter.getState() != Thread.State.WAITING
+                && System.nanoTime() < waitingDeadline) {
+            Thread.sleep(5);
+        }
+        assertEquals(Thread.State.WAITING, waiter.getState());
+
+        owner.interrupt();
+        owner.join(5000);
+        waiter.join(5000);
+
+        assertFalse(owner.isAlive());
+        assertFalse(waiter.isAlive());
+        assertTrue(ownerFailure.get() instanceof CRSFetchException);
+        assertNull(waiterFailure.get());
+        assertNotNull(waiterResult.get());
+        assertEquals(1, requestCount("/interrupt-primary/epsg/4326.json"));
+        assertEquals(1, requestCount("/interrupt-fallback/epsg/4326.json"));
     }
 
     // ==================== Authority Filtering ====================

--- a/src/test/java/org/datasyslab/proj4sedona/defs/UrlCRSProviderTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/UrlCRSProviderTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -49,6 +50,7 @@ class UrlCRSProviderTest {
             new ConcurrentHashMap<>();
     private static final AtomicReference<String> redirectedAuthorization =
             new AtomicReference<>();
+    private static final AtomicInteger redirectedRequests = new AtomicInteger();
     private static volatile CountDownLatch oldRequestStarted;
     private static volatile CountDownLatch releaseOldRequest;
     private static volatile CountDownLatch probeRequestStarted;
@@ -56,6 +58,8 @@ class UrlCRSProviderTest {
     private static volatile CountDownLatch slowBodyStopped;
     private static volatile CountDownLatch slowRedirectStopped;
     private static volatile CountDownLatch interruptRequestStarted;
+    private static volatile CountDownLatch ttlRefreshStarted;
+    private static volatile CountDownLatch releaseTtlRefresh;
 
     /** A valid PROJJSON for WGS 84 (EPSG:4326). */
     private static final String WGS84_PROJJSON = "{\n" +
@@ -96,6 +100,7 @@ class UrlCRSProviderTest {
         redirectTargetBaseUrl = "http://127.0.0.1:"
                 + redirectTargetServer.getAddress().getPort();
         redirectTargetServer.createContext("/", exchange -> {
+            redirectedRequests.incrementAndGet();
             redirectedAuthorization.set(
                     exchange.getRequestHeaders().getFirst("Authorization"));
             respond(exchange, 200, WGS84_PROJJSON);
@@ -178,12 +183,33 @@ class UrlCRSProviderTest {
                 } else {
                     respond(exchange, 200, WGS84_PROJJSON);
                 }
+            } else if ("/ttl/epsg/3000.json".equals(path)) {
+                if (currentRequestCount == 1) {
+                    respond(exchange, 404, "Not Found");
+                } else {
+                    ttlRefreshStarted.countDown();
+                    awaitLatch(releaseTtlRefresh);
+                    respond(exchange, 200, WGS84_PROJJSON);
+                }
+            } else if ("/cdn/epsg/cdn-lag.json".equals(path)) {
+                respond(exchange, 404, "Not Found");
+            } else if ("/github/epsg/cdn-lag.json".equals(path)) {
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/cdn/epsg/missing.json".equals(path)) {
+                respond(exchange, 503, "Service Unavailable");
+            } else if ("/github/epsg/missing.json".equals(path)) {
+                respond(exchange, 404, "Not Found");
+            } else if ("/cdn/epsg/github-down.json".equals(path)) {
+                respond(exchange, 404, "Not Found");
+            } else if ("/github/epsg/github-down.json".equals(path)) {
+                respond(exchange, 503, "Service Unavailable");
             } else if ("/primary/epsg/4326.json".equals(path)
                     || "/primary/epsg/2154.json".equals(path)
                     || "/primary/esri/102001.json".equals(path)) {
                 respond(exchange, 503, "Service Unavailable");
             } else if ("/fallback/epsg/4326.json".equals(path)
-                    || "/fallback/esri/102001.json".equals(path)) {
+                    || "/fallback/esri/102001.json".equals(path)
+                    || "/fallback/epsg/cross-origin.json".equals(path)) {
                 respond(exchange, 200, WGS84_PROJJSON);
             } else if ("/primary/epsg/9999.json".equals(path)
                     || "/fallback/epsg/2154.json".equals(path)) {
@@ -232,6 +258,7 @@ class UrlCRSProviderTest {
         Defs.reset();
         requestCounts.clear();
         redirectedAuthorization.set(null);
+        redirectedRequests.set(0);
         oldRequestStarted = new CountDownLatch(1);
         releaseOldRequest = new CountDownLatch(1);
         probeRequestStarted = new CountDownLatch(1);
@@ -239,6 +266,8 @@ class UrlCRSProviderTest {
         slowBodyStopped = new CountDownLatch(1);
         slowRedirectStopped = new CountDownLatch(1);
         interruptRequestStarted = new CountDownLatch(1);
+        ttlRefreshStarted = new CountDownLatch(1);
+        releaseTtlRefresh = new CountDownLatch(1);
     }
 
     @AfterEach
@@ -266,7 +295,7 @@ class UrlCRSProviderTest {
             long durationMs,
             CountDownLatch stopped)
             throws IOException {
-        byte[] chunk = new byte[64 * 1024];
+        byte[] chunk = new byte[1024];
         chunk[0] = '{';
         exchange.getResponseHeaders().set("Content-Type", "application/json");
         exchange.sendResponseHeaders(statusCode, 0);
@@ -357,6 +386,39 @@ class UrlCRSProviderTest {
     }
 
     @Test
+    void testBuilder_NullNotFoundPoliciesThrow() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () ->
+                UrlCRSProvider.builder("test")
+                        .baseUrl(baseUrl)
+                        .primaryNotFoundPolicy(null));
+        assertThrows(IllegalArgumentException.class, () ->
+                UrlCRSProvider.builder("test")
+                        .baseUrl(baseUrl)
+                        .fallbackFetcher(fallback, null));
+    }
+
+    @Test
+    void testBuilder_InvalidNotFoundCacheTtlThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                UrlCRSFetcher.builder()
+                        .baseUrl(baseUrl)
+                        .notFoundCacheTtl(null));
+        assertThrows(IllegalArgumentException.class, () ->
+                UrlCRSFetcher.builder()
+                        .baseUrl(baseUrl)
+                        .notFoundCacheTtl(Duration.ofNanos(-1)));
+        assertThrows(IllegalArgumentException.class, () ->
+                UrlCRSFetcher.builder()
+                        .baseUrl(baseUrl)
+                        .notFoundCacheTtl(
+                                Duration.ofSeconds(Long.MAX_VALUE)));
+    }
+
+    @Test
     void testExistingFailureEnumOrdinalsRemainStable() {
         assertEquals(2, UrlCRSFetcher.FetchResult.Status.NETWORK_ERROR.ordinal());
         assertEquals(1, CRSFetchException.Reason.NETWORK_ERROR.ordinal());
@@ -406,6 +468,82 @@ class UrlCRSProviderTest {
         UrlCRSFetcher.FetchResult r2 = fetcher.fetch("epsg", "9999");
         assertTrue(r2.isNotFound());
         assertEquals(0, r2.getAttemptCount());
+    }
+
+    @Test
+    void testFetcher_NegativeCacheExpiresAtConfiguredTtl() {
+        AtomicLong nowNanos = new AtomicLong();
+        Duration ttl = Duration.ofMinutes(5);
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/rolling/{authority}/{code}.json")
+                .notFoundCacheTtl(ttl)
+                .notFoundCacheTicker(nowNanos::get)
+                .build();
+
+        UrlCRSFetcher.FetchResult first = fetcher.fetch("epsg", "3000");
+        assertTrue(first.isNotFound());
+        assertEquals(1, first.getAttemptCount());
+        assertEquals(1, requestCount("/rolling/epsg/3000.json"));
+
+        nowNanos.set(ttl.toNanos() - 1);
+        UrlCRSFetcher.FetchResult cached = fetcher.fetch("epsg", "3000");
+        assertTrue(cached.isNotFound());
+        assertEquals(0, cached.getAttemptCount());
+        assertTrue(fetcher.isInNotFoundCache("epsg", "3000"));
+        assertEquals(1, fetcher.getNotFoundCacheSize());
+
+        nowNanos.set(ttl.toNanos());
+        assertFalse(fetcher.isInNotFoundCache("epsg", "3000"));
+        assertEquals(0, fetcher.getNotFoundCacheSize());
+        UrlCRSFetcher.FetchResult refreshed = fetcher.fetch("epsg", "3000");
+        assertTrue(refreshed.isSuccess());
+        assertEquals(1, refreshed.getAttemptCount());
+        assertEquals(2, requestCount("/rolling/epsg/3000.json"));
+    }
+
+    @Test
+    void testFetcher_ConcurrentExpiryPerformsOneRevalidation() throws Exception {
+        AtomicLong nowNanos = new AtomicLong();
+        Duration ttl = Duration.ofMinutes(5);
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/ttl/{authority}/{code}.json")
+                .notFoundCacheTtl(ttl)
+                .notFoundCacheTicker(nowNanos::get)
+                .build();
+        assertTrue(fetcher.fetch("epsg", "3000").isNotFound());
+        nowNanos.set(ttl.toNanos());
+
+        int callerCount = 32;
+        ExecutorService callers = Executors.newFixedThreadPool(callerCount);
+        CountDownLatch ready = new CountDownLatch(callerCount);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<UrlCRSFetcher.FetchResult>> results = new ArrayList<>();
+        try {
+            for (int i = 0; i < callerCount; i++) {
+                results.add(callers.submit(() -> {
+                    ready.countDown();
+                    assertTrue(start.await(5, TimeUnit.SECONDS));
+                    return fetcher.fetch("epsg", "3000");
+                }));
+            }
+            assertTrue(ready.await(5, TimeUnit.SECONDS));
+            start.countDown();
+            assertTrue(ttlRefreshStarted.await(5, TimeUnit.SECONDS));
+            assertEquals(1, fetcher.getInFlightCount());
+            releaseTtlRefresh.countDown();
+
+            for (Future<UrlCRSFetcher.FetchResult> result : results) {
+                assertTrue(result.get(5, TimeUnit.SECONDS).isSuccess());
+            }
+        } finally {
+            releaseTtlRefresh.countDown();
+            callers.shutdownNow();
+        }
+
+        assertEquals(2, requestCount("/ttl/epsg/3000.json"),
+                "expiry should trigger one shared revalidation request");
     }
 
     @Test
@@ -663,7 +801,58 @@ class UrlCRSProviderTest {
 
         assertTrue(result.isHttpError());
         assertEquals(302, result.getHttpStatusCode());
+        assertNotNull(result.getLastException());
+        assertTrue(result.getLastException().getMessage()
+                .contains("refused unsafe redirect"));
+        assertTrue(result.getLastException().getMessage().contains(baseUrl));
+        assertTrue(result.getLastException().getMessage()
+                .contains(redirectTargetBaseUrl));
+        assertFalse(result.getLastException().getMessage()
+                .contains("/target.json"));
+        assertEquals(0, redirectedRequests.get());
         assertNull(redirectedAuthorization.get());
+    }
+
+    @Test
+    void testProvider_ReportsRefusedRedirectAndUsesFallback() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/fallback")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("redirecting")
+                .baseUrl(baseUrl)
+                .pathTemplate("/redirect/{code}.json")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+
+        assertNotNull(provider.resolve("epsg", "cross-origin"));
+        assertEquals(0, redirectedRequests.get());
+        assertEquals(1, requestCount("/fallback/epsg/cross-origin.json"));
+    }
+
+    @Test
+    void testProvider_ReportsRefusedRedirectWhenFallbacksFail() {
+        UrlCRSFetcher fallback = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/github")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("redirecting")
+                .baseUrl(baseUrl)
+                .pathTemplate("/redirect/{code}.json")
+                .maxRetries(1)
+                .fallbackFetcher(fallback)
+                .build();
+
+        CRSFetchException failure = assertThrows(
+                CRSFetchException.class,
+                () -> provider.resolve("epsg", "cross-origin"));
+
+        assertTrue(failure.getMessage().contains("HTTP 302"));
+        assertTrue(failure.getMessage().contains("refused unsafe redirect"));
+        assertTrue(failure.getMessage().contains(baseUrl));
+        assertTrue(failure.getMessage().contains(redirectTargetBaseUrl));
+        assertEquals(0, redirectedRequests.get());
     }
 
     @Test
@@ -812,6 +1001,7 @@ class UrlCRSProviderTest {
                 .circuitBreakerFailureThreshold(4)
                 .circuitBreakerResetTimeout(Duration.ofSeconds(45))
                 .cacheNotFound(false)
+                .notFoundCacheTtl(Duration.ofMinutes(2))
                 .header("X-Key", "abc")
                 .build();
 
@@ -825,6 +1015,7 @@ class UrlCRSProviderTest {
         assertEquals(4, fetcher.getCircuitBreakerFailureThreshold());
         assertEquals(Duration.ofSeconds(45), fetcher.getCircuitBreakerResetTimeout());
         assertFalse(fetcher.isNotFoundCacheEnabled());
+        assertEquals(Duration.ofMinutes(2), fetcher.getNotFoundCacheTtl());
         assertEquals("abc", fetcher.getHeaders().get("X-Key"));
     }
 
@@ -841,6 +1032,7 @@ class UrlCRSProviderTest {
         assertEquals(0, fetcher.getTotalTimeoutSeconds());
         assertEquals(0, fetcher.getCircuitBreakerFailureThreshold());
         assertTrue(fetcher.isNotFoundCacheEnabled());
+        assertEquals(Duration.ZERO, fetcher.getNotFoundCacheTtl());
     }
 
     // ==================== UrlCRSProvider ====================
@@ -952,31 +1144,136 @@ class UrlCRSProviderTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    void testSpatialReferenceProviderUsesGitHubWithPinnedCdnFallback() {
+    void testSpatialReferenceProviderUsesRollingCdnThenGitHub() {
         UrlCRSProvider provider = UrlCRSProvider.spatialReference();
-        String commit = "c43e4e72634af65fcf684def42ddc2dcfd834938";
         String github =
                 "https://raw.githubusercontent.com/OSGeo/spatialreference.org/gh-pages";
         String jsDelivr =
-                "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@" + commit;
+                "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@gh-pages";
 
-        assertEquals(commit, UrlCRSProvider.SPATIAL_REFERENCE_SNAPSHOT_COMMIT);
         assertEquals(github, UrlCRSProvider.SPATIAL_REFERENCE_GITHUB_BASE_URL);
         assertEquals(jsDelivr, UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL);
         assertEquals(2, provider.getFetchers().size());
-        assertEquals(github, provider.getFetcher().getBaseUrl());
-        assertEquals(github, provider.getFetchers().get(0).getBaseUrl());
-        assertEquals(jsDelivr, provider.getFetchers().get(1).getBaseUrl());
         assertEquals(
-                github + "/ref/epsg/2154/projjson.json",
-                provider.getFetcher().buildUrl("epsg", "2154"));
+                List.of(
+                        UrlCRSProvider.NotFoundPolicy.TRY_NEXT_ENDPOINT,
+                        UrlCRSProvider.NotFoundPolicy.AUTHORITATIVE),
+                provider.getNotFoundPolicies());
+        assertEquals(jsDelivr, provider.getFetcher().getBaseUrl());
+        assertEquals(jsDelivr, provider.getFetchers().get(0).getBaseUrl());
+        assertEquals(github, provider.getFetchers().get(1).getBaseUrl());
         assertEquals(
                 jsDelivr + "/ref/epsg/2154/projjson.json",
+                provider.getFetcher().buildUrl("epsg", "2154"));
+        assertEquals(
+                github + "/ref/epsg/2154/projjson.json",
                 provider.getFetchers().get(1).buildUrl("epsg", "2154"));
-        assertFalse(provider.getFetcher().isNotFoundCacheEnabled());
+        assertTrue(provider.getFetcher().isNotFoundCacheEnabled());
         assertTrue(provider.getFetchers().get(1).isNotFoundCacheEnabled());
+        assertEquals(
+                UrlCRSProvider.SPATIAL_REFERENCE_NOT_FOUND_CACHE_TTL,
+                provider.getFetcher().getNotFoundCacheTtl());
+        assertEquals(
+                UrlCRSProvider.SPATIAL_REFERENCE_NOT_FOUND_CACHE_TTL,
+                provider.getFetchers().get(1).getNotFoundCacheTtl());
         assertEquals("https://spatialreference.org",
                 UrlCRSProvider.SPATIAL_REFERENCE_BASE_URL);
+    }
+
+    @Test
+    void testProvider_NonAuthoritativeCdnMissUsesGitHub() {
+        UrlCRSFetcher github = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/github")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("cdn-first")
+                .baseUrl(baseUrl + "/cdn")
+                .maxRetries(1)
+                .primaryNotFoundPolicy(
+                        UrlCRSProvider.NotFoundPolicy.TRY_NEXT_ENDPOINT)
+                .fallbackFetcher(
+                        github,
+                        UrlCRSProvider.NotFoundPolicy.AUTHORITATIVE)
+                .build();
+
+        assertNotNull(provider.resolve("epsg", "cdn-lag"));
+        assertEquals(1, requestCount("/cdn/epsg/cdn-lag.json"));
+        assertEquals(1, requestCount("/github/epsg/cdn-lag.json"));
+    }
+
+    @Test
+    void testProvider_AuthoritativeGitHubMissWinsAfterCdnFailure() {
+        UrlCRSFetcher github = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/github")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("cdn-first")
+                .baseUrl(baseUrl + "/cdn")
+                .maxRetries(1)
+                .primaryNotFoundPolicy(
+                        UrlCRSProvider.NotFoundPolicy.TRY_NEXT_ENDPOINT)
+                .fallbackFetcher(
+                        github,
+                        UrlCRSProvider.NotFoundPolicy.AUTHORITATIVE)
+                .build();
+
+        assertNull(provider.resolve("epsg", "missing"));
+        assertEquals(1, requestCount("/cdn/epsg/missing.json"));
+        assertEquals(1, requestCount("/github/epsg/missing.json"));
+    }
+
+    @Test
+    void testProvider_GitHubFailureDoesNotTurnCdnMissIntoNotFound() {
+        UrlCRSFetcher github = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/github")
+                .maxRetries(1)
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("cdn-first")
+                .baseUrl(baseUrl + "/cdn")
+                .maxRetries(1)
+                .primaryNotFoundPolicy(
+                        UrlCRSProvider.NotFoundPolicy.TRY_NEXT_ENDPOINT)
+                .fallbackFetcher(
+                        github,
+                        UrlCRSProvider.NotFoundPolicy.AUTHORITATIVE)
+                .build();
+
+        CRSFetchException failure = assertThrows(
+                CRSFetchException.class,
+                () -> provider.resolve("epsg", "github-down"));
+
+        assertEquals(CRSFetchException.Reason.HTTP_ERROR, failure.getReason());
+        assertTrue(failure.getMessage().contains("HTTP 404"));
+        assertTrue(failure.getMessage().contains("HTTP 503"));
+        assertEquals(1, requestCount("/cdn/epsg/github-down.json"));
+        assertEquals(1, requestCount("/github/epsg/github-down.json"));
+    }
+
+    @Test
+    void testProvider_RepeatedMissingCodeUsesBothEndpointCaches() {
+        UrlCRSFetcher github = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl + "/github")
+                .notFoundCacheTtl(Duration.ofMinutes(5))
+                .build();
+        UrlCRSProvider provider = UrlCRSProvider.builder("cdn-first")
+                .baseUrl(baseUrl + "/cdn")
+                .notFoundCacheTtl(Duration.ofMinutes(5))
+                .primaryNotFoundPolicy(
+                        UrlCRSProvider.NotFoundPolicy.TRY_NEXT_ENDPOINT)
+                .fallbackFetcher(
+                        github,
+                        UrlCRSProvider.NotFoundPolicy.AUTHORITATIVE)
+                .build();
+
+        Defs.globals();
+        Defs.clearProviders();
+        Defs.registerProvider(provider, 50);
+        for (int i = 0; i < 10_000; i++) {
+            assertNull(Defs.get("EPSG:unknown"));
+        }
+
+        assertEquals(1, requestCount("/cdn/epsg/unknown.json"));
+        assertEquals(1, requestCount("/github/epsg/unknown.json"));
     }
 
     @Test
@@ -1312,21 +1609,64 @@ class UrlCRSProviderTest {
     @Test
     void testProvider_FallsThroughWhen404() {
         Defs.globals();
-
-        UrlCRSProvider provider = UrlCRSProvider.builder("fallthrough")
+        AtomicInteger fallbackCalls = new AtomicInteger();
+        UrlCRSProvider urlProvider = UrlCRSProvider.builder("fallthrough")
                 .baseUrl(baseUrl)
+                .authorities("custom")
                 .build();
-        Defs.registerProvider(provider, 50);
+        CRSProvider fallback = new CRSProvider() {
+            @Override
+            public String getName() {
+                return "custom-fallback";
+            }
 
-        // EPSG:4326 is served by our mock; it should resolve
-        ProjectionDef def = Defs.get("EPSG:4326");
-        assertNotNull(def);
+            @Override
+            public CRSResult resolve(String authority, String code) {
+                fallbackCalls.incrementAndGet();
+                return CRSResult.proj4("+proj=longlat +datum=WGS84");
+            }
+        };
+        Defs.registerProvider(urlProvider, 50);
+        Defs.registerProvider(fallback, 60);
 
-        // A code that doesn't exist on our mock server — UrlCRSProvider returns null,
-        // falls through to BuiltInCRSProvider which knows EPSG:3857
-        ProjectionDef merc = Defs.get("EPSG:3857");
-        assertNotNull(merc);
-        assertEquals("merc", merc.getProjName());
+        ProjectionDef resolved = Defs.get("CUSTOM:missing");
+
+        assertNotNull(resolved);
+        assertEquals("longlat", resolved.getProjName());
+        assertEquals(1, requestCount("/custom/missing.json"));
+        assertEquals(1, fallbackCalls.get());
+    }
+
+    @Test
+    void testProvider_HttpErrorStopsDefsChain() {
+        Defs.globals();
+        AtomicInteger fallbackCalls = new AtomicInteger();
+        UrlCRSProvider urlProvider = UrlCRSProvider.builder("http-error")
+                .baseUrl(baseUrl)
+                .authorities("error")
+                .maxRetries(1)
+                .build();
+        CRSProvider fallback = new CRSProvider() {
+            @Override
+            public String getName() {
+                return "should-not-run";
+            }
+
+            @Override
+            public CRSResult resolve(String authority, String code) {
+                fallbackCalls.incrementAndGet();
+                return CRSResult.proj4("+proj=longlat +datum=WGS84");
+            }
+        };
+        Defs.registerProvider(urlProvider, 50);
+        Defs.registerProvider(fallback, 60);
+
+        CRSFetchException failure = assertThrows(
+                CRSFetchException.class,
+                () -> Defs.get("ERROR:403"));
+
+        assertEquals(CRSFetchException.Reason.HTTP_ERROR, failure.getReason());
+        assertEquals(0, fallbackCalls.get());
     }
 
     @Test

--- a/src/test/java/org/datasyslab/proj4sedona/defs/UrlCRSProviderTest.java
+++ b/src/test/java/org/datasyslab/proj4sedona/defs/UrlCRSProviderTest.java
@@ -14,8 +14,18 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -29,8 +39,17 @@ class UrlCRSProviderTest {
 
     /** Embedded HTTP server serving fake CRS files. */
     private static HttpServer server;
+    private static ExecutorService serverExecutor;
     private static int port;
     private static String baseUrl;
+    private static final ConcurrentMap<String, AtomicInteger> requestCounts =
+            new ConcurrentHashMap<>();
+    private static volatile CountDownLatch oldRequestStarted;
+    private static volatile CountDownLatch releaseOldRequest;
+    private static volatile CountDownLatch probeRequestStarted;
+    private static volatile CountDownLatch releaseProbeRequest;
+    private static volatile CountDownLatch slowBodyStopped;
+    private static volatile CountDownLatch slowRedirectStopped;
 
     /** A valid PROJJSON for WGS 84 (EPSG:4326). */
     private static final String WGS84_PROJJSON = "{\n" +
@@ -70,6 +89,9 @@ class UrlCRSProviderTest {
         // Serve PROJJSON files at /{authority}/{code}.json
         server.createContext("/", exchange -> {
             String path = exchange.getRequestURI().getPath();
+            int currentRequestCount =
+                    requestCounts.computeIfAbsent(path, ignored -> new AtomicInteger())
+                            .incrementAndGet();
 
             if ("/epsg/4326.json".equals(path)) {
                 respond(exchange, 200, WGS84_PROJJSON);
@@ -82,9 +104,42 @@ class UrlCRSProviderTest {
                 respond(exchange, 200, LCC_PROJ4);
             } else if ("/error/500.json".equals(path)) {
                 respond(exchange, 500, "Internal Server Error");
+            } else if ("/error/503.json".equals(path)) {
+                respond(exchange, 503, "Service Unavailable");
+            } else if ("/error/429.json".equals(path)) {
+                respond(exchange, 429, "Too Many Requests");
+            } else if ("/error/403.json".equals(path)) {
+                respond(exchange, 403, "Forbidden");
             } else if ("/slow/timeout.json".equals(path)) {
                 // Simulate a slow response
                 try { Thread.sleep(5000); } catch (InterruptedException ignored) {}
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/singleflight/4326.json".equals(path)) {
+                try { Thread.sleep(250); } catch (InterruptedException ignored) {}
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/slowbody/timeout.json".equals(path)) {
+                streamResponse(exchange, 200, 5000, slowBodyStopped);
+            } else if ("/redirect/normal.json".equals(path)) {
+                exchange.getResponseHeaders().set("Location", "/epsg/4326.json");
+                exchange.sendResponseHeaders(302, -1);
+                exchange.close();
+            } else if ("/redirect/slow.json".equals(path)) {
+                exchange.getResponseHeaders().set("Location", "/epsg/4326.json");
+                streamResponse(exchange, 302, 5000, slowRedirectStopped);
+            } else if ("/mixed/failure.json".equals(path)) {
+                if (currentRequestCount == 1) {
+                    respond(exchange, 503, "Service Unavailable");
+                } else {
+                    try { Thread.sleep(5000); } catch (InterruptedException ignored) {}
+                    respond(exchange, 200, WGS84_PROJJSON);
+                }
+            } else if ("/race/old.json".equals(path)) {
+                oldRequestStarted.countDown();
+                awaitLatch(releaseOldRequest);
+                respond(exchange, 200, WGS84_PROJJSON);
+            } else if ("/race/probe.json".equals(path)) {
+                probeRequestStarted.countDown();
+                awaitLatch(releaseProbeRequest);
                 respond(exchange, 200, WGS84_PROJJSON);
             } else if ("/epsg/2154.json".equals(path)) {
                 respond(exchange, 200, WGS84_PROJJSON); // Reuse WGS84 for simplicity
@@ -102,7 +157,8 @@ class UrlCRSProviderTest {
             }
         });
 
-        server.setExecutor(null);
+        serverExecutor = Executors.newCachedThreadPool();
+        server.setExecutor(serverExecutor);
         server.start();
     }
 
@@ -111,11 +167,21 @@ class UrlCRSProviderTest {
         if (server != null) {
             server.stop(0);
         }
+        if (serverExecutor != null) {
+            serverExecutor.shutdownNow();
+        }
     }
 
     @BeforeEach
     void setUp() {
         Defs.reset();
+        requestCounts.clear();
+        oldRequestStarted = new CountDownLatch(1);
+        releaseOldRequest = new CountDownLatch(1);
+        probeRequestStarted = new CountDownLatch(1);
+        releaseProbeRequest = new CountDownLatch(1);
+        slowBodyStopped = new CountDownLatch(1);
+        slowRedirectStopped = new CountDownLatch(1);
     }
 
     @AfterEach
@@ -129,6 +195,49 @@ class UrlCRSProviderTest {
         exchange.sendResponseHeaders(statusCode, bytes.length);
         try (OutputStream os = exchange.getResponseBody()) {
             os.write(bytes);
+        }
+    }
+
+    private static int requestCount(String path) {
+        AtomicInteger count = requestCounts.get(path);
+        return count == null ? 0 : count.get();
+    }
+
+    private static void streamResponse(
+            HttpExchange exchange,
+            int statusCode,
+            long durationMs,
+            CountDownLatch stopped)
+            throws IOException {
+        byte[] chunk = new byte[64 * 1024];
+        chunk[0] = '{';
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, 0);
+        long deadlineNanos =
+                System.nanoTime() + Duration.ofMillis(durationMs).toNanos();
+        try (OutputStream os = exchange.getResponseBody()) {
+            while (System.nanoTime() < deadlineNanos) {
+                os.write(chunk);
+                os.flush();
+                try {
+                    Thread.sleep(10);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        } catch (IOException ignored) {
+            // Expected when the client cancels after its overall deadline.
+        } finally {
+            stopped.countDown();
+        }
+    }
+
+    private static void awaitLatch(CountDownLatch latch) {
+        try {
+            latch.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -172,6 +281,21 @@ class UrlCRSProviderTest {
     void testBuilder_InvalidPathTemplateThrows() {
         assertThrows(IllegalArgumentException.class, () ->
                 UrlCRSProvider.builder("test").baseUrl(baseUrl).pathTemplate("no-leading-slash"));
+    }
+
+    @Test
+    void testBuilder_InvalidCircuitBreakerResetTimeoutThrows() {
+        assertThrows(IllegalArgumentException.class, () ->
+                UrlCRSProvider.builder("test")
+                        .baseUrl(baseUrl)
+                        .circuitBreakerResetTimeout(Duration.ZERO));
+    }
+
+    @Test
+    void testExistingFailureEnumOrdinalsRemainStable() {
+        assertEquals(2, UrlCRSFetcher.FetchResult.Status.NETWORK_ERROR.ordinal());
+        assertEquals(1, CRSFetchException.Reason.NETWORK_ERROR.ordinal());
+        assertEquals(2, CRSFetchException.Reason.INVALID_RESPONSE.ordinal());
     }
 
     // ==================== UrlCRSFetcher ====================
@@ -231,6 +355,289 @@ class UrlCRSProviderTest {
         fetcher.clearNotFoundCache();
         assertEquals(0, fetcher.getNotFoundCacheSize());
         assertFalse(fetcher.isInNotFoundCache("epsg", "9999"));
+    }
+
+    @Test
+    void testFetcher_ForbiddenIsHttpErrorAndIsNotNegativeCached() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/error/{code}.json")
+                .circuitBreakerFailureThreshold(100)
+                .build();
+
+        UrlCRSFetcher.FetchResult first = fetcher.fetch("epsg", "403");
+        assertTrue(first.isHttpError());
+        assertEquals(403, first.getHttpStatusCode());
+        assertEquals(1, first.getAttemptCount());
+        assertFalse(fetcher.isInNotFoundCache("epsg", "403"));
+
+        UrlCRSFetcher.FetchResult second = fetcher.fetch("epsg", "403");
+        assertTrue(second.isHttpError());
+        assertEquals(2, requestCount("/error/403.json"),
+                "403 must not be cached as a missing CRS");
+    }
+
+    @Test
+    void testFetcher_RetryableHttpErrorPreservesStatus() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/error/{code}.json")
+                .maxRetries(2)
+                .initialBackoffMs(0)
+                .build();
+
+        UrlCRSFetcher.FetchResult result = fetcher.fetch("epsg", "503");
+
+        assertTrue(result.isHttpError());
+        assertEquals(503, result.getHttpStatusCode());
+        assertEquals(2, result.getAttemptCount());
+        assertEquals(2, requestCount("/error/503.json"));
+    }
+
+    @Test
+    void testFetcher_TooManyRequestsIsRetriedAndPreservesStatus() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/error/{code}.json")
+                .maxRetries(2)
+                .initialBackoffMs(0)
+                .build();
+
+        UrlCRSFetcher.FetchResult result = fetcher.fetch("epsg", "429");
+
+        assertTrue(result.isHttpError());
+        assertEquals(429, result.getHttpStatusCode());
+        assertEquals(2, result.getAttemptCount());
+        assertEquals(2, requestCount("/error/429.json"));
+    }
+
+    @Test
+    void testFetcher_SingleFlightCoalescesConcurrentLookups() throws Exception {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/singleflight/{code}.json")
+                .build();
+        int callers = 12;
+        ExecutorService callersPool = Executors.newFixedThreadPool(callers);
+        CountDownLatch start = new CountDownLatch(1);
+        List<Future<UrlCRSFetcher.FetchResult>> futures = new ArrayList<>();
+
+        try {
+            for (int i = 0; i < callers; i++) {
+                futures.add(callersPool.submit(() -> {
+                    start.await();
+                    return fetcher.fetch("epsg", "4326");
+                }));
+            }
+            start.countDown();
+
+            for (Future<UrlCRSFetcher.FetchResult> future : futures) {
+                assertTrue(future.get(5, TimeUnit.SECONDS).isSuccess());
+            }
+        } finally {
+            callersPool.shutdownNow();
+        }
+
+        assertEquals(1, requestCount("/singleflight/4326.json"));
+        assertEquals(0, fetcher.getInFlightCount());
+    }
+
+    @Test
+    void testFetcher_CircuitBreakerRejectsAndRecovers() throws Exception {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .maxRetries(1)
+                .circuitBreakerFailureThreshold(2)
+                .circuitBreakerResetTimeout(Duration.ofMillis(100))
+                .build();
+
+        assertTrue(fetcher.fetch("error", "503").isHttpError());
+        assertTrue(fetcher.fetch("error", "503").isHttpError());
+        assertTrue(fetcher.isCircuitOpen());
+
+        UrlCRSFetcher.FetchResult rejected = fetcher.fetch("epsg", "4326");
+        assertTrue(rejected.isCircuitOpen());
+        assertEquals(0, rejected.getAttemptCount());
+        assertEquals(0, requestCount("/epsg/4326.json"));
+
+        Thread.sleep(150);
+        UrlCRSFetcher.FetchResult recovered = fetcher.fetch("epsg", "4326");
+        assertTrue(recovered.isSuccess());
+        assertFalse(fetcher.isCircuitOpen());
+        assertEquals(0, fetcher.getConsecutiveFailureCount());
+    }
+
+    @Test
+    void testFetcher_LateRequestCannotReleaseHalfOpenProbe() throws Exception {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .maxRetries(1)
+                .circuitBreakerFailureThreshold(1)
+                .circuitBreakerResetTimeout(Duration.ofMillis(100))
+                .build();
+        ExecutorService callersPool = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<UrlCRSFetcher.FetchResult> oldRequest =
+                    callersPool.submit(() -> fetcher.fetch("race", "old"));
+            assertTrue(oldRequestStarted.await(2, TimeUnit.SECONDS));
+
+            assertTrue(fetcher.fetch("error", "503").isHttpError());
+            assertTrue(fetcher.isCircuitOpen());
+
+            Thread.sleep(150);
+            Future<UrlCRSFetcher.FetchResult> probeRequest =
+                    callersPool.submit(() -> fetcher.fetch("race", "probe"));
+            assertTrue(probeRequestStarted.await(2, TimeUnit.SECONDS));
+
+            releaseOldRequest.countDown();
+            assertTrue(oldRequest.get(2, TimeUnit.SECONDS).isSuccess());
+
+            UrlCRSFetcher.FetchResult rejected = fetcher.fetch("race", "extra");
+            assertTrue(rejected.isCircuitOpen());
+            assertEquals(0, requestCount("/race/extra.json"));
+
+            releaseProbeRequest.countDown();
+            assertTrue(probeRequest.get(2, TimeUnit.SECONDS).isSuccess());
+            assertFalse(fetcher.isCircuitOpen());
+        } finally {
+            releaseOldRequest.countDown();
+            releaseProbeRequest.countDown();
+            callersPool.shutdownNow();
+        }
+    }
+
+    @Test
+    void testFetcher_OverallTimeoutBoundsRetries() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/slow/{code}.json")
+                .readTimeout(5)
+                .totalTimeout(1)
+                .maxRetries(2)
+                .initialBackoffMs(0)
+                .build();
+
+        long started = System.nanoTime();
+        UrlCRSFetcher.FetchResult result = fetcher.fetch("epsg", "timeout");
+        long elapsedMs = Duration.ofNanos(System.nanoTime() - started).toMillis();
+
+        assertTrue(result.isNetworkError());
+        assertTrue(elapsedMs < 2500,
+                "overall timeout should bound the lookup, took " + elapsedMs + "ms");
+    }
+
+    @Test
+    void testFetcher_OverallTimeoutIncludesResponseBody() throws Exception {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/slowbody/{code}.json")
+                .readTimeout(5)
+                .totalTimeout(1)
+                .maxRetries(1)
+                .build();
+
+        long started = System.nanoTime();
+        UrlCRSFetcher.FetchResult result = fetcher.fetch("epsg", "timeout");
+        long elapsedMs = Duration.ofNanos(System.nanoTime() - started).toMillis();
+
+        assertTrue(result.isNetworkError());
+        assertEquals(-1, result.getHttpStatusCode());
+        assertTrue(elapsedMs < 2500,
+                "response body must be covered by the total timeout, took " + elapsedMs + "ms");
+        assertTrue(slowBodyStopped.await(2, TimeUnit.SECONDS),
+                "timing out must cancel the response body subscription");
+    }
+
+    @Test
+    void testFetcher_FollowsRedirectWithinDeadline() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/redirect/{code}.json")
+                .readTimeout(5)
+                .totalTimeout(2)
+                .maxRetries(1)
+                .build();
+
+        UrlCRSFetcher.FetchResult result = fetcher.fetch("epsg", "normal");
+
+        assertTrue(result.isSuccess());
+        assertEquals(1, requestCount("/redirect/normal.json"));
+        assertEquals(1, requestCount("/epsg/4326.json"));
+    }
+
+    @Test
+    void testFetcher_OverallTimeoutCancelsRedirectBody() throws Exception {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/redirect/{code}.json")
+                .readTimeout(5)
+                .totalTimeout(1)
+                .maxRetries(1)
+                .build();
+
+        long started = System.nanoTime();
+        UrlCRSFetcher.FetchResult result = fetcher.fetch("epsg", "slow");
+        long elapsedMs = Duration.ofNanos(System.nanoTime() - started).toMillis();
+
+        assertTrue(result.isNetworkError());
+        assertTrue(elapsedMs < 2500,
+                "redirect body must be covered by the total timeout, took "
+                        + elapsedMs + "ms");
+        assertTrue(slowRedirectStopped.await(2, TimeUnit.SECONDS),
+                "timing out must cancel the redirect body subscription");
+        assertEquals(0, requestCount("/epsg/4326.json"),
+                "the redirect target must not start before its body completes");
+    }
+
+    @Test
+    void testFetcher_NetworkFailureSupersedesEarlierHttpStatus() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .pathTemplate("/mixed/{code}.json")
+                .readTimeout(1)
+                .totalTimeout(3)
+                .maxRetries(2)
+                .initialBackoffMs(0)
+                .build();
+
+        UrlCRSFetcher.FetchResult result = fetcher.fetch("epsg", "failure");
+
+        assertTrue(result.isNetworkError());
+        assertEquals(-1, result.getHttpStatusCode());
+        assertEquals(2, result.getAttemptCount());
+        assertEquals(2, requestCount("/mixed/failure.json"));
+    }
+
+    @Test
+    void testFetcher_InvalidUrlDoesNotOpenCircuit() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .circuitBreakerFailureThreshold(1)
+                .build();
+
+        assertThrows(IllegalArgumentException.class, () -> fetcher.fetch("epsg", "%"));
+        assertFalse(fetcher.isCircuitOpen());
+        assertEquals(0, fetcher.getConsecutiveFailureCount());
+        assertTrue(fetcher.fetch("epsg", "4326").isSuccess());
+    }
+
+    @Test
+    void testFetcher_InvalidHalfOpenProbeReleasesPermit() throws Exception {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl(baseUrl)
+                .maxRetries(1)
+                .circuitBreakerFailureThreshold(1)
+                .circuitBreakerResetTimeout(Duration.ofMillis(100))
+                .build();
+
+        assertTrue(fetcher.fetch("error", "503").isHttpError());
+        Thread.sleep(150);
+
+        assertThrows(IllegalArgumentException.class, () -> fetcher.fetch("epsg", "%"));
+        assertTrue(fetcher.isCircuitOpen());
+        assertTrue(fetcher.fetch("epsg", "4326").isSuccess());
+        assertFalse(fetcher.isCircuitOpen());
     }
 
     @Test
@@ -301,6 +708,9 @@ class UrlCRSProviderTest {
                 .readTimeout(15)
                 .maxRetries(2)
                 .initialBackoffMs(100)
+                .totalTimeout(20)
+                .circuitBreakerFailureThreshold(4)
+                .circuitBreakerResetTimeout(Duration.ofSeconds(45))
                 .header("X-Key", "abc")
                 .build();
 
@@ -310,7 +720,24 @@ class UrlCRSProviderTest {
         assertEquals(15, fetcher.getReadTimeoutSeconds());
         assertEquals(2, fetcher.getMaxRetries());
         assertEquals(100, fetcher.getInitialBackoffMs());
+        assertEquals(20, fetcher.getTotalTimeoutSeconds());
+        assertEquals(4, fetcher.getCircuitBreakerFailureThreshold());
+        assertEquals(Duration.ofSeconds(45), fetcher.getCircuitBreakerResetTimeout());
         assertEquals("abc", fetcher.getHeaders().get("X-Key"));
+    }
+
+    @Test
+    void testFetcher_GenericDefaultsRemainCompatible() {
+        UrlCRSFetcher fetcher = UrlCRSFetcher.builder()
+                .baseUrl("https://example.com")
+                .build();
+
+        assertEquals(10, fetcher.getConnectTimeoutSeconds());
+        assertEquals(30, fetcher.getReadTimeoutSeconds());
+        assertEquals(3, fetcher.getMaxRetries());
+        assertEquals(500, fetcher.getInitialBackoffMs());
+        assertEquals(0, fetcher.getTotalTimeoutSeconds());
+        assertEquals(0, fetcher.getCircuitBreakerFailureThreshold());
     }
 
     // ==================== UrlCRSProvider ====================
@@ -382,6 +809,60 @@ class UrlCRSProviderTest {
                 provider.resolve("epsg", "4326"));
         assertEquals(CRSFetchException.Reason.NETWORK_ERROR, ex.getReason());
         assertTrue(ex.getMessage().contains("test-network-err"));
+        assertTrue(ex.getMessage().contains("http://127.0.0.1:59990"));
+    }
+
+    @Test
+    void testProvider_ForbiddenIncludesHttpStatusAndCrs() {
+        UrlCRSProvider provider = UrlCRSProvider.builder("test-http-err")
+                .baseUrl(baseUrl)
+                .pathTemplate("/error/{code}.json")
+                .build();
+
+        CRSFetchException ex = assertThrows(CRSFetchException.class, () ->
+                provider.resolve("epsg", "403"));
+
+        assertEquals("EPSG:403", ex.getCrsCode());
+        assertEquals(CRSFetchException.Reason.HTTP_ERROR, ex.getReason());
+        assertTrue(ex.getMessage().contains("HTTP 403"));
+        assertTrue(ex.getMessage().contains("EPSG:403"));
+        assertTrue(ex.getMessage().contains(baseUrl));
+    }
+
+    @Test
+    void testProvider_CircuitOpenHasDistinctReason() {
+        UrlCRSProvider provider = UrlCRSProvider.builder("test-circuit")
+                .baseUrl(baseUrl)
+                .maxRetries(1)
+                .circuitBreakerFailureThreshold(1)
+                .build();
+
+        assertThrows(CRSFetchException.class, () ->
+                provider.resolve("error", "503"));
+        CRSFetchException ex = assertThrows(CRSFetchException.class, () ->
+                provider.resolve("epsg", "4326"));
+
+        assertEquals(CRSFetchException.Reason.CIRCUIT_OPEN, ex.getReason());
+        assertTrue(ex.getMessage().contains("circuit breaker is open"));
+        assertTrue(ex.getMessage().contains(baseUrl));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void testSpatialReferenceProviderUsesPinnedOsGeoSnapshot() {
+        UrlCRSProvider provider = UrlCRSProvider.spatialReference();
+        String commit = "c43e4e72634af65fcf684def42ddc2dcfd834938";
+        String base =
+                "https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@" + commit;
+
+        assertEquals(commit, UrlCRSProvider.SPATIAL_REFERENCE_SNAPSHOT_COMMIT);
+        assertEquals(base, UrlCRSProvider.SPATIAL_REFERENCE_CDN_BASE_URL);
+        assertEquals(base, provider.getFetcher().getBaseUrl());
+        assertEquals(
+                base + "/ref/epsg/2154/projjson.json",
+                provider.getFetcher().buildUrl("epsg", "2154"));
+        assertEquals("https://spatialreference.org",
+                UrlCRSProvider.SPATIAL_REFERENCE_BASE_URL);
     }
 
     // ==================== Authority Filtering ====================
@@ -477,6 +958,11 @@ class UrlCRSProviderTest {
         // and serves it from our mock server
         ProjectionDef def = Defs.get("EPSG:2154");
         assertNotNull(def, "Should resolve EPSG:2154 via UrlCRSProvider");
+
+        ProjectionDef cached = Defs.get("epsg:2154");
+        assertSame(def, cached);
+        assertEquals(1, requestCount("/epsg/2154.json"),
+                "successful remote definitions should be cached in the JVM");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Use the rolling OSGeo `gh-pages` catalog through jsDelivr as the primary remote CRS source.
- Fall back to the raw GitHub branch after network failures, non-404 HTTP errors, an open circuit, or a jsDelivr 404.
- Treat raw GitHub as authoritative for not-found: a GitHub 404 returns not-found even after a CDN failure, while a CDN 404 followed by a GitHub failure propagates the failure.
- Cache 404s from both rolling endpoints for five minutes, with single-flight revalidation at expiry. Generic URL fetchers retain their lifetime negative-cache default unless configured otherwise.
- Keep successful CRS definitions in the existing per-JVM `Defs` cache, so repeated transforms do not download PROJJSON again.
- Keep each endpoint's timeout, negative cache, in-flight requests, and circuit breaker independent.
- Restrict redirects to the same origin and include sanitized refused-redirect diagnostics without forwarding endpoint headers.
- Preserve generic provider behavior, existing enum ordinals, the legacy public base URL constant, and `getFetcher()` compatibility.

## Root cause

An unresolved authority lookup could spend roughly 91 seconds across three 30-second requests and backoff. The original spatialreference.org host is unreliable, while a single replacement host would leave another availability risk.

The default provider now uses:

1. Primary: `https://cdn.jsdelivr.net/gh/OSGeo/spatialreference.org@gh-pages`
2. Fallback/source check: `https://raw.githubusercontent.com/OSGeo/spatialreference.org/gh-pages`

The catalog remains an external runtime dependency rather than being bundled in the JAR.

## Failover behavior

- jsDelivr success: return immediately.
- jsDelivr 404: ask raw GitHub, which avoids treating CDN propagation lag as an authoritative miss.
- jsDelivr hard failure + GitHub 404: return not-found.
- jsDelivr 404 + GitHub hard failure: propagate the GitHub failure instead of reporting a false not-found.
- Both endpoints fail: preserve diagnostics for both endpoint outcomes.
- Interrupted caller: stop without starting another endpoint request.

Each built-in endpoint has a 3-second connect timeout, 5-second request timeout, 8-second per-endpoint deadline, two total attempts, and an independent circuit breaker. A complete two-endpoint outage is therefore bounded to approximately 16 seconds and four attempts.

## Caching

- Successful definitions are parsed and cached by normalized CRS code for the executor JVM lifetime.
- Both rolling endpoints cache a confirmed HTTP 404 for five minutes.
- Concurrent first lookups and concurrent expiry revalidation share one request per endpoint.
- A regression test performs 10,000 repeated `Defs.get` calls for one missing code and verifies only one request reaches each endpoint within the TTL.
- Executor restarts begin with empty process-local caches.

## Validation

- `mvn -q test` — 1,206 tests passed
- Corretto 11.0.29: focused endpoint suite — 101 tests passed
- `mvn -q -DskipTests javadoc:javadoc`
- `git diff --check`
