### PR TITLE
Prepare 0.1.6 release

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,14 +12,14 @@ Add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.5</version>
+    <version>0.1.6</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```groovy
-implementation 'org.datasyslab:proj4sedona:0.1.5'
+implementation 'org.datasyslab:proj4sedona:0.1.6'
 ```
 
 ### Building from Source

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.datasyslab</groupId>
     <artifactId>proj4sedona</artifactId>
-    <version>0.1.5</version>
+    <version>0.1.6</version>
     <packaging>jar</packaging>
 
     <name>Proj4Sedona</name>


### PR DESCRIPTION
## Summary

- bump the Maven artifact version from `0.1.5` to `0.1.6`
- update the Maven and Gradle dependency examples

## Why

This prepares a release containing the merged remote CRS resolver hardening, including the jsDelivr primary endpoint, raw GitHub fallback, bounded retries, and local caching behavior.

## Impact

Consumers can depend on `org.datasyslab:proj4sedona:0.1.6` once the release is published. There are no API or behavior changes in this version-only commit beyond the changes already merged to `main`.

## Validation

- `mvn -q test` on JDK 11
- Apache Sedona `master` with Spark 3.5 / Scala 2.12 resolved the exact merged code as `0.1.6-SNAPSHOT`
- Sedona's `CRSTransformProj4Test` passed all 39 tests
- a cold Spark SQL `ST_Transform` resolved non-built-in `EPSG:2154` through the default remote provider
- 10,000 subsequent Spark SQL transforms reused the cached CRS definition
